### PR TITLE
fix: catch async hook rejections in EventBus

### DIFF
--- a/src/hooks/event-bus.spec.ts
+++ b/src/hooks/event-bus.spec.ts
@@ -107,6 +107,21 @@ describe(EventBus, () => {
         expect(logger.error).toHaveBeenCalledWith(expect.stringContaining(message));
       });
 
+      it('should catch async hook rejections and log them', async () => {
+        // Given: an async hook that rejects
+        const message = faker.lorem.sentence();
+        const asyncHook = vi.fn().mockRejectedValue(new Error(message));
+
+        sut = new EventBus(logger, { [TransportEvent.Connect]: asyncHook });
+
+        // When: event emitted
+        sut.emit(TransportEvent.Connect, 'server');
+        await new Promise(process.nextTick);
+
+        // Then: rejection caught and logged
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining(message));
+      });
+
       it('should stringify non-Error thrown values in the log message', () => {
         // Given: a hook that throws a plain string (not an Error)
         const thrown = faker.lorem.word();

--- a/src/hooks/event-bus.ts
+++ b/src/hooks/event-bus.ts
@@ -45,7 +45,16 @@ export class EventBus {
     if (!hook) return;
 
     try {
-      (hook as (...a: unknown[]) => void)(...args);
+      const result = (hook as (...a: unknown[]) => unknown)(...args);
+
+      // Catch async hook rejections that would otherwise go to unhandledRejection
+      if (result && typeof (result as Promise<unknown>).catch === 'function') {
+        (result as Promise<unknown>).catch((err: unknown) => {
+          this.logger.error(
+            `Async hook "${event}" rejected: ${err instanceof Error ? err.message : err}`,
+          );
+        });
+      }
     } catch (err) {
       this.logger.error(
         `Hook "${event}" threw an error: ${err instanceof Error ? err.message : err}`,


### PR DESCRIPTION
## Summary

Async hooks (returning a Promise) now have their rejections caught and logged. Previously, unhandled rejections went to Node.js `unhandledRejection` handler.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (`type: description`)
- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)