### PR TITLE
docs: clarify that rpc.timeout controls both client wait and server handler limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ Discriminated union on `mode`:
 | `'core'`      | 30s             | None             | Low-latency, simple RPC                |
 | `'jetstream'` | 3 min           | JetStream stream | Commands must survive handler downtime |
 
+> **Note:** `timeout` controls both the **client-side wait** (how long the caller waits for a response) and the **server-side handler limit** (how long the handler is allowed to run before being terminated). Both sides use the same value from their own `forRoot()` config.
+
 ```typescript
 // Core mode (default)
 rpc: { mode: 'core', timeout: 10_000 }


### PR DESCRIPTION
## Summary

Add a note to the RPC configuration table clarifying that `timeout` has dual meaning: client-side wait timeout and server-side handler execution limit.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (`type: description`)
- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)