### PR TITLE
fix: respond with error when no Core RPC handler found

### DIFF
--- a/src/server/core-rpc.server.spec.ts
+++ b/src/server/core-rpc.server.spec.ts
@@ -142,7 +142,7 @@ describe(CoreRpcServer, () => {
 
     describe('edge cases', () => {
       describe('when no handler is found', () => {
-        it('should not respond', async () => {
+        it('should respond with error instead of silently dropping', async () => {
           // Given: no handler registered
           patternRegistry.getHandler.mockReturnValue(null);
 
@@ -155,8 +155,13 @@ describe(CoreRpcServer, () => {
           subscriptionCallback(null, msg);
           await new Promise(process.nextTick);
 
-          // Then: no response sent
-          expect(msg.respond).not.toHaveBeenCalled();
+          // Then: error response sent with x-error header
+          expect(msg.respond).toHaveBeenCalledWith(
+            expect.any(Uint8Array),
+            expect.objectContaining({
+              headers: expect.anything(),
+            }),
+          );
         });
       });
 

--- a/src/server/core-rpc.server.ts
+++ b/src/server/core-rpc.server.ts
@@ -69,6 +69,7 @@ export class CoreRpcServer {
 
     if (!handler) {
       this.logger.warn(`No handler for Core RPC: ${msg.subject}`);
+      this.respondWithError(msg, new Error(`No handler for subject: ${msg.subject}`));
       return;
     }
 

--- a/test/integration/core-rpc.spec.ts
+++ b/test/integration/core-rpc.spec.ts
@@ -90,11 +90,11 @@ describe('Core RPC Round-Trip', () => {
     expect(result).toEqual({ id: 1, tenant: 'acme' });
   });
 
-  it('should timeout when no handler matches', async () => {
+  it('should return error immediately when no handler matches', async () => {
     const record = new JetstreamRecordBuilder({}).setTimeout(500).build();
 
     await expect(firstValueFrom(client.send('nonexistent.pattern', record))).rejects.toThrow(
-      /timeout/i,
+      /no handler/i,
     );
   });
 });


### PR DESCRIPTION
## Summary

When no handler matches a Core RPC request, the server now responds with an immediate error instead of silently dropping the request and forcing the caller to wait for a full timeout (30s).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (`type: description`)
- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)