### PR TITLE
refactor!: replace nanos() with toNanos(value, unit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ export class OrdersController {
 **[Read the full documentation →](https://horizonrepublic.github.io/nestjs-jetstream/)**
 
 - [Getting Started](https://horizonrepublic.github.io/nestjs-jetstream/docs/getting-started) — installation, module setup, first handler
-- [Messaging Patterns](https://horizonrepublic.github.io/nestjs-jetstream/docs/category/messaging-patterns) — events, broadcast, ordered delivery, RPC
 - [Guides](https://horizonrepublic.github.io/nestjs-jetstream/docs/guides/health-checks) — health checks, graceful shutdown, lifecycle hooks
-- [API Reference](https://horizonrepublic.github.io/nestjs-jetstream/api) — full TypeDoc-generated API
+- [API Reference](https://horizonrepublic.github.io/nestjs-jetstream/docs/reference/api/) — full TypeDoc-generated API
 
 ## Links
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "dist",
+    "!dist/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export {
   JETSTREAM_CONNECTION,
   JETSTREAM_EVENT_BUS,
   JETSTREAM_OPTIONS,
-  nanos,
+  toNanos,
 } from './jetstream.constants';
 
 // Hooks

--- a/src/jetstream.constants.spec.ts
+++ b/src/jetstream.constants.spec.ts
@@ -8,18 +8,21 @@ import {
   consumerName,
   getClientToken,
   internalName,
-  nanos,
+  toNanos,
   streamName,
 } from './jetstream.constants';
 
 describe('jetstream.constants', () => {
-  describe(nanos.name, () => {
+  describe(toNanos.name, () => {
     it.each([
-      [1, 1_000_000],
-      [1000, 1_000_000_000],
-      [0, 0],
-    ])('should convert %dms to %dns', (ms, expected) => {
-      expect(nanos(ms)).toBe(expected);
+      [1, 'ms', 1_000_000],
+      [1, 'seconds', 1_000_000_000],
+      [2, 'minutes', 120_000_000_000],
+      [1, 'hours', 3_600_000_000_000],
+      [1, 'days', 86_400_000_000_000],
+      [0, 'seconds', 0],
+    ] as const)('should convert %d %s to %d nanoseconds', (value, unit, expected) => {
+      expect(toNanos(value, unit)).toBe(expected);
     });
   });
 

--- a/src/jetstream.constants.ts
+++ b/src/jetstream.constants.ts
@@ -51,19 +51,32 @@ const KB = 1024;
 const MB = 1024 * KB;
 const GB = 1024 * MB;
 
+/** Supported time units for {@link toNanos}. */
+type TimeUnit = 'ms' | 'seconds' | 'minutes' | 'hours' | 'days';
+
+const NANOS_PER: Record<TimeUnit, number> = {
+  ms: 1_000_000,
+  seconds: 1_000_000_000,
+  minutes: 60_000_000_000,
+  hours: 3_600_000_000_000,
+  days: 86_400_000_000_000,
+};
+
 /**
- * Convert milliseconds to nanoseconds (NATS JetStream format).
+ * Convert a human-readable duration to nanoseconds (NATS JetStream format).
  *
- * @param ms - Duration in milliseconds.
+ * @param value - Numeric duration value.
+ * @param unit - Time unit to convert from.
  * @returns Duration in nanoseconds.
  *
  * @example
  * ```typescript
- * // Set consumer ack_wait to 30 seconds
- * { ack_wait: nanos(30_000) }
+ * { ack_wait: toNanos(30, 'seconds') }
+ * { max_age: toNanos(7, 'days') }
+ * { duplicate_window: toNanos(2, 'minutes') }
  * ```
  */
-export const nanos = (ms: number): number => ms * 1_000_000;
+export const toNanos = (value: number, unit: TimeUnit): number => value * NANOS_PER[unit];
 
 // ---------------------------------------------------------------------------
 // Default Stream Configurations
@@ -90,8 +103,8 @@ export const DEFAULT_EVENT_STREAM_CONFIG: Partial<StreamConfig> = {
   max_msgs_per_subject: 5_000_000,
   max_msgs: 50_000_000,
   max_bytes: 5 * GB,
-  max_age: nanos(7 * 24 * 60 * 60 * 1000), // 7 days
-  duplicate_window: nanos(2 * 60 * 1000), // 2 min
+  max_age: toNanos(7, 'days'),
+  duplicate_window: toNanos(2, 'minutes'),
 };
 
 /** Default config for RPC command streams (jetstream mode only). */
@@ -103,8 +116,8 @@ export const DEFAULT_COMMAND_STREAM_CONFIG: Partial<StreamConfig> = {
   max_msgs_per_subject: 100_000,
   max_msgs: 1_000_000,
   max_bytes: 100 * MB,
-  max_age: nanos(3 * 60 * 1000), // 3 min
-  duplicate_window: nanos(30 * 1000), // 30s
+  max_age: toNanos(3, 'minutes'),
+  duplicate_window: toNanos(30, 'seconds'),
 };
 
 /** Default config for broadcast event streams. */
@@ -117,8 +130,8 @@ export const DEFAULT_BROADCAST_STREAM_CONFIG: Partial<StreamConfig> = {
   max_msgs_per_subject: 1_000_000,
   max_msgs: 10_000_000,
   max_bytes: 2 * GB,
-  max_age: nanos(24 * 60 * 60 * 1000), // 1 day
-  duplicate_window: nanos(2 * 60 * 1000), // 2 min
+  max_age: toNanos(1, 'days'),
+  duplicate_window: toNanos(2, 'minutes'),
 };
 
 /** Default config for ordered event streams (Limits retention). */
@@ -131,8 +144,8 @@ export const DEFAULT_ORDERED_STREAM_CONFIG: Partial<StreamConfig> = {
   max_msgs_per_subject: 5_000_000,
   max_msgs: 50_000_000,
   max_bytes: 5 * GB,
-  max_age: nanos(24 * 60 * 60 * 1000), // 1 day
-  duplicate_window: nanos(2 * 60 * 1000), // 2 min
+  max_age: toNanos(1, 'days'),
+  duplicate_window: toNanos(2, 'minutes'),
 };
 
 // ---------------------------------------------------------------------------
@@ -141,7 +154,7 @@ export const DEFAULT_ORDERED_STREAM_CONFIG: Partial<StreamConfig> = {
 
 /** Default config for workqueue event consumers. */
 export const DEFAULT_EVENT_CONSUMER_CONFIG: Partial<ConsumerConfig> = {
-  ack_wait: nanos(10 * 1000), // 10s
+  ack_wait: toNanos(10, 'seconds'),
   max_deliver: 3,
   max_ack_pending: 100,
   ack_policy: AckPolicy.Explicit,
@@ -151,7 +164,7 @@ export const DEFAULT_EVENT_CONSUMER_CONFIG: Partial<ConsumerConfig> = {
 
 /** Default config for RPC command consumers (jetstream mode only). */
 export const DEFAULT_COMMAND_CONSUMER_CONFIG: Partial<ConsumerConfig> = {
-  ack_wait: nanos(5 * 60 * 1000), // 5 min
+  ack_wait: toNanos(5, 'minutes'),
   max_deliver: 1,
   max_ack_pending: 100,
   ack_policy: AckPolicy.Explicit,
@@ -161,7 +174,7 @@ export const DEFAULT_COMMAND_CONSUMER_CONFIG: Partial<ConsumerConfig> = {
 
 /** Default config for broadcast event consumers. */
 export const DEFAULT_BROADCAST_CONSUMER_CONFIG: Partial<ConsumerConfig> = {
-  ack_wait: nanos(10 * 1000), // 10s
+  ack_wait: toNanos(10, 'seconds'),
   max_deliver: 3,
   max_ack_pending: 100,
   ack_policy: AckPolicy.Explicit,

--- a/test/integration/dead-letter.spec.ts
+++ b/test/integration/dead-letter.spec.ts
@@ -6,7 +6,7 @@ import { NatsConnection } from 'nats';
 import { firstValueFrom } from 'rxjs';
 
 import type { DeadLetterInfo } from '../../src';
-import { getClientToken, nanos } from '../../src';
+import { getClientToken, toNanos } from '../../src';
 
 import {
   cleanupStreams,
@@ -66,7 +66,7 @@ describe('Dead Letter Queue Hook', () => {
             consumer: {
               max_deliver: 2,
 
-              ack_wait: nanos(2_000),
+              ack_wait: toNanos(2, 'seconds'),
             },
           },
           onDeadLetter: async (info) => {
@@ -127,7 +127,7 @@ describe('Dead Letter Queue Hook', () => {
             consumer: {
               max_deliver: 2,
 
-              ack_wait: nanos(2_000),
+              ack_wait: toNanos(2, 'seconds'),
             },
           },
         },

--- a/test/integration/infrastructure.spec.ts
+++ b/test/integration/infrastructure.spec.ts
@@ -3,7 +3,7 @@ import { Controller } from '@nestjs/common';
 import { EventPattern, MessagePattern } from '@nestjs/microservices';
 import { NatsConnection, RetentionPolicy } from 'nats';
 
-import { nanos } from '../../src';
+import { toNanos } from '../../src';
 
 import { cleanupStreams, createNatsConnection, createTestApp, uniqueServiceName } from './helpers';
 
@@ -110,7 +110,7 @@ describe('Stream & Consumer Lifecycle', () => {
 
     it('should apply user stream config overrides', async () => {
       const serviceName = uniqueServiceName();
-      const customMaxAge = nanos(5 * 60 * 1000); // 5 minutes (must exceed duplicate_window default of 2 min)
+      const customMaxAge = toNanos(5, 'minutes');
 
       const { app } = await createTestApp(
         {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   format: ['cjs', 'esm'],
   dts: true,
   tsconfig: 'tsconfig.build.json',
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
   target: 'es2024',
   splitting: false,

--- a/website/docs/getting-started/module-configuration.md
+++ b/website/docs/getting-started/module-configuration.md
@@ -15,7 +15,7 @@ The library follows NestJS conventions with three registration methods: `forRoot
 
 ```typescript title="src/app.module.ts"
 import { Module } from '@nestjs/common';
-import { JetstreamModule, TransportEvent, nanos } from '@horizon-republic/nestjs-jetstream';
+import { JetstreamModule, TransportEvent, toNanos } from '@horizon-republic/nestjs-jetstream';
 
 @Module({
   imports: [
@@ -25,7 +25,7 @@ import { JetstreamModule, TransportEvent, nanos } from '@horizon-republic/nestjs
       rpc: { mode: 'core', timeout: 10_000 },
       shutdownTimeout: 15_000,
       events: {
-        consumer: { max_deliver: 5, ack_wait: nanos(30_000) },
+        consumer: { max_deliver: 5, ack_wait: toNanos(30, 'seconds') },
       },
       hooks: {
         [TransportEvent.Error]: (err, ctx) => console.error(`[${ctx}]`, err),
@@ -221,7 +221,7 @@ rpc: { mode: 'core', timeout: 10_000 }
 rpc: {
   mode: 'jetstream',
   timeout: 60_000,
-  stream: { max_age: nanos(60_000) },     // stream overrides
+  stream: { max_age: toNanos(1, 'minutes') },     // stream overrides
   consumer: { max_deliver: 3 },            // consumer overrides
 }
 ```
@@ -237,19 +237,19 @@ See [RPC Patterns](/docs/patterns/rpc) for a full comparison of the two modes.
 The `events` and `broadcast` fields accept stream and consumer configuration overrides:
 
 ```typescript
-import { nanos } from '@horizon-republic/nestjs-jetstream';
+import { toNanos } from '@horizon-republic/nestjs-jetstream';
 
 JetstreamModule.forRoot({
   name: 'orders',
   servers: ['nats://localhost:4222'],
   events: {
     stream: {
-      max_age: nanos(3 * 24 * 60 * 60 * 1000), // 3 days instead of default 7
+      max_age: toNanos(3, 'days'), // 3 days instead of default 7
       max_bytes: 512 * 1024 * 1024,              // 512 MB instead of default 5 GB
     },
     consumer: {
       max_deliver: 5,          // retry 5 times instead of default 3
-      ack_wait: nanos(30_000), // 30s ack timeout instead of default 10s
+      ack_wait: toNanos(30, 'seconds'), // 30s ack timeout instead of default 10s
     },
   },
 })
@@ -257,8 +257,8 @@ JetstreamModule.forRoot({
 
 These overrides are merged with the [production defaults](/docs/reference/default-configs). You only need to specify the fields you want to change.
 
-:::tip The nanos() helper
-NATS JetStream uses nanoseconds for all time-based configuration. The library exports a `nanos(ms)` helper that converts milliseconds to nanoseconds, so you don't have to do the math yourself.
+:::tip The toNanos() helper
+NATS JetStream uses nanoseconds for all time-based configuration. The library exports a `toNanos(value, unit)` helper that converts human-readable durations to nanoseconds. Supported units: `'ms'`, `'seconds'`, `'minutes'`, `'hours'`, `'days'`.
 :::
 
 ### OrderedEventOverrides
@@ -276,7 +276,7 @@ JetstreamModule.forRoot({
   ordered: {
     deliverPolicy: DeliverPolicy.New,   // only new messages (default: All)
     stream: {
-      max_age: nanos(12 * 60 * 60 * 1000), // 12 hours
+      max_age: toNanos(12, 'hours'), // 12 hours
     },
   },
 })

--- a/website/docs/patterns/broadcast.md
+++ b/website/docs/patterns/broadcast.md
@@ -183,7 +183,7 @@ JetstreamModule.forRoot({
   servers: ['nats://localhost:4222'],
   broadcast: {
     stream: {
-      max_age: nanos(48 * 60 * 60 * 1000), // Keep broadcasts for 48 hours
+      max_age: toNanos(48, 'hours'), // Keep broadcasts for 48 hours
       max_bytes: 5 * 1024 * 1024 * 1024,   // 5 GB limit
     },
   },
@@ -206,7 +206,7 @@ JetstreamModule.forRoot({
   broadcast: {
     consumer: {
       max_deliver: 5,              // Orders service retries 5 times
-      ack_wait: nanos(30 * 1000),  // 30s timeout for orders handlers
+      ack_wait: toNanos(30, 'seconds'),  // 30s timeout for orders handlers
     },
   },
 }),
@@ -220,7 +220,7 @@ JetstreamModule.forRoot({
   broadcast: {
     consumer: {
       max_deliver: 10,             // Payments retries 10 times
-      ack_wait: nanos(60 * 1000),  // 60s timeout for payment handlers
+      ack_wait: toNanos(60, 'seconds'),  // 60s timeout for payment handlers
     },
   },
 }),

--- a/website/docs/patterns/events.md
+++ b/website/docs/patterns/events.md
@@ -223,9 +223,9 @@ JetstreamModule.forRoot({
   servers: ['nats://localhost:4222'],
   events: {
     stream: {
-      max_age: nanos(14 * 24 * 60 * 60 * 1000), // 14 days instead of 7
+      max_age: toNanos(14, 'days'), // 14 days instead of 7
       max_bytes: 10 * 1024 * 1024 * 1024,        // 10 GB instead of 5 GB
-      duplicate_window: nanos(5 * 60 * 1000),     // 5 min dedup window instead of 2 min
+      duplicate_window: toNanos(5, 'minutes'),     // 5 min dedup window instead of 2 min
     },
   },
 }),
@@ -242,7 +242,7 @@ JetstreamModule.forRoot({
   events: {
     consumer: {
       max_deliver: 5,              // 5 retries instead of 3
-      ack_wait: nanos(30 * 1000),  // 30s ack timeout instead of 10s
+      ack_wait: toNanos(30, 'seconds'),  // 30s ack timeout instead of 10s
       max_ack_pending: 50,         // Limit in-flight messages to 50
     },
   },

--- a/website/docs/patterns/ordered-events.md
+++ b/website/docs/patterns/ordered-events.md
@@ -166,7 +166,7 @@ import { JetstreamModule } from '@horizon-republic/nestjs-jetstream';
         // Replay all events from the stream on startup
         // (default behavior -- included for clarity)
         stream: {
-          max_age: nanos(7 * 24 * 60 * 60 * 1000), // 7 days of history
+          max_age: toNanos(7, 'days'), // 7 days of history
         },
       },
     }),
@@ -226,7 +226,7 @@ JetstreamModule.forRoot({
   ordered: {
     // DeliverPolicy.All is the default -- you can omit this entirely
     stream: {
-      max_age: nanos(7 * 24 * 60 * 60 * 1000), // 7 days
+      max_age: toNanos(7, 'days'), // 7 days
     },
   },
 })
@@ -430,11 +430,11 @@ The `ordered` field in `JetstreamModuleOptions` accepts the following options:
 The ordered stream defaults to Limits retention with a 1-day `max_age`. Override these for your use case:
 
 ```typescript
-import { nanos } from '@horizon-republic/nestjs-jetstream';
+import { toNanos } from '@horizon-republic/nestjs-jetstream';
 
 ordered: {
   stream: {
-    max_age: nanos(7 * 24 * 60 * 60 * 1000),  // 7 days instead of default 1 day
+    max_age: toNanos(7, 'days'),  // 7 days instead of default 1 day
     max_bytes: 10 * 1024 * 1024 * 1024,         // 10 GB instead of default 5 GB
     max_msg_size: 1024 * 1024,                   // 1 MB instead of default 10 MB
   },

--- a/website/docs/reference/default-configs.md
+++ b/website/docs/reference/default-configs.md
@@ -161,7 +161,7 @@ JetstreamModule.forRoot({
   events: {
     stream: {
       storage: StorageType.Memory,   // override just storage type
-      max_age: nanos(3 * 24 * 60 * 60 * 1000), // 3 days instead of 7
+      max_age: toNanos(3, 'days'), // 3 days instead of 7
     },
     consumer: {
       max_deliver: 5, // 5 retries instead of 3

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -10,6 +10,7 @@ const config: Config = {
   baseUrl: '/nestjs-jetstream/',
   organizationName: 'HorizonRepublic',
   projectName: 'nestjs-jetstream',
+  trailingSlash: false,
   onBrokenLinks: 'throw',
   markdown: {
     mermaid: true,
@@ -60,7 +61,17 @@ const config: Config = {
       },
     ],
   ],
+  headTags: [
+    { tagName: 'meta', attributes: { name: 'keywords', content: 'NestJS, NATS, JetStream, microservices, message queue, event-driven, Node.js, TypeScript' } },
+  ],
   themeConfig: {
+    metadata: [
+      { name: 'description', content: 'Events, broadcast, ordered delivery, and RPC for NestJS — powered by NATS JetStream.' },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:title', content: '@horizon-republic/nestjs-jetstream' },
+      { property: 'og:description', content: 'Ship reliable microservices with NATS JetStream and NestJS — events, broadcast, ordered delivery, and RPC.' },
+      { name: 'twitter:card', content: 'summary' },
+    ],
     mermaid: {
       theme: { light: 'dark', dark: 'dark' },
       options: {


### PR DESCRIPTION
## Summary
- **Breaking**: Replace `nanos(ms)` with `toNanos(value, unit)` — self-documenting duration config with typed units (`'ms'`, `'seconds'`, `'minutes'`, `'hours'`, `'days'`)
- **Chore**: Remove source maps from npm package (560KB → 244KB)
- **Docs**: Add basic SEO meta tags (Open Graph, Twitter Card, keywords) to docs site

## Migration

```typescript
// Before
import { nanos } from '@horizon-republic/nestjs-jetstream';
{ ack_wait: nanos(30_000) }
{ max_age: nanos(7 * 24 * 60 * 60 * 1000) }

// After
import { toNanos } from '@horizon-republic/nestjs-jetstream';
{ ack_wait: toNanos(30, 'seconds') }
{ max_age: toNanos(7, 'days') }
```

## Test plan
- [x] All 260 unit + integration tests pass
- [x] Docs site builds successfully
- [x] No remaining `nanos` references in source or docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `toNanos()` helper for configuring durations using human-readable units (seconds, minutes, hours, days) instead of manual millisecond calculations.

* **Breaking Changes**
  * The `nanos` export has been renamed to `toNanos`.

* **Documentation**
  * Updated all configuration examples to use the new API.
  * Enhanced website with SEO metadata and improved navigation.

* **Chores**
  * Disabled source map generation in production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->