### PR TITLE
fix(routing): fail-fast on duplicate handler patterns

### DIFF
--- a/src/server/__tests__/strategy.spec.ts
+++ b/src/server/__tests__/strategy.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
 import { createMock } from '@golevelup/ts-vitest';
+import type { MessageHandler } from '@nestjs/microservices';
 import type { NatsConnection } from '@nats-io/transport-node';
 
 import { ConnectionProvider } from '../../connection';
@@ -14,6 +15,8 @@ import {
 } from '../infrastructure';
 import { EventRouter, PatternRegistry, RpcRouter } from '../routing';
 import { JetstreamStrategy } from '../strategy';
+
+const fakeHandler = (): MessageHandler => vi.fn() as unknown as MessageHandler;
 
 describe(JetstreamStrategy, () => {
   let sut: JetstreamStrategy;
@@ -109,6 +112,47 @@ describe(JetstreamStrategy, () => {
 
       // Then
       expect(metadataProvider.publish).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addHandler()', () => {
+    it('should register a handler when the pattern is unique', () => {
+      // Given: a fresh strategy
+      // When
+      sut.addHandler('user.created', fakeHandler(), true);
+
+      // Then: handler is stored, no throw
+      expect(sut.getHandlers().size).toBe(1);
+    });
+
+    it('should throw when the same pattern is registered twice', () => {
+      // Given: a handler already registered for the pattern
+      sut.addHandler('user.created', fakeHandler(), true);
+
+      // When/Then: the second registration fails fast
+      expect(() => {
+        sut.addHandler('user.created', fakeHandler(), true);
+      }).toThrow(/Duplicate handler registered for pattern "user\.created"/);
+    });
+
+    it('should throw when an event handler collides with an RPC handler on the same pattern', () => {
+      // Given: an event handler registered
+      sut.addHandler('user.created', fakeHandler(), true);
+
+      // When/Then: an RPC handler (isEventHandler=false) for the same pattern is rejected
+      expect(() => {
+        sut.addHandler('user.created', fakeHandler(), false);
+      }).toThrow(/Duplicate handler registered/);
+    });
+
+    it('should mention the conflicting pattern in the error message', () => {
+      // Given
+      sut.addHandler('orders.placed', fakeHandler(), false);
+
+      // When/Then
+      expect(() => {
+        sut.addHandler('orders.placed', fakeHandler(), false);
+      }).toThrow(/orders\.placed/);
     });
   });
 

--- a/src/server/strategy.ts
+++ b/src/server/strategy.ts
@@ -1,4 +1,5 @@
 import { CustomTransportStrategy, Server } from '@nestjs/microservices';
+import type { MessageHandler, MsPattern } from '@nestjs/microservices';
 import type { ConsumerInfo } from '@nats-io/jetstream';
 
 import { ConnectionProvider } from '../connection';
@@ -133,6 +134,36 @@ export class JetstreamStrategy extends Server implements CustomTransportStrategy
     this.coreRpcServer.stop();
     this.messageProvider.destroy();
     this.started = false;
+  }
+
+  /**
+   * Override NestJS `Server.addHandler` to fail-fast on duplicate pattern registration.
+   *
+   * The base class silently overwrites duplicate RPC handlers (last wins) and appends
+   * duplicate event handlers to a linked list. Both behaviors are hazardous in a
+   * JetStream context: silent overwrite drops a handler the user wrote, and double
+   * event dispatch double-acks/double-processes the same JetStream message.
+   *
+   * We treat any pattern collision as a fatal misconfiguration so it surfaces at
+   * bootstrap instead of in production traffic.
+   */
+  public override addHandler(
+    pattern: unknown,
+    callback: MessageHandler,
+    isEventHandler = false,
+    extras: Record<string, unknown> = {},
+  ): void {
+    const normalizedPattern = this.normalizePattern(pattern as MsPattern);
+
+    if (this.messageHandlers.has(normalizedPattern)) {
+      throw new Error(
+        `Duplicate handler registered for pattern "${normalizedPattern}". ` +
+          `Each @EventPattern() / @MessagePattern() value must be unique within a microservice — ` +
+          `find and remove the second declaration.`,
+      );
+    }
+
+    super.addHandler(pattern, callback, isEventHandler, extras);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Override `Server.addHandler` in `JetstreamStrategy` to throw on duplicate pattern registration instead of letting NestJS silently overwrite (RPC) or append-to-linked-list (events).
- Error names the conflicting pattern so the second `@EventPattern()` / `@MessagePattern()` is trivially greppable.

## Why

NestJS's `Server.addHandler` has two silent failure modes for duplicates:

- **RPC handlers** (`@MessagePattern`): the second registration overwrites the first in \`messageHandlers\` — the dropped handler is never invoked, with no warning at any point.
- **Event handlers** (`@EventPattern`): the second registration is appended to a linked list — both handlers fire for every JetStream message, double-acking and double-processing.

Both manifest only in production traffic. Surfacing this at bootstrap with a descriptive error is strictly better than discovering it via missing-handler bug reports or duplicate side effects.

## Test plan

- [x] Unit: handler registers when pattern is unique
- [x] Unit: throws on event+event collision
- [x] Unit: throws on event+RPC collision on the same pattern
- [x] Unit: error message names the conflicting pattern
- [x] Full suite green (799/799)
- [x] \`tsc --noEmit\` clean, lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message handler registration now prevents duplicates. Attempting to register the same handler pattern twice throws an error instead of silently overwriting the previous handler, improving configuration reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HorizonRepublic/nestjs-jetstream/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->