### PR TITLE
fix: lower Node.js engine requirement to >= 20.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">= 24.14.0"
+    "node": ">= 20.0.0"
   },
   "packageManager": "pnpm@10.32.1",
   "scripts": {

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,12 @@
       "description": "Don't touch peer dependencies automatically",
       "matchDepTypes": ["peerDependencies"],
       "enabled": false
+    },
+    {
+      "description": "Don't bump Node.js engine constraint",
+      "matchDepTypes": ["engines"],
+      "matchPackageNames": ["node"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Renovate bumped `engines.node` to `>= 24.14.0`, blocking installation on Node 20/22. Lowered to `>= 20.0.0` and configured Renovate to ignore the `engines.node` field.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (`type: description`)
- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Lowered the minimum Node.js version requirement from 24.14.0 to 20.0.0, expanding compatibility with a wider range of Node.js versions and system environments.
  * Updated automated dependency management settings to prevent automatic modifications to Node.js engine version constraints, ensuring stable and controlled upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->