### PR TITLE
feat: add setMessageId for custom deduplication, remove unused reserved headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,14 +483,18 @@ Attach custom headers and per-request timeouts using the builder pattern:
 import { JetstreamRecordBuilder } from '@horizon-republic/nestjs-jetstream';
 
 const record = new JetstreamRecordBuilder({ id: 1 })
-  .setHeader('x-trace-id', 'abc-123')
   .setHeader('x-tenant', 'acme')
   .setTimeout(5000)
   .build();
 
+// Custom message ID for JetStream deduplication
+const idempotentRecord = new JetstreamRecordBuilder(orderData)
+  .setMessageId(`order-${order.id}`)
+  .build();
+
 // Works with both send() and emit()
 this.client.send('user.get', record);
-this.client.emit('user.created', record);
+this.client.emit('order.created', idempotentRecord);
 ```
 
 **Reserved headers** (set automatically by the transport, cannot be overridden):
@@ -503,15 +507,12 @@ this.client.emit('user.created', record);
 
 Attempting to set a reserved header throws an error at build time.
 
-**Additional transport headers** (set automatically, available in handlers):
+**Additional transport headers** (set automatically, available in handlers via `RpcContext`):
 
-| Header          | Purpose                                     |
-|-----------------|---------------------------------------------|
-| `x-subject`     | Original NATS subject                       |
-| `x-caller-name` | Sending service name                        |
-| `x-request-id`  | Available for user-defined request tracking |
-| `x-trace-id`    | Available for distributed tracing           |
-| `x-span-id`     | Available for distributed tracing           |
+| Header          | Purpose              |
+|-----------------|----------------------|
+| `x-subject`     | Original NATS subject |
+| `x-caller-name` | Sending service name  |
 
 ## Handler Context & Serialization
 
@@ -526,7 +527,7 @@ import { RpcContext } from '@horizon-republic/nestjs-jetstream';
 @MessagePattern('user.get')
 getUser(@Payload() data: GetUserDto, @Ctx() ctx: RpcContext) {
   const subject = ctx.getSubject();            // Full NATS subject
-  const traceId = ctx.getHeader('x-trace-id'); // Single header value
+  const tenant = ctx.getHeader('x-tenant');     // Single header value
   const headers = ctx.getHeaders();            // All headers (MsgHdrs)
   const isJs = ctx.isJetStream();              // true for JetStream messages
   const msg = ctx.getMessage();                // Raw JsMsg | Msg (escape hatch)

--- a/src/client/jetstream.client.ts
+++ b/src/client/jetstream.client.ts
@@ -129,7 +129,7 @@ export class JetstreamClient extends ClientProxy {
    */
   protected async dispatchEvent<T = unknown>(packet: ReadPacket): Promise<T> {
     const nc = await this.connect();
-    const { data, hdrs } = this.extractRecordData(packet.data);
+    const { data, hdrs, messageId } = this.extractRecordData(packet.data);
 
     // Determine if this is a broadcast event
     // Broadcast subjects start with 'broadcast:'
@@ -138,7 +138,7 @@ export class JetstreamClient extends ClientProxy {
 
     const ack = await nc.jetstream().publish(subject, this.codec.encode(data), {
       headers: msgHeaders,
-      msgID: crypto.randomUUID(),
+      msgID: messageId ?? crypto.randomUUID(),
     });
 
     if (ack.duplicate) {
@@ -156,7 +156,7 @@ export class JetstreamClient extends ClientProxy {
    */
   protected publish(packet: ReadPacket, callback: (p: WritePacket) => void): () => void {
     const subject = buildSubject(this.targetName, 'cmd', packet.pattern);
-    const { data, hdrs, timeout } = this.extractRecordData(packet.data);
+    const { data, hdrs, timeout, messageId } = this.extractRecordData(packet.data);
 
     const onUnhandled = (err: unknown): void => {
       this.logger.error('Unhandled publish error:', err);
@@ -177,6 +177,7 @@ export class JetstreamClient extends ClientProxy {
         timeout,
         callback,
         jetStreamCorrelationId,
+        messageId,
       ).catch(onUnhandled);
     }
 
@@ -238,6 +239,7 @@ export class JetstreamClient extends ClientProxy {
     timeout: number | undefined,
     callback: (p: WritePacket) => void,
     correlationId: string = crypto.randomUUID(),
+    messageId?: string,
   ): Promise<void> {
     const effectiveTimeout = timeout ?? this.getRpcTimeout();
 
@@ -270,7 +272,7 @@ export class JetstreamClient extends ClientProxy {
 
       await nc.jetstream().publish(subject, this.codec.encode(data), {
         headers: hdrs,
-        msgID: crypto.randomUUID(),
+        msgID: messageId ?? crypto.randomUUID(),
       });
     } catch (err) {
       clearTimeout(timeoutId);
@@ -418,10 +420,11 @@ export class JetstreamClient extends ClientProxy {
         data: rawData.data,
         hdrs: rawData.headers.size > 0 ? new Map(rawData.headers) : null,
         timeout: rawData.timeout,
+        messageId: rawData.messageId,
       };
     }
 
-    return { data: rawData, hdrs: null, timeout: undefined };
+    return { data: rawData, hdrs: null, timeout: undefined, messageId: undefined };
   }
 
   private isCoreRpcMode(): boolean {

--- a/src/client/jetstream.record.spec.ts
+++ b/src/client/jetstream.record.spec.ts
@@ -68,6 +68,29 @@ describe(JetstreamRecordBuilder, () => {
       });
     });
 
+    describe('when using setMessageId()', () => {
+      it('should set custom message ID for deduplication', () => {
+        // Given: a custom message ID
+        const messageId = `order-${faker.string.uuid()}`;
+
+        // When: built with messageId
+        const record = sut.setData({ id: 1 }).setMessageId(messageId).build();
+
+        // Then: messageId is set
+        expect(record.messageId).toBe(messageId);
+      });
+    });
+
+    describe('when messageId is not set', () => {
+      it('should be undefined', () => {
+        // When: built without messageId
+        const record = sut.setData({ id: 1 }).build();
+
+        // Then: messageId is undefined
+        expect(record.messageId).toBeUndefined();
+      });
+    });
+
     describe('when using setHeaders() with multiple entries', () => {
       it('should set all headers at once', () => {
         // Given: multiple headers

--- a/src/client/jetstream.record.ts
+++ b/src/client/jetstream.record.ts
@@ -24,6 +24,8 @@ export class JetstreamRecord<TData = unknown> {
     public readonly headers: ReadonlyMap<string, string>,
     /** Per-request RPC timeout override in ms. */
     public readonly timeout?: number,
+    /** Custom message ID for JetStream deduplication. */
+    public readonly messageId?: string,
   ) {}
 }
 
@@ -37,6 +39,7 @@ export class JetstreamRecordBuilder<TData = unknown> {
   private data: TData | undefined;
   private readonly headers = new Map<string, string>();
   private timeout: number | undefined;
+  private messageId: string | undefined;
 
   public constructor(data?: TData) {
     this.data = data;
@@ -80,6 +83,29 @@ export class JetstreamRecordBuilder<TData = unknown> {
   }
 
   /**
+   * Set a custom message ID for JetStream deduplication.
+   *
+   * NATS JetStream uses this ID to detect duplicate publishes within the
+   * stream's `duplicate_window`. If two messages with the same ID arrive
+   * within the window, the second is silently dropped.
+   *
+   * When not set, a random UUID is generated automatically.
+   *
+   * @param id - Unique message identifier (e.g. order ID, idempotency key).
+   *
+   * @example
+   * ```typescript
+   * new JetstreamRecordBuilder(data)
+   *   .setMessageId(`order-${order.id}`)
+   *   .build();
+   * ```
+   */
+  public setMessageId(id: string): this {
+    this.messageId = id;
+    return this;
+  }
+
+  /**
    * Set per-request RPC timeout.
    *
    * @param ms - Timeout in milliseconds. Overrides the global RPC timeout for this request only.
@@ -95,7 +121,12 @@ export class JetstreamRecordBuilder<TData = unknown> {
    * @returns A frozen record ready to pass to `client.send()` or `client.emit()`.
    */
   public build(): JetstreamRecord<TData> {
-    return new JetstreamRecord(this.data as TData, new Map(this.headers), this.timeout);
+    return new JetstreamRecord(
+      this.data as TData,
+      new Map(this.headers),
+      this.timeout,
+      this.messageId,
+    );
   }
 
   /** Validate that a header key is not reserved. */

--- a/src/interfaces/client.interface.ts
+++ b/src/interfaces/client.interface.ts
@@ -16,4 +16,6 @@ export interface ExtractedRecordData {
   hdrs: Map<string, string> | null;
   /** Per-request RPC timeout override in ms, or `undefined` for default. */
   timeout: number | undefined;
+  /** Custom message ID for JetStream deduplication, or `undefined` for auto-generated UUID. */
+  messageId: string | undefined;
 }

--- a/src/jetstream.constants.ts
+++ b/src/jetstream.constants.ts
@@ -190,12 +190,6 @@ export enum JetstreamHeader {
   Subject = 'x-subject',
   /** Internal name of the service that sent the message. */
   CallerName = 'x-caller-name',
-  /** User-provided request ID (pass-through, not auto-generated). */
-  RequestId = 'x-request-id',
-  /** User-provided trace ID for distributed tracing (pass-through). */
-  TraceId = 'x-trace-id',
-  /** User-provided span ID for distributed tracing (pass-through). */
-  SpanId = 'x-span-id',
   /** Set to `'true'` on error responses so the client can distinguish success from failure. */
   Error = 'x-error',
 }


### PR DESCRIPTION
## Summary

- Add `setMessageId(id)` to `JetstreamRecordBuilder` — allows custom JetStream deduplication IDs instead of auto-generated UUIDs
- Remove unused `RequestId`, `TraceId`, `SpanId` from `JetstreamHeader` enum — these were never set automatically and only occupied namespace that users might want
- Update README with `setMessageId` examples, clean up header documentation

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (`type: description`)
- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Records now support custom message identifiers for enhanced control.

* **Documentation**
  * Updated JetStream record builder examples demonstrating new message identifier feature.
  * Refined transport headers documentation; `x-subject` and `x-caller-name` are now the accessible headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->