### PR TITLE
fix: guard subscribeToFirst error handler against post-resolve rejection

### DIFF
--- a/src/utils/unwrap-result.ts
+++ b/src/utils/unwrap-result.ts
@@ -46,7 +46,12 @@ const subscribeToFirst = (obs: Observable<unknown>): Promise<unknown> =>
           subscription?.unsubscribe();
         }
       },
-      error: reject,
+      error: (err: unknown) => {
+        if (!done) {
+          done = true;
+          reject(err);
+        }
+      },
       complete: () => {
         if (!done) resolve(undefined);
       },

--- a/test/integration/workqueue-events.spec.ts
+++ b/test/integration/workqueue-events.spec.ts
@@ -86,7 +86,7 @@ describe('Workqueue Event Delivery', () => {
       await cleanupStreams(nc, serviceName);
     });
 
-    it('should deliver event to handler and ack', async () => {
+    it('should deliver event to handler', async () => {
       await firstValueFrom(client.emit('order.created', { orderId: 123 }));
 
       await waitForCondition(() => controller.received.length > 0, 5_000);


### PR DESCRIPTION
## Summary
- Guard `error` callback in `subscribeToFirst` with `done` flag to prevent unhandled promise rejection when an Observable emits a value and then errors
- Fix misleading test title "should deliver event to handler and ack" — we don't assert ack behavior

## Test plan
- [x] All 260 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential issue where error handling could result in multiple Promise rejections in certain scenarios, ensuring proper error state management.

* **Tests**
  * Updated integration test descriptions for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->