### PR TITLE
fix: correct DLQ threshold for unlimited retries, clear jsmPromise on rejection

### DIFF
--- a/src/connection/connection.provider.ts
+++ b/src/connection/connection.provider.ts
@@ -91,9 +91,10 @@ export class ConnectionProvider {
 
       this.jsmInstance = await nc.jetstreamManager();
       this.logger.log('JetStream manager initialized');
-      this.jsmPromise = null;
       return this.jsmInstance;
-    })();
+    })().finally(() => {
+      this.jsmPromise = null;
+    });
 
     return this.jsmPromise;
   }

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -147,7 +147,7 @@ export class EventRouter {
 
     const maxDeliver = this.deadLetterConfig.maxDeliverByStream.get(msg.info.stream);
 
-    if (maxDeliver === undefined) return false;
+    if (maxDeliver === undefined || maxDeliver <= 0) return false;
 
     return msg.info.deliveryCount >= maxDeliver;
   }

--- a/src/server/strategy.ts
+++ b/src/server/strategy.ts
@@ -161,7 +161,7 @@ export class JetstreamStrategy extends Server implements CustomTransportStrategy
       const stream = info.stream_name;
       const maxDeliver = info.config.max_deliver;
 
-      if (stream && maxDeliver) {
+      if (stream && maxDeliver !== undefined && maxDeliver > 0) {
         map.set(stream, maxDeliver);
       }
     }


### PR DESCRIPTION
## Summary

Post-merge review found 2 bugs introduced by previous fixes:

1. `buildMaxDeliverMap` used truthy check that dropped `max_deliver = -1` (unlimited retries). Now uses explicit `> 0` check.
2. `jsmPromise` was never cleared on rejection, making JSM permanently broken after transient failure. Now uses `finally()`.

Also adds defensive guard in `isDeadLetter` for `max_deliver <= 0`.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (`type: description`)
- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dead-letter message handling to properly respect max_deliver configurations set to zero or negative values.
  * Improved JetStream manager initialization promise cleanup to ensure proper cache management in both success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->