### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
Potential fix for [https://github.com/HorizonRepublic/nestjs-jetstream/security/code-scanning/1](https://github.com/HorizonRepublic/nestjs-jetstream/security/code-scanning/1)

To fix this, explicitly restrict the `GITHUB_TOKEN` permissions for the `build` job by adding a `permissions` block granting only `contents: read`, which is sufficient for `actions/checkout` and for reading repository contents during the build. The `publish-npm` job already has an appropriate `permissions` block, so it does not need changes.

Concretely, in `.github/workflows/publish.yml`, under `jobs: build:`, insert:

```yaml
    permissions:
      contents: read
```

between `runs-on: ubuntu-latest` and `steps:`. This keeps existing functionality unchanged while ensuring the `build` job no longer relies on potentially over-privileged repository defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for improved security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->