### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/HorizonRepublic/nestjs-jetstream/security/code-scanning/3](https://github.com/HorizonRepublic/nestjs-jetstream/security/code-scanning/3)

In general, the fix is to explicitly define a `permissions` block that limits the `GITHUB_TOKEN` to the minimal scopes required. For this coverage workflow, the job checks out code, installs dependencies, runs tests, and uploads coverage to Codecov using an external token stored in secrets; none of these steps require write access to the repository.

The best minimal, non‑breaking fix is to add a top‑level `permissions` block (before `jobs:`) setting `contents: read`. This will apply to all jobs in this workflow (currently just `test`) and documents that the workflow only needs read access to the repository contents, avoiding unintended write capabilities while preserving all existing functionality.

Concretely, in `.github/workflows/coverage.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (i.e., after line 7 and before line 9), keeping indentation consistent. No additional imports, methods, or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->