### PR TITLE
fix: update existing consumers on startup, build DLQ threshold from NATS

### DIFF
--- a/src/jetstream.module.ts
+++ b/src/jetstream.module.ts
@@ -21,15 +21,12 @@ import type {
   JetstreamModuleOptions,
 } from './interfaces';
 import {
-  DEFAULT_BROADCAST_CONSUMER_CONFIG,
-  DEFAULT_EVENT_CONSUMER_CONFIG,
   DEFAULT_SHUTDOWN_TIMEOUT,
   getClientToken,
   JETSTREAM_CODEC,
   JETSTREAM_CONNECTION,
   JETSTREAM_EVENT_BUS,
   JETSTREAM_OPTIONS,
-  streamName,
 } from './jetstream.constants';
 import {
   CoreRpcServer,
@@ -195,30 +192,6 @@ export class JetstreamModule implements OnApplicationShutdown {
   // Provider factories
   // -------------------------------------------------------------------
 
-  /** Create all providers for synchronous forRoot(). */
-  /**
-   * Build a map of stream name -> max_deliver for dead letter detection.
-   * Each stream kind (ev, broadcast) has its own consumer config with potentially
-   * different max_deliver values.
-   */
-  private static buildMaxDeliverMap(options: JetstreamModuleOptions): Map<string, number> {
-    const map = new Map<string, number>();
-    const defaultEventMax = DEFAULT_EVENT_CONSUMER_CONFIG.max_deliver ?? 3;
-    const defaultBroadcastMax = DEFAULT_BROADCAST_CONSUMER_CONFIG.max_deliver ?? 3;
-
-    map.set(
-      streamName(options.name, 'ev'),
-      options.events?.consumer?.max_deliver ?? defaultEventMax,
-    );
-
-    map.set(
-      streamName(options.name, 'broadcast'),
-      options.broadcast?.consumer?.max_deliver ?? defaultBroadcastMax,
-    );
-
-    return map;
-  }
-
   private static createCoreProviders(options: JetstreamModuleOptions): Provider[] {
     return [
       {
@@ -369,7 +342,7 @@ export class JetstreamModule implements OnApplicationShutdown {
 
           const deadLetterConfig: DeadLetterConfig | undefined = options.onDeadLetter
             ? {
-                maxDeliverByStream: JetstreamModule.buildMaxDeliverMap(options),
+                maxDeliverByStream: new Map(),
                 onDeadLetter: options.onDeadLetter,
               }
             : undefined;

--- a/src/server/infrastructure/consumer.provider.spec.ts
+++ b/src/server/infrastructure/consumer.provider.spec.ts
@@ -18,7 +18,13 @@ describe(ConsumerProvider, () => {
   let connection: Mocked<ConnectionProvider>;
   let streamProvider: Mocked<StreamProvider>;
   let patternRegistry: Mocked<PatternRegistry>;
-  let mockJsm: { consumers: { info: ReturnType<typeof vi.fn>; add: ReturnType<typeof vi.fn> } };
+  let mockJsm: {
+    consumers: {
+      info: ReturnType<typeof vi.fn>;
+      add: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
+  };
 
   beforeEach(() => {
     options = { name: faker.lorem.word(), servers: ['nats://localhost:4222'] };
@@ -27,6 +33,7 @@ describe(ConsumerProvider, () => {
       consumers: {
         info: vi.fn(),
         add: vi.fn(),
+        update: vi.fn(),
       },
     };
 
@@ -69,17 +76,21 @@ describe(ConsumerProvider, () => {
 
         patternRegistry.getBroadcastPatterns.mockReturnValue(patterns);
 
-        const existingConsumer = createMock<ConsumerInfo>({
-          config: { durable_name: sut.getConsumerName('broadcast') },
-        });
+        mockJsm.consumers.info.mockResolvedValue(createMock<ConsumerInfo>());
 
-        mockJsm.consumers.info.mockResolvedValue(existingConsumer);
+        const updated = createMock<ConsumerInfo>();
+
+        mockJsm.consumers.update.mockResolvedValue(updated);
 
         // When: ensure broadcast consumer
         await sut.ensureConsumers(['broadcast']);
 
-        // Then: consumer.info was called (consumer exists), config had filter_subjects
-        expect(mockJsm.consumers.info).toHaveBeenCalled();
+        // Then: consumer updated with filter_subjects
+        expect(mockJsm.consumers.update).toHaveBeenCalledWith(
+          'test-stream',
+          expect.any(String),
+          expect.objectContaining({ filter_subjects: patterns }),
+        );
       });
     });
 
@@ -88,17 +99,21 @@ describe(ConsumerProvider, () => {
         // Given: registry returns 1 broadcast pattern
         patternRegistry.getBroadcastPatterns.mockReturnValue(['broadcast.config.updated']);
 
-        const existingConsumer = createMock<ConsumerInfo>({
-          config: { durable_name: sut.getConsumerName('broadcast') },
-        });
+        mockJsm.consumers.info.mockResolvedValue(createMock<ConsumerInfo>());
 
-        mockJsm.consumers.info.mockResolvedValue(existingConsumer);
+        const updated = createMock<ConsumerInfo>();
+
+        mockJsm.consumers.update.mockResolvedValue(updated);
 
         // When: ensure broadcast consumer
         await sut.ensureConsumers(['broadcast']);
 
-        // Then: consumer.info was called
-        expect(mockJsm.consumers.info).toHaveBeenCalled();
+        // Then: consumer updated with filter_subject
+        expect(mockJsm.consumers.update).toHaveBeenCalledWith(
+          'test-stream',
+          expect.any(String),
+          expect.objectContaining({ filter_subject: 'broadcast.config.updated' }),
+        );
       });
     });
 

--- a/src/server/infrastructure/consumer.provider.ts
+++ b/src/server/infrastructure/consumer.provider.ts
@@ -70,10 +70,9 @@ export class ConsumerProvider {
     this.logger.log(`Ensuring consumer: ${name} on stream: ${stream}`);
 
     try {
-      const info = await jsm.consumers.info(stream, name);
-
-      this.logger.debug(`Consumer exists: ${name}`);
-      return info;
+      await jsm.consumers.info(stream, name);
+      this.logger.debug(`Consumer exists, updating: ${name}`);
+      return await jsm.consumers.update(stream, name, config);
     } catch (err) {
       if (err instanceof NatsError && err.api_error?.err_code === CONSUMER_NOT_FOUND) {
         this.logger.log(`Creating consumer: ${name}`);

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -60,6 +60,15 @@ export class EventRouter {
     private readonly deadLetterConfig?: DeadLetterConfig,
   ) {}
 
+  /**
+   * Update the max_deliver thresholds from actual NATS consumer configs.
+   * Called after consumers are ensured so the DLQ map reflects reality.
+   */
+  public updateMaxDeliverMap(consumerMaxDelivers: Map<string, number>): void {
+    if (!this.deadLetterConfig) return;
+    this.deadLetterConfig.maxDeliverByStream = consumerMaxDelivers;
+  }
+
   /** Start routing event and broadcast messages to handlers. */
   public start(): void {
     this.subscribeToStream(this.messageProvider.events$, 'workqueue');

--- a/src/server/strategy.ts
+++ b/src/server/strategy.ts
@@ -1,4 +1,5 @@
 import { CustomTransportStrategy, Server } from '@nestjs/microservices';
+import type { ConsumerInfo } from 'nats';
 
 import { ConnectionProvider } from '../connection';
 import type { JetstreamModuleOptions, StreamKind } from '../interfaces';
@@ -65,21 +66,24 @@ export class JetstreamStrategy extends Server implements CustomTransportStrategy
       // 4. Ensure consumers exist
       const consumers = await this.consumerProvider.ensureConsumers(streamKinds);
 
-      // 5. Start message consumption
+      // 5. Update DLQ thresholds from actual NATS consumer configs
+      this.eventRouter.updateMaxDeliverMap(this.buildMaxDeliverMap(consumers));
+
+      // 6. Start message consumption
       this.messageProvider.start(consumers);
 
-      // 6. Start event router if needed
+      // 7. Start event router if needed
       if (this.patternRegistry.hasEventHandlers() || this.patternRegistry.hasBroadcastHandlers()) {
         this.eventRouter.start();
       }
 
-      // 7. Start RPC router if JetStream mode
+      // 8. Start RPC router if JetStream mode
       if (this.isJetStreamRpcMode() && this.patternRegistry.hasRpcHandlers()) {
         this.rpcRouter.start();
       }
     }
 
-    // 8. Start Core RPC server if core mode
+    // 9. Start Core RPC server if core mode
     if (this.isCoreRpcMode() && this.patternRegistry.hasRpcHandlers()) {
       await this.coreRpcServer.start();
     }
@@ -147,6 +151,22 @@ export class JetstreamStrategy extends Server implements CustomTransportStrategy
     }
 
     return kinds;
+  }
+
+  /** Build max_deliver map from actual NATS consumer configs (not options). */
+  private buildMaxDeliverMap(consumers: Map<StreamKind, ConsumerInfo>): Map<string, number> {
+    const map = new Map<string, number>();
+
+    for (const [, info] of consumers) {
+      const stream = info.stream_name;
+      const maxDeliver = info.config.max_deliver;
+
+      if (stream && maxDeliver) {
+        map.set(stream, maxDeliver);
+      }
+    }
+
+    return map;
   }
 
   private isCoreRpcMode(): boolean {


### PR DESCRIPTION
## Summary

1. ConsumerProvider now calls `consumers.update()` for existing consumers (like StreamProvider does for streams). Config changes are no longer silently ignored after first deployment.

2. DLQ max_deliver threshold is built from actual NATS consumer configs after `ensureConsumers`, not from module options at init time. Prevents stale thresholds from previous deployments.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (`type: description`)
- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consumers are now updated to ensure configuration consistency instead of only being verified.
  * Dead-letter queue thresholds are now dynamically derived from actual consumer configurations at runtime, improving alignment with real consumer settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->