### PR TITLE
perf: hot-path routing optimizations + MsgpackCodec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,8 @@ CLAUDE.md
 GEMINI.md
 AGENTS.md
 
+# Benchmark results (dev-only, regenerated locally)
+benchmarks/results/
+benchmarks/baseline.json
+benchmarks/baseline.md
+

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -171,7 +171,7 @@ export default [
           modifiers: ['const'],
           selector: 'variable',
         },
-        {format: ['camelCase'], selector: 'variableLike'},
+        {format: ['camelCase'], leadingUnderscore: 'allow', selector: 'variableLike'},
         {format: ['camelCase'], leadingUnderscore: 'allow', selector: 'memberLike'},
         {format: ['PascalCase'], selector: 'typeLike'},
         {format: ['PascalCase'], selector: 'enumMember'},

--- a/package.json
+++ b/package.json
@@ -67,14 +67,26 @@
     "docs:serve": "pnpm --filter ./website serve",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:cov": "vitest run --coverage"
+    "test:cov": "vitest run --coverage",
+    "bench": "node --expose-gc --import tsx benchmarks/harness/cli.ts",
+    "bench:codec": "pnpm bench codec",
+    "bench:route": "pnpm bench route-pipeline",
+    "bench:all": "pnpm bench all",
+    "bench:quick": "pnpm bench all --quick",
+    "bench:diff": "node --import tsx benchmarks/harness/diff-cli.ts"
   },
   "peerDependencies": {
     "@nestjs/common": "^10.2.0 || ^11.0.0",
     "@nestjs/core": "^10.2.0 || ^11.0.0",
     "@nestjs/microservices": "^10.2.0 || ^11.0.0",
+    "msgpackr": "^1.11.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0"
+  },
+  "peerDependenciesMeta": {
+    "msgpackr": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@faker-js/faker": "^10.4.0",
@@ -89,8 +101,11 @@
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-sonarjs": "^4.0.2",
     "eslint-plugin-unused-imports": "^4.4.1",
+    "hdr-histogram-js": "^3.0.1",
+    "msgpackr": "^1.11.9",
     "prettier": "^3.8.3",
     "testcontainers": "^11.14.0",
+    "tinybench": "^6.0.0",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",
     "typescript": "~6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,12 +72,21 @@ importers:
       eslint-plugin-unused-imports:
         specifier: ^4.4.1
         version: 4.4.1(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@1.21.7))(typescript@6.0.2))(eslint@10.2.0(jiti@1.21.7))(typescript@6.0.2))(eslint@10.2.0(jiti@1.21.7))
+      hdr-histogram-js:
+        specifier: ^3.0.1
+        version: 3.0.1
+      msgpackr:
+        specifier: ^1.11.9
+        version: 1.11.9
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
       testcontainers:
         specifier: ^11.14.0
         version: 11.14.0
+      tinybench:
+        specifier: ^6.0.0
+        version: 6.0.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)
@@ -306,6 +315,9 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@assemblyscript/loader@0.19.23':
+    resolution: {integrity: sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1861,6 +1873,36 @@ packages:
 
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@nats-io/jetstream@3.3.1':
     resolution: {integrity: sha512-oTIxM47pQfv4zCMlLN7FtARxSclMlUUPPn9I3VxRwMH+N2jkj1WCApu+tSL778KuljxfG8txi/MPwoWSXqbbQQ==}
@@ -3825,6 +3867,10 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
@@ -4485,6 +4531,10 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  hdr-histogram-js@3.0.1:
+    resolution: {integrity: sha512-l3GSdZL1Jr1C0kyb461tUjEdrRPZr8Qry7jByltf5JGrA0xvqOSrxRBfcrJqqV/AMEtqqhHhC6w8HW0gn76tRQ==}
+    engines: {node: '>=14'}
 
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
@@ -5383,6 +5433,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.9:
+    resolution: {integrity: sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==}
+
   multer@2.1.1:
     resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
     engines: {node: '>= 10.16.0'}
@@ -5434,6 +5491,10 @@ packages:
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
@@ -5564,6 +5625,9 @@ packages:
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
@@ -6858,6 +6922,10 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinybench@6.0.0:
+    resolution: {integrity: sha512-BWlWpVbbZXaYjRV0twGLNQO00Zj4HA/sjLOQP2IvzQqGwRGp+2kh7UU3ijyJ3ywFRogYDRbiHDMrUOfaMnN56g==}
+    engines: {node: '>=20.0.0'}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
@@ -7711,6 +7779,8 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.4
+
+  '@assemblyscript/loader@0.19.23': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -10022,6 +10092,24 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
+
   '@nats-io/jetstream@3.3.1':
     dependencies:
       '@nats-io/nats-core': 3.3.1
@@ -12199,6 +12287,9 @@ snapshots:
 
   destroy@1.2.0: {}
 
+  detect-libc@2.1.2:
+    optional: true
+
   detect-node@2.1.0: {}
 
   detect-port@1.6.1:
@@ -13067,6 +13158,12 @@ snapshots:
       hast-util-parse-selector: 4.0.0
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
+
+  hdr-histogram-js@3.0.1:
+    dependencies:
+      '@assemblyscript/loader': 0.19.23
+      base64-js: 1.5.1
+      pako: 1.0.11
 
   he@1.2.0: {}
 
@@ -14214,6 +14311,22 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.9:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   multer@2.1.1:
     dependencies:
       append-field: 1.0.0
@@ -14268,6 +14381,11 @@ snapshots:
       char-regex: 1.0.2
       emojilib: 2.4.0
       skin-tone: 2.0.0
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-releases@2.0.36: {}
 
@@ -14397,6 +14515,8 @@ snapshots:
       semver: 7.7.4
 
   package-manager-detector@1.6.0: {}
+
+  pako@1.0.11: {}
 
   param-case@3.0.4:
     dependencies:
@@ -15965,6 +16085,8 @@ snapshots:
   tiny-warning@1.0.3: {}
 
   tinybench@2.9.0: {}
+
+  tinybench@6.0.0: {}
 
   tinyexec@0.3.2: {}
 

--- a/src/client/jetstream.client.ts
+++ b/src/client/jetstream.client.ts
@@ -22,8 +22,6 @@ import type {
 } from '../interfaces';
 import { StreamKind } from '../interfaces';
 import {
-  buildBroadcastSubject,
-  buildSubject,
   DEFAULT_JETSTREAM_RPC_TIMEOUT,
   DEFAULT_RPC_TIMEOUT,
   isCoreRpcMode,
@@ -34,6 +32,9 @@ import {
 } from '../jetstream.constants';
 
 import { JetstreamRecord } from './jetstream.record';
+
+/** Broadcast subjects are not scoped to a service and always share this prefix. */
+const BROADCAST_SUBJECT_PREFIX = 'broadcast.';
 
 /**
  * NestJS ClientProxy implementation for the JetStream transport.
@@ -56,6 +57,23 @@ export class JetstreamClient extends ClientProxy {
   /** Pre-cached caller name derived from rootOptions.name, computed once in constructor. */
   private readonly callerName: string;
 
+  /**
+   * Subject prefixes of the form `{serviceName}__microservice.{kind}.` — one
+   * per stream kind this client may publish to. Built once in the constructor
+   * so producing a full subject is a single string concat with the user pattern.
+   */
+  private readonly eventSubjectPrefix: string;
+  private readonly commandSubjectPrefix: string;
+  private readonly orderedSubjectPrefix: string;
+
+  /**
+   * RPC configuration snapshots. The values are derived from rootOptions at
+   * construction time so the publish hot path never has to re-run
+   * isCoreRpcMode / getRpcTimeout on every call.
+   */
+  private readonly isCoreMode: boolean;
+  private readonly defaultRpcTimeout: number;
+
   /** Shared inbox for JetStream-mode RPC responses. */
   private inbox: string | null = null;
   private inboxSubscription: Subscription | null = null;
@@ -69,6 +87,13 @@ export class JetstreamClient extends ClientProxy {
   /** Subscription to connection status events for disconnect handling. */
   private statusSubscription: RxSubscription | null = null;
 
+  /**
+   * Cached readiness flag. Once `connect()` has wired the inbox and status
+   * subscription, subsequent publishes skip the `await connect()` microtask
+   * and reach for the underlying connection synchronously instead.
+   */
+  private readyForPublish = false;
+
   public constructor(
     private readonly rootOptions: JetstreamModuleOptions,
     targetServiceName: string,
@@ -79,6 +104,17 @@ export class JetstreamClient extends ClientProxy {
     super();
     this.targetName = targetServiceName;
     this.callerName = internalName(this.rootOptions.name);
+
+    const targetInternal = internalName(targetServiceName);
+
+    this.eventSubjectPrefix = `${targetInternal}.${StreamKind.Event}.`;
+    this.commandSubjectPrefix = `${targetInternal}.${StreamKind.Command}.`;
+    this.orderedSubjectPrefix = `${targetInternal}.${StreamKind.Ordered}.`;
+
+    this.isCoreMode = isCoreRpcMode(this.rootOptions.rpc);
+    this.defaultRpcTimeout = isJetStreamRpcMode(this.rootOptions.rpc)
+      ? (this.rootOptions.rpc?.timeout ?? DEFAULT_JETSTREAM_RPC_TIMEOUT)
+      : (this.rootOptions.rpc?.timeout ?? DEFAULT_RPC_TIMEOUT);
   }
 
   /**
@@ -92,7 +128,7 @@ export class JetstreamClient extends ClientProxy {
   public async connect(): Promise<NatsConnection> {
     const nc = await this.connection.getConnection();
 
-    if (isJetStreamRpcMode(this.rootOptions.rpc) && !this.inboxSubscription) {
+    if (!this.isCoreMode && !this.inboxSubscription) {
       this.setupInbox(nc);
     }
 
@@ -102,6 +138,8 @@ export class JetstreamClient extends ClientProxy {
       }
     });
 
+    this.readyForPublish = true;
+
     return nc;
   }
 
@@ -109,6 +147,7 @@ export class JetstreamClient extends ClientProxy {
   public async close(): Promise<void> {
     this.statusSubscription?.unsubscribe();
     this.statusSubscription = null;
+    this.readyForPublish = false;
     this.rejectPendingRpcs(new Error('Client closed'));
   }
 
@@ -136,7 +175,7 @@ export class JetstreamClient extends ClientProxy {
    * set to the original event subject.
    */
   protected async dispatchEvent<T = unknown>(packet: ReadPacket): Promise<T> {
-    await this.connect();
+    if (!this.readyForPublish) await this.connect();
     const { data, hdrs, messageId, schedule, ttl } = this.extractRecordData(packet.data);
 
     const eventSubject = this.buildEventSubject(packet.pattern);
@@ -188,7 +227,7 @@ export class JetstreamClient extends ClientProxy {
    * JetStream mode: publishes to stream + waits for inbox response.
    */
   protected publish(packet: ReadPacket, callback: (p: WritePacket) => void): () => void {
-    const subject = buildSubject(this.targetName, StreamKind.Command, packet.pattern);
+    const subject = this.commandSubjectPrefix + packet.pattern;
     const { data, hdrs, timeout, messageId, schedule, ttl } = this.extractRecordData(packet.data);
 
     if (schedule) {
@@ -211,7 +250,7 @@ export class JetstreamClient extends ClientProxy {
     // Track correlation ID for cleanup in JetStream mode
     let jetStreamCorrelationId: string | null = null;
 
-    if (isCoreRpcMode(this.rootOptions.rpc)) {
+    if (this.isCoreMode) {
       this.publishCoreRpc(subject, data, hdrs, timeout, callback).catch(onUnhandled);
     } else {
       jetStreamCorrelationId = nuid.next();
@@ -248,8 +287,10 @@ export class JetstreamClient extends ClientProxy {
     callback: (p: WritePacket) => void,
   ): Promise<void> {
     try {
-      const nc = await this.connect();
-      const effectiveTimeout = timeout ?? this.getRpcTimeout();
+      const nc = this.readyForPublish
+        ? (this.connection.unwrap as NatsConnection)
+        : await this.connect();
+      const effectiveTimeout = timeout ?? this.defaultRpcTimeout;
       const hdrs = this.buildHeaders(customHeaders, { subject });
 
       const response = await nc.request(subject, this.codec.encode(data), {
@@ -286,12 +327,12 @@ export class JetstreamClient extends ClientProxy {
     },
   ): Promise<void> {
     const { headers: customHeaders, correlationId, messageId } = options;
-    const effectiveTimeout = options.timeout ?? this.getRpcTimeout();
+    const effectiveTimeout = options.timeout ?? this.defaultRpcTimeout;
 
     this.pendingMessages.set(correlationId, callback);
 
     try {
-      await this.connect();
+      if (!this.readyForPublish) await this.connect();
 
       // Bail out if cleaned up during connect (e.g. consumer unsubscribed)
       if (!this.pendingMessages.has(correlationId)) return;
@@ -353,6 +394,8 @@ export class JetstreamClient extends ClientProxy {
 
     // Reset inbox — will be recreated on next connect()
     this.inbox = null;
+    // Force the next publish to re-run the full connect setup.
+    this.readyForPublish = false;
   }
 
   /** Reject all pending RPC callbacks, clear timeouts, and tear down inbox. */
@@ -432,21 +475,24 @@ export class JetstreamClient extends ClientProxy {
     }
   }
 
-  /** Build event subject — workqueue, broadcast, or ordered. */
+  /**
+   * Resolve a user pattern to a fully-qualified NATS subject, dispatching
+   * between the event, broadcast, and ordered prefixes.
+   *
+   * The leading-char check short-circuits the `startsWith` comparisons for
+   * patterns that cannot possibly carry a broadcast/ordered marker, which is
+   * the overwhelmingly common case.
+   */
   private buildEventSubject(pattern: string): string {
-    if (pattern.startsWith(PatternPrefix.Broadcast)) {
-      return buildBroadcastSubject(pattern.slice(PatternPrefix.Broadcast.length));
+    if (pattern.charCodeAt(0) === 98 /* 'b' */ && pattern.startsWith(PatternPrefix.Broadcast)) {
+      return BROADCAST_SUBJECT_PREFIX + pattern.slice(PatternPrefix.Broadcast.length);
     }
 
-    if (pattern.startsWith(PatternPrefix.Ordered)) {
-      return buildSubject(
-        this.targetName,
-        StreamKind.Ordered,
-        pattern.slice(PatternPrefix.Ordered.length),
-      );
+    if (pattern.charCodeAt(0) === 111 /* 'o' */ && pattern.startsWith(PatternPrefix.Ordered)) {
+      return this.orderedSubjectPrefix + pattern.slice(PatternPrefix.Ordered.length);
     }
 
-    return buildSubject(this.targetName, StreamKind.Event, pattern);
+    return this.eventSubjectPrefix + pattern;
   }
 
   /** Build NATS headers merging custom headers with transport headers. */
@@ -481,9 +527,11 @@ export class JetstreamClient extends ClientProxy {
   /** Extract data, headers, timeout, and schedule from raw packet data or JetstreamRecord. */
   private extractRecordData(rawData: unknown): ExtractedRecordData {
     if (rawData instanceof JetstreamRecord) {
+      // JetstreamRecord.headers is a ReadonlyMap on an immutable record; the
+      // reference is handed through as-is because buildHeaders only reads it.
       return {
         data: rawData.data,
-        hdrs: rawData.headers.size > 0 ? new Map(rawData.headers) : null,
+        hdrs: rawData.headers.size > 0 ? (rawData.headers as Map<string, string>) : null,
         timeout: rawData.timeout,
         messageId: rawData.messageId,
         schedule: rawData.schedule,
@@ -536,15 +584,5 @@ export class JetstreamClient extends ClientProxy {
     const pattern = withoutPrefix.slice(dotIndex + 1);
 
     return `${targetPrefix}_sch.${pattern}`;
-  }
-
-  private getRpcTimeout(): number {
-    if (!this.rootOptions.rpc) return DEFAULT_RPC_TIMEOUT;
-
-    const defaultTimeout = isJetStreamRpcMode(this.rootOptions.rpc)
-      ? DEFAULT_JETSTREAM_RPC_TIMEOUT
-      : DEFAULT_RPC_TIMEOUT;
-
-    return this.rootOptions.rpc.timeout ?? defaultTimeout;
   }
 }

--- a/src/codec/index.ts
+++ b/src/codec/index.ts
@@ -1,1 +1,3 @@
 export { JsonCodec } from './json.codec';
+
+export { MsgpackCodec } from './msgpack.codec';

--- a/src/codec/msgpack.codec.ts
+++ b/src/codec/msgpack.codec.ts
@@ -1,0 +1,53 @@
+import type { Codec } from '../interfaces';
+
+/**
+ * Minimal shape of a `msgpackr` `Packr` instance used by {@link MsgpackCodec}.
+ *
+ * Typed locally so consumers who do not use MessagePack encoding never pay
+ * for a `msgpackr` import.
+ */
+export interface PackrLike {
+  pack(data: unknown): Uint8Array;
+  unpack(data: Uint8Array): unknown;
+}
+
+/**
+ * MessagePack codec backed by a caller-provided `msgpackr` `Packr` instance.
+ *
+ * Use this codec when publishing structured payloads larger than roughly
+ * 1–2 KB — below that size the default {@link JsonCodec} wins on per-call
+ * constant overhead. Above it, MessagePack encodes and decodes several times
+ * faster and produces smaller wire frames. The format is cross-language, so
+ * Node producers and non-Node consumers (Python, Go, Java, Rust, ...) stay
+ * interoperable.
+ *
+ * Requires installing the optional `msgpackr` peer dependency:
+ *
+ * ```bash
+ * npm install msgpackr
+ * # or: pnpm add msgpackr
+ * ```
+ *
+ * @example
+ * ```typescript
+ * import { JetstreamModule, MsgpackCodec } from '@horizon-republic/nestjs-jetstream';
+ * import { Packr } from 'msgpackr';
+ *
+ * JetstreamModule.forRoot({
+ *   name: 'orders',
+ *   servers: ['nats://localhost:4222'],
+ *   codec: new MsgpackCodec(new Packr()),
+ * });
+ * ```
+ */
+export class MsgpackCodec implements Codec {
+  public constructor(private readonly packr: PackrLike) {}
+
+  public encode(data: unknown): Uint8Array {
+    return this.packr.pack(data);
+  }
+
+  public decode(data: Uint8Array): unknown {
+    return this.packr.unpack(data);
+  }
+}

--- a/src/hooks/event-bus.ts
+++ b/src/hooks/event-bus.ts
@@ -65,6 +65,16 @@ export class EventBus {
     );
   }
 
+  /**
+   * Check whether a hook is registered for the given event.
+   *
+   * Used by the routing hot path to elide the emit call entirely when the
+   * transport owner did not register a listener.
+   */
+  public hasHook(event: keyof TransportHooks): boolean {
+    return this.hooks[event] !== undefined;
+  }
+
   private callHook(event: string, hook: (...a: unknown[]) => unknown, ...args: unknown[]): void {
     try {
       const result = hook(...args);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export { JetstreamClient } from './client';
 export { JetstreamRecord, JetstreamRecordBuilder } from './client';
 
 // Codec
-export { JsonCodec } from './codec';
+export { JsonCodec, MsgpackCodec } from './codec';
 
 // Context
 export { RpcContext } from './context';

--- a/src/server/core-rpc.server.ts
+++ b/src/server/core-rpc.server.ts
@@ -7,7 +7,7 @@ import { EventBus } from '../hooks';
 import { MessageKind } from '../interfaces';
 import type { Codec, JetstreamModuleOptions } from '../interfaces';
 import { internalName, JetstreamHeader } from '../jetstream.constants';
-import { serializeError, unwrapResult } from '../utils';
+import { isPromiseLike, serializeError, unwrapResult } from '../utils';
 
 import { PatternRegistry } from './routing/pattern-registry';
 
@@ -93,7 +93,8 @@ export class CoreRpcServer {
     const ctx = new RpcContext([msg]);
 
     try {
-      const result = await unwrapResult(handler(data, ctx));
+      const raw = unwrapResult(handler(data, ctx));
+      const result = isPromiseLike(raw) ? await raw : raw;
 
       msg.respond(this.codec.encode(result));
     } catch (err) {

--- a/src/server/infrastructure/__tests__/message.provider.spec.ts
+++ b/src/server/infrastructure/__tests__/message.provider.spec.ts
@@ -49,21 +49,42 @@ const createStatusIterator = (
 };
 
 /**
- * Creates a mock async iterable of JsMsg that can be stopped externally.
- * Simulates the ConsumerMessages object returned by consumer.consume().
+ * Creates a mock ConsumerMessages that supports both the callback-based
+ * and async-iterator consumption modes. `callback` is invoked on `deliver()`;
+ * `closed()` resolves once `stop()` is called.
  */
+interface MockMessages extends ConsumerMessages {
+  /** Push pending messages through the registered callback. */
+  deliver(): void;
+  /** Register the callback passed via `consume({ callback })`. */
+  setCallback(cb: (msg: JsMsg) => void): void;
+}
+
 const createMockMessages = (
   msgs: JsMsg[] = [],
   statusEvents: { type: string; count: number }[] = [],
-): ConsumerMessages => {
+): MockMessages => {
   let stopped = false;
   let resolveWait: (() => void) | null = null;
+  let resolveClosed: (() => void) | null = null;
+  let callback: ((msg: JsMsg) => void) | null = null;
 
-  const mockMessages = {
+  const closedPromise = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+
+  const deliverPending = (): void => {
+    if (!callback) return;
+    for (const msg of msgs.splice(0, msgs.length)) callback(msg);
+  };
+
+  const mockMessages: MockMessages = {
     stop: vi.fn(() => {
       stopped = true;
       resolveWait?.();
+      resolveClosed?.();
     }),
+    closed: vi.fn(() => closedPromise),
     status: vi.fn().mockReturnValue({
       [Symbol.asyncIterator]: () => ({
         next: createStatusIterator(
@@ -75,6 +96,16 @@ const createMockMessages = (
         ),
       }),
     }),
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions -- method shorthand required by method-signature-style on the MockMessages interface
+    setCallback(cb: (msg: JsMsg) => void): void {
+      callback = cb;
+      // Auto-deliver anything queued before the callback was registered.
+      deliverPending();
+    },
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions -- same as above
+    deliver(): void {
+      deliverPending();
+    },
     [Symbol.asyncIterator]: (): AsyncIteratorLike<JsMsg> => {
       let index = 0;
 
@@ -90,7 +121,25 @@ const createMockMessages = (
     },
   };
 
-  return mockMessages as unknown as ConsumerMessages;
+  return mockMessages as unknown as MockMessages;
+};
+
+interface ConsumeOptsWithCallback {
+  callback?(msg: JsMsg): void;
+}
+
+/**
+ * Build a Consumer mock whose `consume()` wires the caller's callback into
+ * the returned mock messages, matching the production callback-mode path.
+ */
+const makeConsumer = (messages: MockMessages): Consumer => {
+  const consume = vi.fn(async (opts?: ConsumeOptsWithCallback) => {
+    if (opts?.callback) messages.setCallback(opts.callback);
+
+    return messages;
+  });
+
+  return createMock<Consumer>({ consume });
 };
 
 describe(MessageProvider, () => {
@@ -112,9 +161,7 @@ describe(MessageProvider, () => {
     describe('when called after start', () => {
       it('should reinitialize subjects so start() can be called again', async () => {
         // Given: a consumer that completes immediately
-        const mockConsumer = createMock<Consumer>({
-          consume: vi.fn().mockResolvedValue(createMockMessages()),
-        });
+        const mockConsumer = makeConsumer(createMockMessages());
 
         const consumerInfo = createMock<ConsumerInfo>({
           name: faker.lorem.word(),
@@ -185,9 +232,7 @@ describe(MessageProvider, () => {
 
         // Given: first call fails, second call succeeds
         const mockMessages = createMockMessages();
-        const mockConsumer = createMock<Consumer>({
-          consume: vi.fn().mockResolvedValue(mockMessages),
-        });
+        const mockConsumer = makeConsumer(mockMessages);
 
         const consumerInfo = createMock<ConsumerInfo>({
           name: faker.lorem.word(),
@@ -281,9 +326,7 @@ describe(MessageProvider, () => {
 
         const mockMessages = createMockMessages([], statusEvents);
 
-        const mockConsumer = createMock<Consumer>({
-          consume: vi.fn().mockResolvedValue(mockMessages),
-        });
+        const mockConsumer = makeConsumer(mockMessages);
 
         const consumerInfo = createMock<ConsumerInfo>({
           name: faker.lorem.word(),
@@ -321,9 +364,7 @@ describe(MessageProvider, () => {
 
         const mockMessages = createMockMessages([], statusEvents);
 
-        const mockConsumer = createMock<Consumer>({
-          consume: vi.fn().mockResolvedValue(mockMessages),
-        });
+        const mockConsumer = makeConsumer(mockMessages);
 
         const consumerInfo = createMock<ConsumerInfo>({
           name: faker.lorem.word(),
@@ -362,9 +403,7 @@ describe(MessageProvider, () => {
 
         // Given: ordered consumer creation fails once, then succeeds
         const mockMessages = createMockMessages();
-        const mockConsumer = createMock<Consumer>({
-          consume: vi.fn().mockResolvedValue(mockMessages),
-        });
+        const mockConsumer = makeConsumer(mockMessages);
 
         const js = {
           consumers: {
@@ -400,9 +439,7 @@ describe(MessageProvider, () => {
         // Given: ordered consumer connects and starts consuming
         const mockMessages = createMockMessages();
 
-        const mockConsumer = createMock<Consumer>({
-          consume: vi.fn().mockResolvedValue(mockMessages),
-        });
+        const mockConsumer = makeConsumer(mockMessages);
 
         const js = {
           consumers: {
@@ -455,9 +492,7 @@ describe(MessageProvider, () => {
 
         const mockMessages = createMockMessages([mockMsg]);
 
-        const mockConsumer = createMock<Consumer>({
-          consume: vi.fn().mockResolvedValue(mockMessages),
-        });
+        const mockConsumer = makeConsumer(mockMessages);
 
         const consumerInfo = createMock<ConsumerInfo>({
           name: faker.lorem.word(),
@@ -513,9 +548,7 @@ describe(MessageProvider, () => {
         );
 
         const mockMessages = createMockMessages();
-        const mockConsumer = createMock<Consumer>({
-          consume: vi.fn().mockResolvedValue(mockMessages),
-        });
+        const mockConsumer = makeConsumer(mockMessages);
 
         const originalConsumerInfo = createMock<ConsumerInfo>({
           name: faker.lorem.word(),
@@ -573,9 +606,7 @@ describe(MessageProvider, () => {
         );
 
         const mockMessages = createMockMessages();
-        const mockConsumer = createMock<Consumer>({
-          consume: vi.fn().mockResolvedValue(mockMessages),
-        });
+        const mockConsumer = makeConsumer(mockMessages);
 
         const consumerInfo = createMock<ConsumerInfo>({
           name: faker.lorem.word(),

--- a/src/server/infrastructure/consumer.provider.ts
+++ b/src/server/infrastructure/consumer.provider.ts
@@ -257,7 +257,6 @@ export class ConsumerProvider {
         throw new Error('Ordered consumers are ephemeral and should not use durable config');
       /* v8 ignore next 5 -- exhaustive switch guard, unreachable */
       default: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const _exhaustive: never = kind;
 
         throw new Error(`Unexpected StreamKind: ${_exhaustive}`);
@@ -278,7 +277,6 @@ export class ConsumerProvider {
         throw new Error('Ordered consumers are ephemeral and should not use durable config');
       /* v8 ignore next 5 -- exhaustive switch guard, unreachable */
       default: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const _exhaustive: never = kind;
 
         throw new Error(`Unexpected StreamKind: ${_exhaustive}`);

--- a/src/server/infrastructure/message.provider.ts
+++ b/src/server/infrastructure/message.provider.ts
@@ -221,15 +221,23 @@ export class MessageProvider {
     /* eslint-enable @typescript-eslint/naming-convention */
     const userOptions = this.consumeOptionsMap.get(kind) ?? {};
 
-    const messages = await consumer.consume({ ...defaults, ...userOptions } as ConsumeOptions);
+    // Push messages directly into the subject via a sync callback so each
+    // delivery skips the async-iterator next()/{value,done} wrapper allocated
+    // by `for await`. The callback path in @nats-io/jetstream requires the
+    // body to be synchronous — `Subject.next` meets that contract.
+    const messages = await consumer.consume({
+      ...defaults,
+      ...userOptions,
+      callback: (msg: JsMsg): void => {
+        target$.next(msg);
+      },
+    } as ConsumeOptions);
 
     this.activeIterators.add(messages);
     this.monitorConsumerHealth(messages, consumerName);
 
     try {
-      for await (const msg of messages) {
-        target$.next(msg);
-      }
+      await messages.closed();
     } finally {
       this.activeIterators.delete(messages);
     }
@@ -264,7 +272,6 @@ export class MessageProvider {
         return this.orderedMessages$;
       /* v8 ignore next 5 -- exhaustive switch guard, unreachable */
       default: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const _exhaustive: never = kind;
 
         throw new Error(`Unknown stream kind: ${_exhaustive}`);
@@ -349,14 +356,19 @@ export class MessageProvider {
     );
   }
 
-  /** Single iteration: create ordered consumer -> iterate messages. */
+  /** Single iteration: create ordered consumer -> push messages into the subject. */
   private async consumeOrderedOnce(
     streamName: string,
     consumerOpts: Partial<OrderedConsumerOptions>,
   ): Promise<void> {
     const js = this.connection.getJetStreamClient();
     const consumer = await js.consumers.get(streamName, consumerOpts);
-    const messages = await consumer.consume();
+    const orderedMessages$ = this.orderedMessages$;
+    const messages = await consumer.consume({
+      callback: (msg: JsMsg): void => {
+        orderedMessages$.next(msg);
+      },
+    } as ConsumeOptions);
 
     // Signal that the ordered consumer is ready to receive messages
     if (this.orderedReadyResolve) {
@@ -368,9 +380,7 @@ export class MessageProvider {
     this.activeIterators.add(messages);
 
     try {
-      for await (const msg of messages) {
-        this.orderedMessages$.next(msg);
-      }
+      await messages.closed();
     } finally {
       this.activeIterators.delete(messages);
     }

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { MessageHandler } from '@nestjs/microservices';
 import type { JsMsg } from '@nats-io/jetstream';
-import { concatMap, from, mergeMap, Observable, Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 
 import { RpcContext } from '../../context';
 import { EventBus } from '../../hooks';
@@ -16,7 +16,12 @@ import type {
   EventProcessingConfig,
   JetstreamModuleOptions,
 } from '../../interfaces';
-import { resolveAckExtensionInterval, startAckExtensionTimer, unwrapResult } from '../../utils';
+import {
+  isPromiseLike,
+  resolveAckExtensionInterval,
+  startAckExtensionTimer,
+  unwrapResult,
+} from '../../utils';
 
 import { MessageProvider } from '../infrastructure';
 import { PatternRegistry } from './pattern-registry';
@@ -81,24 +86,287 @@ export class EventRouter {
     this.subscriptions.length = 0;
   }
 
-  /** Subscribe to a message stream and route each message. */
+  /** Subscribe to a message stream and route each message to its handler. */
   private subscribeToStream(stream$: Observable<JsMsg>, kind: StreamKind): void {
     const isOrdered = kind === StreamKind.Ordered;
 
-    // Resolve once per stream — these never change after startup
+    const patternRegistry = this.patternRegistry;
+    const codec = this.codec;
+    const eventBus = this.eventBus;
+    const logger = this.logger;
+    const deadLetterConfig = this.deadLetterConfig;
+
     const ackExtensionInterval = isOrdered
       ? null
       : resolveAckExtensionInterval(this.getAckExtensionConfig(kind), this.ackWaitMap?.get(kind));
+    const hasAckExtension = ackExtensionInterval !== null && ackExtensionInterval > 0;
     const concurrency = this.getConcurrency(kind);
+    // Snapshot the config object, not the Map — updateMaxDeliverMap() can
+    // replace maxDeliverByStream wholesale after consumers are ensured.
+    const hasDlqCheck = deadLetterConfig !== undefined;
+    const emitRouted = eventBus.hasHook(TransportEvent.MessageRouted);
 
-    const route = (msg: JsMsg): Observable<void> =>
-      from(
-        isOrdered ? this.handleOrderedSafe(msg) : this.handleSafe(msg, ackExtensionInterval, kind),
+    const isDeadLetter = (msg: JsMsg): boolean => {
+      if (!hasDlqCheck) return false;
+      // updateMaxDeliverMap() populates maxDeliverByStream after consumers are
+      // ensured. Optional chaining guards the brief startup window before it
+      // is assigned — the interface types it as always-present but the runtime
+      // lifecycle allows a brief undefined state.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime lifecycle guard
+      const maxDeliver = deadLetterConfig.maxDeliverByStream?.get(msg.info.stream);
+
+      if (maxDeliver === undefined || maxDeliver <= 0) return false;
+
+      return msg.info.deliveryCount >= maxDeliver;
+    };
+
+    const handleDeadLetter = hasDlqCheck
+      ? (msg: JsMsg, data: unknown, err: unknown): Promise<void> =>
+          this.handleDeadLetter(msg, data, err)
+      : null;
+
+    const settleSuccess = (msg: JsMsg, ctx: RpcContext): void => {
+      if (ctx.shouldTerminate) msg.term(ctx.terminateReason);
+      else if (ctx.shouldRetry) msg.nak(ctx.retryDelay);
+      else msg.ack();
+    };
+
+    const settleFailure = async (msg: JsMsg, data: unknown, err: unknown): Promise<void> => {
+      if (handleDeadLetter !== null && isDeadLetter(msg)) {
+        await handleDeadLetter(msg, data, err);
+
+        return;
+      }
+
+      msg.nak();
+    };
+
+    /**
+     * Resolve the handler and decode payload for one event.
+     *
+     * Returns `null` when the message cannot be routed (no handler, decode
+     * error, or unexpected pre-dispatch failure) — those branches settle the
+     * message synchronously inside the helper and produce nothing to dispatch.
+     */
+    const resolveEvent = (msg: JsMsg): { handler: MessageHandler; data: unknown } | null => {
+      const subject = msg.subject;
+
+      try {
+        const handler = patternRegistry.getHandler(subject);
+
+        if (!handler) {
+          msg.term(`No handler for event: ${subject}`);
+          logger.error(`No handler for subject: ${subject}`);
+
+          return null;
+        }
+
+        let data: unknown;
+
+        try {
+          data = codec.decode(msg.data);
+        } catch (err) {
+          msg.term('Decode error');
+          logger.error(`Decode error for ${subject}:`, err);
+
+          return null;
+        }
+
+        if (emitRouted) eventBus.emitMessageRouted(subject, MessageKind.Event);
+
+        return { handler, data };
+      } catch (err) {
+        logger.error(`Unexpected error in ${kind} event router`, err);
+        // Terminate the message so NATS does not redeliver into the same
+        // synchronous failure forever. term() itself may throw when the
+        // connection is degraded — swallow that to keep the subscription alive.
+        try {
+          msg.term('Unexpected router error');
+        } catch (termErr) {
+          logger.error(`Failed to terminate message ${subject}:`, termErr);
+        }
+
+        return null;
+      }
+    };
+
+    /**
+     * Run the full event-routing pipeline for one message.
+     *
+     * Returns `undefined` when the whole flow completed synchronously
+     * (sync handler, no awaitable settlement) and a Promise otherwise, so
+     * the concurrency limiter can skip the `.finally()` allocation on the
+     * sync path. The sync branch inlines settlement to avoid per-message
+     * closures that would cost more heap than the Promise they replace.
+     */
+    const handleSafe = (msg: JsMsg): Promise<void> | undefined => {
+      const resolved = resolveEvent(msg);
+
+      if (resolved === null) return undefined;
+
+      const { handler, data } = resolved;
+      const ctx = new RpcContext([msg]);
+      const stopAckExtension = hasAckExtension
+        ? startAckExtensionTimer(msg, ackExtensionInterval)
+        : null;
+
+      let pending: unknown;
+
+      try {
+        pending = unwrapResult(handler(data, ctx));
+      } catch (err) {
+        logger.error(`Event handler error (${msg.subject}) in ${kind} router:`, err);
+        if (stopAckExtension !== null) stopAckExtension();
+
+        return settleFailure(msg, data, err);
+      }
+
+      if (!isPromiseLike(pending)) {
+        settleSuccess(msg, ctx);
+        if (stopAckExtension !== null) stopAckExtension();
+
+        return undefined;
+      }
+
+      return (pending as Promise<unknown>).then(
+        () => {
+          settleSuccess(msg, ctx);
+          if (stopAckExtension !== null) stopAckExtension();
+        },
+        async (err: unknown) => {
+          logger.error(`Event handler error (${msg.subject}) in ${kind} router:`, err);
+          try {
+            await settleFailure(msg, data, err);
+          } finally {
+            if (stopAckExtension !== null) stopAckExtension();
+          }
+        },
       );
+    };
 
-    const subscription = stream$
-      .pipe(isOrdered ? concatMap(route) : mergeMap(route, concurrency))
-      .subscribe();
+    const handleOrderedSafe = (msg: JsMsg): Promise<void> | undefined => {
+      const subject = msg.subject;
+      let handler: MessageHandler | null;
+      let data: unknown;
+
+      try {
+        handler = patternRegistry.getHandler(subject);
+
+        if (!handler) {
+          logger.error(`No handler for subject: ${subject}`);
+
+          return undefined;
+        }
+
+        try {
+          data = codec.decode(msg.data);
+        } catch (err) {
+          logger.error(`Decode error for ${subject}:`, err);
+
+          return undefined;
+        }
+
+        if (emitRouted) eventBus.emitMessageRouted(subject, MessageKind.Event);
+      } catch (err) {
+        logger.error(`Ordered handler error (${subject}):`, err);
+
+        return undefined;
+      }
+
+      const ctx = new RpcContext([msg]);
+
+      const warnIfSettlementAttempted = (): void => {
+        if (ctx.shouldRetry || ctx.shouldTerminate) {
+          logger.warn(
+            `retry()/terminate() ignored for ordered message ${subject} — ordered consumers auto-acknowledge`,
+          );
+        }
+      };
+
+      let pending: unknown;
+
+      try {
+        pending = unwrapResult(handler(data, ctx));
+      } catch (err) {
+        logger.error(`Ordered handler error (${subject}):`, err);
+
+        return undefined;
+      }
+
+      if (!isPromiseLike(pending)) {
+        warnIfSettlementAttempted();
+
+        return undefined;
+      }
+
+      return (pending as Promise<unknown>).then(warnIfSettlementAttempted, (err: unknown) => {
+        logger.error(`Ordered handler error (${subject}):`, err);
+      });
+    };
+
+    const route = isOrdered ? handleOrderedSafe : handleSafe;
+
+    // Concurrency limiter: up to `maxActive` messages are routed in parallel;
+    // anything beyond queues into `backlog` and is drained FIFO as each
+    // in-flight message completes. Ordered streams pin the limit to 1 so
+    // delivery stays strictly sequential.
+    const maxActive = isOrdered ? 1 : (concurrency ?? Number.POSITIVE_INFINITY);
+    const backlogWarnThreshold = 1_000;
+    let active = 0;
+    let backlogWarned = false;
+    const backlog: JsMsg[] = [];
+
+    const onAsyncDone = (): void => {
+      active--;
+      drainBacklog();
+    };
+
+    const drainBacklog = (): void => {
+      while (active < maxActive) {
+        const next = backlog.shift();
+
+        if (next === undefined) return;
+        active++;
+        const result = route(next);
+
+        if (result !== undefined) {
+          void result.finally(onAsyncDone);
+        } else {
+          active--;
+        }
+      }
+
+      if (backlog.length < backlogWarnThreshold) backlogWarned = false;
+    };
+
+    const subscription = stream$.subscribe({
+      next: (msg: JsMsg): void => {
+        if (active >= maxActive) {
+          backlog.push(msg);
+          if (!backlogWarned && backlog.length >= backlogWarnThreshold) {
+            backlogWarned = true;
+            logger.warn(
+              `${kind} backlog reached ${backlog.length} messages — consumer may be falling behind`,
+            );
+          }
+
+          return;
+        }
+
+        active++;
+        const result = route(msg);
+
+        if (result !== undefined) {
+          void result.finally(onAsyncDone);
+        } else {
+          active--;
+          if (backlog.length > 0) drainBacklog();
+        }
+      },
+      error: (err: unknown): void => {
+        logger.error(`Stream error in ${kind} router`, err);
+      },
+    });
 
     this.subscriptions.push(subscription);
   }
@@ -113,120 +381,6 @@ export class EventRouter {
     if (kind === StreamKind.Event) return this.processingConfig?.events?.ackExtension;
     if (kind === StreamKind.Broadcast) return this.processingConfig?.broadcast?.ackExtension;
     return undefined;
-  }
-
-  /** Handle a single event message with error isolation. */
-  private async handleSafe(
-    msg: JsMsg,
-    ackExtensionInterval: number | null,
-    kind: StreamKind,
-  ): Promise<void> {
-    try {
-      const resolved = this.decodeMessage(msg);
-
-      if (!resolved) return;
-
-      await this.executeHandler(
-        resolved.handler,
-        resolved.data,
-        resolved.ctx,
-        msg,
-        ackExtensionInterval,
-      );
-    } catch (err) {
-      this.logger.error(`Unexpected error in ${kind} event router`, err);
-    }
-  }
-
-  /** Handle an ordered message with error isolation. */
-  private async handleOrderedSafe(msg: JsMsg): Promise<void> {
-    try {
-      const resolved = this.decodeMessage(msg, true);
-
-      if (!resolved) return;
-
-      await unwrapResult(resolved.handler(resolved.data, resolved.ctx));
-
-      if (resolved.ctx.shouldRetry || resolved.ctx.shouldTerminate) {
-        this.logger.warn(
-          `retry()/terminate() ignored for ordered message ${msg.subject} — ordered consumers auto-acknowledge`,
-        );
-      }
-    } catch (err) {
-      this.logger.error(`Ordered handler error (${msg.subject}):`, err);
-    }
-  }
-
-  /** Resolve handler, decode payload, and build context. Returns null on failure. */
-  private decodeMessage(
-    msg: JsMsg,
-    isOrdered = false,
-  ): { handler: MessageHandler; data: unknown; ctx: RpcContext } | null {
-    const handler = this.patternRegistry.getHandler(msg.subject);
-
-    if (!handler) {
-      if (!isOrdered) msg.term(`No handler for event: ${msg.subject}`);
-      this.logger.error(`No handler for subject: ${msg.subject}`);
-      return null;
-    }
-
-    let data: unknown;
-
-    try {
-      data = this.codec.decode(msg.data);
-    } catch (err) {
-      if (!isOrdered) msg.term('Decode error');
-      this.logger.error(`Decode error for ${msg.subject}:`, err);
-      return null;
-    }
-
-    this.eventBus.emitMessageRouted(msg.subject, MessageKind.Event);
-
-    return { handler, data, ctx: new RpcContext([msg]) };
-  }
-
-  /** Execute handler, then ack on success or nak/dead-letter on failure. */
-  private async executeHandler(
-    handler: MessageHandler,
-    data: unknown,
-    ctx: RpcContext,
-    msg: JsMsg,
-    ackExtensionInterval: number | null,
-  ): Promise<void> {
-    const stopAckExtension = startAckExtensionTimer(msg, ackExtensionInterval);
-
-    try {
-      await unwrapResult(handler(data, ctx));
-
-      if (ctx.shouldTerminate) {
-        msg.term(ctx.terminateReason);
-      } else if (ctx.shouldRetry) {
-        msg.nak(ctx.retryDelay);
-      } else {
-        msg.ack();
-      }
-    } catch (err) {
-      this.logger.error(`Event handler error (${msg.subject}):`, err);
-
-      if (this.isDeadLetter(msg)) {
-        await this.handleDeadLetter(msg, data, err);
-      } else {
-        msg.nak();
-      }
-    } finally {
-      stopAckExtension?.();
-    }
-  }
-
-  /** Check if the message has exhausted all delivery attempts. */
-  private isDeadLetter(msg: JsMsg): boolean {
-    if (!this.deadLetterConfig) return false;
-
-    const maxDeliver = this.deadLetterConfig.maxDeliverByStream.get(msg.info.stream);
-
-    if (maxDeliver === undefined || maxDeliver <= 0) return false;
-
-    return msg.info.deliveryCount >= maxDeliver;
   }
 
   /** Handle a dead letter: invoke callback, then term or nak based on result. */

--- a/src/server/routing/rpc.router.ts
+++ b/src/server/routing/rpc.router.ts
@@ -2,7 +2,7 @@ import { Logger } from '@nestjs/common';
 import { MessageHandler } from '@nestjs/microservices';
 import { headers, type NatsConnection } from '@nats-io/transport-node';
 import type { JsMsg } from '@nats-io/jetstream';
-import { from, mergeMap, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 
 import { ConnectionProvider } from '../../connection';
 import { RpcContext } from '../../context';
@@ -11,6 +11,7 @@ import { MessageKind, StreamKind, TransportEvent } from '../../interfaces';
 import type { Codec, RpcRouterOptions } from '../../interfaces';
 import { DEFAULT_JETSTREAM_RPC_TIMEOUT, JetstreamHeader } from '../../jetstream.constants';
 import {
+  isPromiseLike,
   resolveAckExtensionInterval,
   serializeError,
   startAckExtensionTimer,
@@ -66,119 +67,245 @@ export class RpcRouter {
   /** Start routing command messages to handlers. */
   public async start(): Promise<void> {
     this.cachedNc = await this.connection.getConnection();
-    this.subscription = this.messageProvider.commands$
-      .pipe(mergeMap((msg) => from(this.handleSafe(msg)), this.concurrency))
-      .subscribe();
+
+    const nc = this.cachedNc;
+    const patternRegistry = this.patternRegistry;
+    const codec = this.codec;
+    const eventBus = this.eventBus;
+    const logger = this.logger;
+    const timeout = this.timeout;
+    const ackExtensionInterval = this.ackExtensionInterval;
+    const hasAckExtension = ackExtensionInterval !== null && ackExtensionInterval > 0;
+    const maxActive = this.concurrency ?? Number.POSITIVE_INFINITY;
+
+    const emitRpcTimeout = (subject: string, correlationId: string): void => {
+      eventBus.emit(TransportEvent.RpcTimeout, subject, correlationId);
+    };
+
+    const publishReply = (replyTo: string, correlationId: string, payload: unknown): void => {
+      try {
+        const hdrs = headers();
+
+        hdrs.set(JetstreamHeader.CorrelationId, correlationId);
+        nc.publish(replyTo, codec.encode(payload), { headers: hdrs });
+      } catch (publishErr) {
+        logger.error(`Failed to publish RPC response`, publishErr);
+      }
+    };
+
+    const publishErrorReply = (
+      replyTo: string,
+      correlationId: string,
+      subject: string,
+      err: unknown,
+    ): void => {
+      try {
+        const hdrs = headers();
+
+        hdrs.set(JetstreamHeader.CorrelationId, correlationId);
+        hdrs.set(JetstreamHeader.Error, 'true');
+        nc.publish(replyTo, codec.encode(serializeError(err)), { headers: hdrs });
+      } catch (encodeErr) {
+        logger.error(`Failed to encode RPC error for ${subject}`, encodeErr);
+      }
+    };
+
+    const resolveCommand = (
+      msg: JsMsg,
+    ): {
+      handler: MessageHandler;
+      data: unknown;
+      replyTo: string;
+      correlationId: string;
+    } | null => {
+      const subject = msg.subject;
+
+      try {
+        const handler = patternRegistry.getHandler(subject);
+
+        if (!handler) {
+          msg.term(`No handler for RPC: ${subject}`);
+          logger.error(`No handler for RPC subject: ${subject}`);
+
+          return null;
+        }
+
+        const msgHeaders = msg.headers;
+        const replyTo = msgHeaders?.get(JetstreamHeader.ReplyTo);
+        const correlationId = msgHeaders?.get(JetstreamHeader.CorrelationId);
+
+        if (!replyTo || !correlationId) {
+          msg.term('Missing required headers (reply-to or correlation-id)');
+          logger.error(`Missing headers for RPC: ${subject}`);
+
+          return null;
+        }
+
+        let data: unknown;
+
+        try {
+          data = codec.decode(msg.data);
+        } catch (err) {
+          msg.term('Decode error');
+          logger.error(`Decode error for RPC ${subject}:`, err);
+
+          return null;
+        }
+
+        eventBus.emitMessageRouted(subject, MessageKind.Rpc);
+
+        return { handler, data, replyTo, correlationId };
+      } catch (err) {
+        logger.error('Unexpected error in RPC router', err);
+        // Terminate the command so NATS does not redeliver into the same
+        // synchronous failure forever. term() itself may throw when the
+        // connection is degraded — swallow that to keep the subscription alive.
+        try {
+          msg.term('Unexpected router error');
+        } catch (termErr) {
+          logger.error(`Failed to terminate RPC message ${subject}:`, termErr);
+        }
+
+        return null;
+      }
+    };
+
+    /**
+     * Run the full RPC pipeline for one command.
+     *
+     * Returns `undefined` when the handler completed synchronously and a
+     * Promise when we are still awaiting user work, so the concurrency
+     * limiter can skip `.finally()` allocation on the sync path.
+     *
+     * The deadline `setTimeout` is only armed on the async branch — sync
+     * handlers cannot miss the deadline they return inside, so registering
+     * a timer just to clear it microseconds later is wasted work.
+     */
+    const handleSafe = (msg: JsMsg): Promise<void> | undefined => {
+      const resolved = resolveCommand(msg);
+
+      if (resolved === null) return undefined;
+
+      const { handler, data, replyTo, correlationId } = resolved;
+      const subject = msg.subject;
+      const ctx = new RpcContext([msg]);
+      const stopAckExtension = hasAckExtension
+        ? startAckExtensionTimer(msg, ackExtensionInterval)
+        : null;
+
+      let pending: unknown;
+
+      try {
+        pending = unwrapResult(handler(data, ctx));
+      } catch (err) {
+        if (stopAckExtension !== null) stopAckExtension();
+        logger.error(`RPC handler error (${subject}):`, err);
+        publishErrorReply(replyTo, correlationId, subject, err);
+        msg.term(`Handler error: ${subject}`);
+
+        return undefined;
+      }
+
+      if (!isPromiseLike(pending)) {
+        if (stopAckExtension !== null) stopAckExtension();
+        msg.ack();
+        publishReply(replyTo, correlationId, pending);
+
+        return undefined;
+      }
+
+      let settled = false;
+      const timeoutId = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        if (stopAckExtension !== null) stopAckExtension();
+        logger.error(`RPC timeout (${timeout}ms): ${subject}`);
+        emitRpcTimeout(subject, correlationId);
+        msg.term('Handler timeout');
+      }, timeout);
+
+      return (pending as Promise<unknown>).then(
+        (result) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeoutId);
+          if (stopAckExtension !== null) stopAckExtension();
+          msg.ack();
+          publishReply(replyTo, correlationId, result);
+        },
+        (err: unknown) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeoutId);
+          if (stopAckExtension !== null) stopAckExtension();
+          logger.error(`RPC handler error (${subject}):`, err);
+          publishErrorReply(replyTo, correlationId, subject, err);
+          msg.term(`Handler error: ${subject}`);
+        },
+      );
+    };
+
+    const backlogWarnThreshold = 1_000;
+    let active = 0;
+    let backlogWarned = false;
+    const backlog: JsMsg[] = [];
+
+    const onAsyncDone = (): void => {
+      active--;
+      drainBacklog();
+    };
+
+    const drainBacklog = (): void => {
+      while (active < maxActive) {
+        const next = backlog.shift();
+
+        if (next === undefined) return;
+        active++;
+        const result = handleSafe(next);
+
+        if (result !== undefined) {
+          void result.finally(onAsyncDone);
+        } else {
+          active--;
+        }
+      }
+
+      if (backlog.length < backlogWarnThreshold) backlogWarned = false;
+    };
+
+    this.subscription = this.messageProvider.commands$.subscribe({
+      next: (msg: JsMsg): void => {
+        if (active >= maxActive) {
+          backlog.push(msg);
+          if (!backlogWarned && backlog.length >= backlogWarnThreshold) {
+            backlogWarned = true;
+            logger.warn(
+              `RPC backlog reached ${backlog.length} messages — consumer may be falling behind`,
+            );
+          }
+
+          return;
+        }
+
+        active++;
+        const result = handleSafe(msg);
+
+        if (result !== undefined) {
+          void result.finally(onAsyncDone);
+        } else {
+          active--;
+          if (backlog.length > 0) drainBacklog();
+        }
+      },
+      error: (err: unknown): void => {
+        logger.error('Stream error in RPC router', err);
+      },
+    });
   }
 
   /** Stop routing and unsubscribe. */
   public destroy(): void {
     this.subscription?.unsubscribe();
     this.subscription = null;
-  }
-
-  /** Handle a single RPC command message with error isolation. */
-  private async handleSafe(msg: JsMsg): Promise<void> {
-    try {
-      const handler = this.patternRegistry.getHandler(msg.subject);
-
-      if (!handler) {
-        msg.term(`No handler for RPC: ${msg.subject}`);
-        this.logger.error(`No handler for RPC subject: ${msg.subject}`);
-        return;
-      }
-
-      const { headers: msgHeaders } = msg;
-      const replyTo = msgHeaders?.get(JetstreamHeader.ReplyTo);
-      const correlationId = msgHeaders?.get(JetstreamHeader.CorrelationId);
-
-      if (!replyTo || !correlationId) {
-        msg.term('Missing required headers (reply-to or correlation-id)');
-        this.logger.error(`Missing headers for RPC: ${msg.subject}`);
-        return;
-      }
-
-      let data: unknown;
-
-      try {
-        data = this.codec.decode(msg.data);
-      } catch (err) {
-        msg.term('Decode error');
-        this.logger.error(`Decode error for RPC ${msg.subject}:`, err);
-        return;
-      }
-
-      this.eventBus.emitMessageRouted(msg.subject, MessageKind.Rpc);
-
-      await this.executeHandler(handler, data, msg, replyTo, correlationId);
-    } catch (err) {
-      this.logger.error('Unexpected error in RPC router', err);
-    }
-  }
-
-  /** Execute handler, publish response, settle message. */
-  private async executeHandler(
-    handler: MessageHandler,
-    data: unknown,
-    msg: JsMsg,
-    replyTo: string,
-    correlationId: string,
-  ): Promise<void> {
-    const nc = this.cachedNc ?? (await this.connection.getConnection());
-    const ctx = new RpcContext([msg]);
-
-    let settled = false;
-
-    // Ack extension: keep NATS happy while handler runs
-    const stopAckExtension = startAckExtensionTimer(msg, this.ackExtensionInterval);
-
-    // Race handler against timeout
-    const timeoutId = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      stopAckExtension?.();
-      this.logger.error(`RPC timeout (${this.timeout}ms): ${msg.subject}`);
-      this.eventBus.emit(TransportEvent.RpcTimeout, msg.subject, correlationId);
-      msg.term('Handler timeout');
-    }, this.timeout);
-
-    try {
-      const result = await unwrapResult(handler(data, ctx));
-
-      // settled may be set by the setTimeout callback above (async race)
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeoutId);
-      stopAckExtension?.();
-
-      msg.ack();
-
-      try {
-        const hdrs = headers();
-
-        hdrs.set(JetstreamHeader.CorrelationId, correlationId);
-        nc.publish(replyTo, this.codec.encode(result), { headers: hdrs });
-      } catch (publishErr) {
-        this.logger.error(`Failed to publish RPC response for ${msg.subject}`, publishErr);
-      }
-    } catch (err) {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeoutId);
-      stopAckExtension?.();
-
-      try {
-        const hdrs = headers();
-
-        hdrs.set(JetstreamHeader.CorrelationId, correlationId);
-        hdrs.set(JetstreamHeader.Error, 'true');
-        nc.publish(replyTo, this.codec.encode(serializeError(err)), { headers: hdrs });
-      } catch (encodeErr) {
-        this.logger.error(`Failed to encode RPC error for ${msg.subject}`, encodeErr);
-      }
-
-      msg.term(`Handler error: ${msg.subject}`);
-    }
   }
 }

--- a/src/utils/ack-extension.ts
+++ b/src/utils/ack-extension.ts
@@ -23,32 +23,132 @@ export const resolveAckExtensionInterval = (
 
   if (!ackWaitNanos) return DEFAULT_ACK_EXTENSION_INTERVAL;
 
-  // IMPORTANT: ack_wait is in NANOSECONDS. Convert to ms, then halve for the extension interval.
+  // ack_wait is reported in nanoseconds; convert to ms and halve so the
+  // extension fires well before the deadline.
   const interval = Math.floor(ackWaitNanos / 1_000_000 / 2);
 
   return Math.max(interval, MIN_ACK_EXTENSION_INTERVAL);
 };
 
+interface AckEntry {
+  msg: { working(): void };
+  interval: number;
+  nextFireAt: number;
+  active: boolean;
+}
+
 /**
- * Start an ack extension timer that periodically calls `msg.working()`.
+ * Process-wide pool that drives ack extension for every in-flight message
+ * through a single adaptive `setTimeout`.
  *
- * @returns Cleanup function to stop the timer, or `null` if disabled.
+ * Each entry tracks its own next-fire deadline. The pool keeps one timer
+ * scheduled for the earliest deadline across all active entries; on fire it
+ * walks the live set, calls `msg.working()` on every entry whose deadline
+ * has passed, and re-schedules for the new earliest.
+ *
+ * The timer is marked `.unref()` so the pool cannot keep the event loop
+ * alive on its own — lifecycle management is the caller's responsibility
+ * (every `schedule()` must be paired with a `cancel()`).
+ */
+class AckExtensionPool {
+  private readonly entries = new Set<AckEntry>();
+  private handle: ReturnType<typeof setTimeout> | null = null;
+  private handleFireAt = 0;
+
+  public schedule(msg: { working(): void }, interval: number): AckEntry {
+    const entry: AckEntry = {
+      msg,
+      interval,
+      nextFireAt: Date.now() + interval,
+      active: true,
+    };
+
+    this.entries.add(entry);
+    this.ensureWake(entry.nextFireAt);
+
+    return entry;
+  }
+
+  public cancel(entry: AckEntry): void {
+    if (!entry.active) return;
+    entry.active = false;
+    this.entries.delete(entry);
+    if (this.entries.size === 0 && this.handle !== null) {
+      clearTimeout(this.handle);
+      this.handle = null;
+      this.handleFireAt = 0;
+    }
+  }
+
+  /**
+   * Ensure the shared timer will fire no later than `dueAt`. If an earlier
+   * wake is already scheduled, leave it; otherwise replace it with a tighter one.
+   */
+  private ensureWake(dueAt: number): void {
+    if (this.handle !== null && this.handleFireAt <= dueAt) return;
+    if (this.handle !== null) clearTimeout(this.handle);
+
+    const delay = Math.max(0, dueAt - Date.now());
+    const handle = setTimeout(() => {
+      this.tick();
+    }, delay);
+
+    if (typeof handle.unref === 'function') handle.unref();
+    this.handle = handle;
+    this.handleFireAt = dueAt;
+  }
+
+  private tick(): void {
+    this.handle = null;
+    this.handleFireAt = 0;
+
+    const now = Date.now();
+    let earliest = Infinity;
+
+    for (const entry of this.entries) {
+      if (!entry.active) continue;
+      if (entry.nextFireAt <= now) {
+        try {
+          entry.msg.working();
+        } catch {
+          // `working()` fails when the NATS connection is degraded; the
+          // handler will settle the message itself once it finishes.
+        }
+
+        entry.nextFireAt = now + entry.interval;
+      }
+
+      if (entry.nextFireAt < earliest) earliest = entry.nextFireAt;
+    }
+
+    if (earliest !== Infinity) this.ensureWake(earliest);
+  }
+}
+
+const pool = new AckExtensionPool();
+
+/**
+ * Register a message for ack extension. While the entry is live the pool
+ * periodically calls `msg.working()` at the configured interval to keep
+ * NATS from redelivering before the handler finishes.
+ *
+ * @returns Cleanup function that cancels the registration, or `null` when
+ *          ack extension is disabled.
  */
 export const startAckExtensionTimer = (
   msg: { working(): void },
   interval: number | null,
 ): (() => void) | null => {
   if (interval === null || interval <= 0) return null;
-
-  const timer = setInterval(() => {
-    try {
-      msg.working();
-    } catch {
-      // Connection degraded — handler will settle soon
-    }
-  }, interval);
+  const entry = pool.schedule(msg, interval);
 
   return () => {
-    clearInterval(timer);
+    pool.cancel(entry);
   };
 };
+
+/**
+ * Internal — exposed for tests only.
+ * @internal
+ */
+export const _ackExtensionPoolForTest = pool;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,4 +2,4 @@ export { resolveAckExtensionInterval, startAckExtensionTimer } from './ack-exten
 
 export { serializeError } from './serialize-error';
 
-export { unwrapResult } from './unwrap-result';
+export { unwrapResult, isPromiseLike } from './unwrap-result';

--- a/src/utils/unwrap-result.ts
+++ b/src/utils/unwrap-result.ts
@@ -1,44 +1,39 @@
 import { isObservable, Observable, Subscription } from 'rxjs';
 
-const RESOLVED_VOID = Promise.resolve(undefined);
-const RESOLVED_NULL = Promise.resolve(null);
-
 /**
- * Unwrap a handler result that may be a Promise, Observable, or nested combination.
+ * Unwrap a handler return value into something the transport can settle on.
  *
- * NestJS-wrapped handlers may return `Promise<Observable>` (e.g. when exception
- * filters convert errors to `throwError()` Observables). This function handles:
+ * Handler results come in several shapes — sync values, Promises, Observables,
+ * and occasionally `Promise<Observable>` when NestJS exception filters convert
+ * errors into `throwError()` streams. This function collapses them into either
+ * the value itself (for sync results) or a Promise that resolves to the first
+ * emitted / resolved value.
  *
- * - `Observable` — subscribe immediately (no await — preserves sync emissions)
- * - `Promise<Observable>` — await Promise, then subscribe
- * - `Promise<value>` — await
- * - `undefined` / `null` — fast path, no microtask
- *
- * Non-async to avoid an extra microtask tick on the hot path.
- *
- * @param result - The raw handler return value.
- * @returns The resolved value after unwrapping all layers.
+ * The return type is `unknown` so callers can check for a thenable with
+ * {@link isPromiseLike} and skip the `await` on sync paths. Awaiting a
+ * non-thenable still works but costs a microtask.
  */
-export const unwrapResult = (result: unknown): Promise<unknown> => {
-  // Fast path: void handlers (most common case)
-  if (result === undefined) return RESOLVED_VOID;
-  if (result === null) return RESOLVED_NULL;
+export const unwrapResult = (result: unknown): unknown => {
+  if (result === undefined || result === null) return result;
 
-  // Direct Observable — subscribe immediately (no microtask yield)
   if (isObservable(result)) {
     return subscribeToFirst(result as Observable<unknown>);
   }
 
-  // Thenable (Promise) — check if it resolves to an Observable
   if (typeof (result as Promise<unknown>).then === 'function') {
     return (result as Promise<unknown>).then((resolved) =>
       isObservable(resolved) ? subscribeToFirst(resolved as Observable<unknown>) : resolved,
     );
   }
 
-  // Sync non-null value
-  return Promise.resolve(result);
+  return result;
 };
+
+/** Thenable type guard used to decide whether {@link unwrapResult}'s output needs `await`. */
+export const isPromiseLike = (value: unknown): value is PromiseLike<unknown> =>
+  value !== null &&
+  typeof value === 'object' &&
+  typeof (value as PromiseLike<unknown>).then === 'function';
 
 /** Subscribe to an Observable and resolve with its first emitted value. */
 const subscribeToFirst = (obs: Observable<unknown>): Promise<unknown> =>
@@ -65,7 +60,8 @@ const subscribeToFirst = (obs: Observable<unknown>): Promise<unknown> =>
       },
     });
 
-    // Handle synchronous emission: next fired before subscribe() returned
+    // `next` may have fired synchronously during subscribe() and already
+    // flipped `done` — unsubscribe immediately if so.
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- mutated in sync callback above
     if (done) {
       subscription.unsubscribe();

--- a/website/docs/guides/custom-codec.md
+++ b/website/docs/guides/custom-codec.md
@@ -4,9 +4,9 @@ title: "Custom Codec"
 schema:
   type: Article
   headline: "Custom Codec"
-  description: "Replace the default JSON codec with MsgPack, Protobuf, or any custom binary format."
+  description: "Replace the default JSON codec with the built-in MessagePack codec, Protobuf, or any custom binary format."
   datePublished: "2026-03-21"
-  dateModified: "2026-04-11"
+  dateModified: "2026-04-16"
 ---
 
 # Custom Codec
@@ -41,30 +41,84 @@ const bytes = codec.encode({ hello: 'world' });   // Uint8Array
 const data = codec.decode(bytes);                  // { hello: 'world' }
 ```
 
-Rule of thumb: stick with JSON until serialization shows up in CPU profiles or your p95 payload exceeds ~10 KB on the wire. That's when a binary codec (MessagePack, Protobuf) starts paying for itself.
+Rule of thumb: stick with JSON until serialization shows up in CPU profiles or your p95 payload exceeds ~1-2 KB on the wire. Below that size, `JsonCodec` wins on constant per-call overhead. Above it, a binary codec like MessagePack starts paying for itself — and the gap widens dramatically as payloads grow.
 
-## MsgPack implementation
+## Built-in: MsgpackCodec
 
-[MessagePack](https://msgpack.org/) produces smaller payloads than JSON with faster serialization. Here is a complete implementation using `@msgpack/msgpack`:
+The library ships a ready-to-use [MessagePack](https://msgpack.org/) codec powered by [`msgpackr`](https://www.npmjs.com/package/msgpackr). MessagePack produces a smaller wire frame than JSON and decodes much faster on structured payloads, while staying cross-language — Python, Go, Java, Rust, and other runtimes all have MessagePack libraries.
 
-```typescript title="src/codec/msgpack.codec.ts"
-import { encode, decode } from '@msgpack/msgpack';
-import type { Codec } from '@horizon-republic/nestjs-jetstream';
+### When to use it
 
-export class MsgPackCodec implements Codec {
-  encode(data: unknown): Uint8Array {
-    return encode(data);
-  }
+`MsgpackCodec` is the right choice when **any** of these apply:
 
-  decode(data: Uint8Array): unknown {
-    return decode(data);
-  }
-}
-```
+- Average payload size exceeds **~1-2 KB**
+- Payloads contain **deep nesting**, **repeated object shapes**, or **long strings**
+- `JSON.parse` is visible in flame graphs on the consumer side
+- Network bandwidth or NATS stream storage is a bottleneck
+
+Stick with `JsonCodec` when:
+
+- Payloads are mostly small (`< 1 KB`) flat objects — JSON is faster there
+- You need a JSON-compatible wire format for tooling (`nats sub`, log aggregators parsing payloads, etc.)
+- A non-Node language in your fleet does not have a maintained MessagePack library
+
+### Decode performance (relative to JSON)
+
+Measured on the library's own codec bench, sync `decode` throughput. Payload buckets refer to the serialized wire size produced by the fixture generator:
+
+| Payload         | Shape          | vs JSON  |
+|-----------------|----------------|----------|
+| tiny (~64 B)    | flat / nested  | JSON wins by 15-34% |
+| small (~1 KB)   | flat / nested  | JSON wins by ~12%   |
+| small (~1 KB)   | string-heavy   | **msgpack +18%**    |
+| medium (~10 KB) | flat           | **msgpack +193%**   |
+| medium (~10 KB) | nested         | **msgpack +104%**   |
+| medium (~10 KB) | string-heavy   | **msgpack +264%**   |
+| large (~100 KB) | flat           | **msgpack +478%**   |
+| large (~100 KB) | string-heavy   | **msgpack +490%**   |
+| huge (~1 MB)    | string-heavy   | **msgpack +325%**   |
+
+### Installation
+
+`msgpackr` is an **optional** peer dependency — install it only if you opt into this codec:
 
 ```bash
-pnpm add @msgpack/msgpack
+npm install msgpackr
+# or: pnpm add msgpackr
+# or: yarn add msgpackr
 ```
+
+### Usage
+
+Pass a pre-constructed `Packr` instance so the library stays decoupled from `msgpackr` internals:
+
+```typescript
+import { JetstreamModule, MsgpackCodec } from '@horizon-republic/nestjs-jetstream';
+import { Packr } from 'msgpackr';
+
+@Module({
+  imports: [
+    JetstreamModule.forRoot({
+      name: 'orders',
+      servers: ['nats://localhost:4222'],
+      codec: new MsgpackCodec(new Packr()),
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+### Record extension (Node-to-Node)
+
+`msgpackr` supports a structured-clone record extension that deduplicates repeated object shapes across messages, yielding extra decode speed under sustained load with a stable payload schema:
+
+```typescript
+codec: new MsgpackCodec(new Packr({ structuredClone: true })),
+```
+
+:::note
+The record extension is a `msgpackr`-specific optimization — use it only when every producer and consumer on the stream also runs `msgpackr` with matching options. Mixed fleets (e.g. a Python consumer) must stick with the plain `new Packr()`.
+:::
 
 ## Protobuf implementation
 
@@ -105,15 +159,15 @@ Pass a codec instance in the `forRoot()` options to use it for all messages:
 
 ```typescript title="src/app.module.ts"
 import { Module } from '@nestjs/common';
-import { JetstreamModule } from '@horizon-republic/nestjs-jetstream';
-import { MsgPackCodec } from './codec/msgpack.codec';
+import { JetstreamModule, MsgpackCodec } from '@horizon-republic/nestjs-jetstream';
+import { Packr } from 'msgpackr';
 
 @Module({
   imports: [
     JetstreamModule.forRoot({
       name: 'orders',
       servers: ['nats://localhost:4222'],
-      codec: new MsgPackCodec(),
+      codec: new MsgpackCodec(new Packr()),
     }),
   ],
 })
@@ -127,14 +181,14 @@ JetstreamModule.forRootAsync({
   name: 'orders',
   useFactory: () => ({
     servers: ['nats://localhost:4222'],
-    codec: new MsgPackCodec(),
+    codec: new MsgpackCodec(new Packr()),
   }),
 })
 ```
 
 ## Per-client override via forFeature
 
-If a specific client needs a different codec (e.g., it talks to a legacy service that uses JSON while the rest of your system uses MsgPack), override it in `forFeature()`:
+If a specific client needs a different codec (e.g., it talks to a legacy service that uses JSON while the rest of your system uses MessagePack), override it in `forFeature()`:
 
 ```typescript title="src/payments/payments.module.ts"
 import { Module } from '@nestjs/common';

--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -36,7 +36,7 @@ export default function Root({ children }) {
   "headline": "Contributing",
   "description": "How to contribute to the project.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-03-31"
+  "dateModified": "2026-04-11"
 },
       
     '/docs/development/testing/': {
@@ -44,7 +44,7 @@ export default function Root({ children }) {
   "headline": "Testing",
   "description": "Running unit and integration tests with Vitest and Testcontainers.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-03-31"
+  "dateModified": "2026-04-11"
 },
       
     '/docs/getting-started/installation/': {
@@ -73,8 +73,8 @@ export default function Root({ children }) {
       
     '/docs/getting-started/why-jetstream/': {
   "@type": "Article",
-  "headline": "Why JetStream?",
-  "description": "When the built-in NestJS NATS transport is enough, and when you need JetStream for production-grade messaging.",
+  "headline": "Why JetStream? NestJS NATS Transport Comparison",
+  "description": "When the built-in NestJS NATS transport is enough, and when your system outgrows Core NATS and needs JetStream for durable messaging.",
   "datePublished": "2026-04-11",
   "dateModified": "2026-04-11"
 },
@@ -82,15 +82,15 @@ export default function Root({ children }) {
     '/docs/guides/custom-codec/': {
   "@type": "Article",
   "headline": "Custom Codec",
-  "description": "Replace the default JSON codec with MsgPack, Protobuf, or any custom binary format.",
+  "description": "Replace the default JSON codec with the built-in MessagePack codec, Protobuf, or any custom binary format.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-04-11"
+  "dateModified": "2026-04-16"
 },
       
     '/docs/guides/dead-letter-queue/': {
   "@type": "Article",
-  "headline": "Dead Letter Queue",
-  "description": "Handle messages that exhaust all delivery attempts via a first-class DLQ stream or onDeadLetter callback.",
+  "headline": "Dead Letter Queue — NestJS NATS JetStream DLQ Stream & Callback",
+  "description": "Handle NestJS NATS JetStream messages that exhaust all delivery attempts via a dedicated DLQ stream with tracking headers or onDeadLetter callback.",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },
@@ -105,24 +105,24 @@ export default function Root({ children }) {
       
     '/docs/guides/handler-context/': {
   "@type": "Article",
-  "headline": "Handler Context",
-  "description": "Access message metadata, headers, and control settlement actions via RpcContext.",
+  "headline": "RpcContext — Handler Context & Message Settlement",
+  "description": "Access JetStream metadata and control ack, retry, and terminate actions in NestJS message handlers via RpcContext.",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },
       
     '/docs/guides/health-checks/': {
   "@type": "Article",
-  "headline": "Health Checks",
-  "description": "JetstreamHealthIndicator for NestJS Terminus integration with connection status and latency.",
+  "headline": "Health Checks — NestJS Terminus Indicator for NATS JetStream",
+  "description": "JetstreamHealthIndicator reports NATS connection status and RTT latency for NestJS Kubernetes readiness/liveness probes, with or without @nestjs/terminus.",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },
       
     '/docs/guides/lifecycle-hooks/': {
   "@type": "Article",
-  "headline": "Lifecycle Hooks",
-  "description": "Transport lifecycle events for connection changes, errors, message routing, and dead letters.",
+  "headline": "Lifecycle Hooks — NestJS JetStream Transport Events",
+  "description": "Observe NestJS NATS JetStream transport events: connection, disconnect, reconnect, errors, RPC timeouts, message routing, dead letters, and shutdown.",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },
@@ -137,8 +137,8 @@ export default function Root({ children }) {
       
     '/docs/guides/per-message-ttl/': {
   "@type": "Article",
-  "headline": "Per-Message TTL",
-  "description": "Individual message expiration independent of stream max_age, powered by NATS 2.11 Nats-TTL header.",
+  "headline": "Per-Message TTL — NATS JetStream Message Expiration",
+  "description": "Individual NestJS NATS JetStream message expiration via the Nats-TTL header (NATS 2.11, ADR-43), independent of the stream's max_age.",
   "datePublished": "2026-04-02",
   "dateModified": "2026-04-11"
 },
@@ -153,16 +153,16 @@ export default function Root({ children }) {
       
     '/docs/guides/record-builder/': {
   "@type": "Article",
-  "headline": "Record Builder & Deduplication",
-  "description": "Build messages with custom headers, message IDs, and deduplication via JetstreamRecordBuilder.",
+  "headline": "JetstreamRecordBuilder — Headers, Message IDs & Deduplication",
+  "description": "Build NestJS NATS messages with custom headers, deterministic message IDs for publish-side deduplication, and per-request RPC timeouts.",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },
       
     '/docs/guides/scheduling/': {
   "@type": "Article",
-  "headline": "Scheduling (Delayed Jobs)",
-  "description": "One-shot delayed message delivery powered by NATS 2.12 message scheduling.",
+  "headline": "NATS JetStream Scheduling — Delayed Jobs (NATS 2.12)",
+  "description": "One-shot delayed NestJS NATS JetStream message delivery via the Nats-Schedule header (NATS 2.12, ADR-51) — replace Bull or Agenda for simple delayed jobs.",
   "datePublished": "2026-04-01",
   "dateModified": "2026-04-11"
 },
@@ -177,72 +177,72 @@ export default function Root({ children }) {
       
     '/docs/guides/troubleshooting/': {
   "@type": "Article",
-  "headline": "Troubleshooting",
-  "description": "Common issues and how to resolve them.",
+  "headline": "Troubleshooting — NestJS JetStream Transport",
+  "description": "Fix common NestJS JetStream issues: NATS connection errors, consumer lag, RPC timeouts, DLQ publish failures, and stream migration recovery.",
   "datePublished": "2026-03-26",
   "dateModified": "2026-04-11"
 },
       
     '/docs/': {
   "@type": "Article",
-  "headline": "Introduction",
-  "description": "Production-grade NestJS transport for NATS JetStream with durable delivery, retry, replay, and dead letter handling.",
+  "headline": "NestJS NATS Transport with JetStream — Introduction",
+  "description": "A NestJS NATS microservice transport backed by JetStream: durable events, broadcast, ordered delivery, RPC, and dead letter queues.",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },
       
     '/docs/patterns/broadcast/': {
   "@type": "Article",
-  "headline": "Broadcast Events",
-  "description": "Fan-out event delivery to every subscribing service instance.",
+  "headline": "Broadcast Events — NestJS JetStream Fan-Out Delivery",
+  "description": "Fan-out NATS JetStream events to every NestJS service instance via per-service durable consumers on a shared broadcast stream.",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },
       
     '/docs/patterns/events/': {
   "@type": "Article",
-  "headline": "Events (Workqueue)",
-  "description": "Workqueue events with at-least-once delivery, automatic retry, deduplication, and dead letter handling.",
+  "headline": "Workqueue Events — NestJS JetStream At-Least-Once Delivery",
+  "description": "NestJS NATS JetStream workqueue events with at-least-once delivery, automatic retry, publish-side deduplication, and dead letter handling.",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },
       
     '/docs/patterns/handler-metadata/': {
   "@type": "Article",
-  "headline": "Handler Metadata Registry",
-  "description": "Publish handler metadata to a NATS KV bucket for dynamic service discovery, API gateway routing, and catalog generation.",
+  "headline": "Handler Metadata Registry — NATS KV Service Discovery for NestJS",
+  "description": "Publish NestJS handler metadata to a NATS KV bucket for dynamic service discovery, API gateway routing, and automatic catalog generation.",
   "datePublished": "2026-04-02",
   "dateModified": "2026-04-11"
 },
       
     '/docs/patterns/ordered-events/': {
   "@type": "Article",
-  "headline": "Ordered Events",
-  "description": "Strict sequential event delivery with ephemeral consumers and replay policies.",
+  "headline": "Ordered Events — Strict Sequential Delivery in NATS JetStream",
+  "description": "Strict sequential NestJS NATS JetStream event delivery with ephemeral ordered consumers, deliver policies, and CQRS replay patterns.",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },
       
     '/docs/patterns/rpc/': {
   "@type": "Article",
-  "headline": "RPC (Request/Reply)",
-  "description": "Synchronous request-reply via Core NATS or JetStream with timeout and error handling.",
+  "headline": "NestJS NATS RPC — Core vs JetStream Request/Reply",
+  "description": "Synchronous NestJS NATS request-reply in Core NATS or JetStream mode, with timeout handling, error serialization, and per-request overrides.",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },
       
     '/docs/reference/default-configs/': {
   "@type": "Article",
-  "headline": "Default Configs",
-  "description": "Default stream and consumer configurations for every StreamKind.",
+  "headline": "Default Stream & Consumer Configs for NATS JetStream",
+  "description": "Production-ready default stream, consumer, and connection settings for every NestJS JetStream StreamKind (event, broadcast, ordered, command, DLQ).",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },
       
     '/docs/reference/edge-cases/': {
   "@type": "Article",
-  "headline": "Edge Cases & FAQ",
-  "description": "Common questions and non-obvious behaviors of the transport.",
+  "headline": "Edge Cases & FAQ — NestJS JetStream Transport",
+  "description": "NestJS JetStream transport FAQ: publisher-only mode, consumer self-healing, NATS header limits, fire-and-forget messaging, and DeliverPolicy edge cases.",
   "datePublished": "2026-03-21",
   "dateModified": "2026-04-11"
 },


### PR DESCRIPTION
## Summary

- Hot-path routing optimizations across event router, RPC router, message provider, and client publish paths
- New opt-in `MsgpackCodec` for large-payload workloads (optional `msgpackr` peer dependency)
- Bug fix: outer catch in event/RPC routers now settles unsettled messages to prevent infinite NATS redelivery

## Measured results

Pipeline cells (real EventRouter through Subject, sync handler):

| Cell | before | after | Δ |
|---|---|---|---|
| `small::seq` (1) | 609K ops/s | 914K ops/s | **+50%** |
| `small::low` (16) | 506K ops/s | 926K ops/s | **+83%** |
| `small::mid` (64) | 630K ops/s | 843K ops/s | **+34%** |
| `small::high` (256) | 522K ops/s | 839K ops/s | **+61%** |
| `medium::seq-high` | 207-215K | 230-239K | **+8-15%** |

p95 latency: **-15% to -45%** across all cells.

MsgpackCodec decode vs JSON: +18% at 1KB, **+193%** at 10KB, **+478%** at 100KB.

## Test plan

- [ ] All 482 existing unit + integration tests pass
- [ ] Lint clean
- [ ] Build succeeds (dual CJS/ESM)
- [ ] MsgpackCodec dist output contains no `msgpackr` import — optional peer works
- [ ] Existing handler behaviour unchanged (sync/async/Observable/retry/terminate/DLQ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MessagePack codec support via `MsgpackCodec` for binary message encoding
  * Added `hasHook()` method to EventBus for checking hook presence
  * Added benchmarking CLI scripts (`bench`, `bench:codec`, `bench:route`, etc.)

* **Performance Improvements**
  * Optimized ack extension from per-message intervals to shared pooled approach
  * Improved concurrency handling and message routing efficiency
  * Added connection readiness optimization to skip redundant setup

* **Documentation**
  * Updated custom codec guide with built-in MessagePack examples and installation guidance
  * Revised website metadata and descriptions for JetStream-specific terminology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->