### PR TITLE
docs(landing): refine hero copy and add coverage badge

### DIFF
--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -349,13 +349,28 @@ export default function Home() {
               <strong>{versionLabel}</strong>
               <span className="lp-eyebrow-sep">·</span>
               <span>MIT</span>
+              <span className="lp-eyebrow-sep">·</span>
+              <a
+                className="lp-eyebrow-badge"
+                href="https://codecov.io/github/HorizonRepublic/nestjs-jetstream"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Code coverage on Codecov"
+              >
+                <img
+                  src="https://img.shields.io/codecov/c/github/HorizonRepublic/nestjs-jetstream?style=flat&label=coverage&color=2c5d3a&labelColor=1a1a1a"
+                  alt="coverage"
+                  height="18"
+                />
+              </a>
             </div>
             <h1 className="lp-hero-title lp-fade-up lp-delay-1">
               nestjs-<span className="lp-accent-mark">jetstream</span>
             </h1>
             <p className="lp-hero-sub lp-fade-up lp-delay-2">
-              The NATS JetStream transport NestJS microservices need — durable, retried, traced —
-              under the same <code>@EventPattern</code> decorators you already use.
+              A NATS JetStream transport for NestJS. Durable streams, bounded retries,
+              and W3C trace context — behind the same <code>@EventPattern</code> decorators
+              you already use.
             </p>
             <div className="lp-hero-ctas lp-fade-up lp-delay-3">
               <Link className="lp-btn lp-btn-primary" to="/docs/getting-started/quick-start">
@@ -398,9 +413,9 @@ export default function Home() {
         <section className="lp-section">
           <div className="lp-container">
             <Reveal>
-              <span className="lp-eyelet">Why this library</span>
-              <h2 className="lp-section-title">Five primitives, one transport.</h2>
-              <p className="lp-section-sub">Each one drops in behind the decorators you already use. Same behavior in dev, staging, and prod.</p>
+              <span className="lp-eyelet">What's inside</span>
+              <h2 className="lp-section-title">Five primitives.</h2>
+              <p className="lp-section-sub">Each one sits behind the NestJS decorators you already use. The library handles the JetStream details.</p>
             </Reveal>
             <Reveal className="lp-pillars">
               <article className="lp-pillar span-3">
@@ -504,9 +519,9 @@ export default function Home() {
         <section className="lp-section">
           <div className="lp-container">
             <Reveal>
-              <span className="lp-eyelet">Live code</span>
-              <h2 className="lp-section-title">Configure once. Decorate handlers. Ship.</h2>
-              <p className="lp-section-sub">Same NestJS surface area you use today. The library does the JetStream work underneath.</p>
+              <span className="lp-eyelet">In code</span>
+              <h2 className="lp-section-title">Register the module, decorate handlers.</h2>
+              <p className="lp-section-sub">The surface area you already use in <code>@nestjs/microservices</code>. JetStream lives underneath.</p>
             </Reveal>
 
             <Reveal className="lp-demo-grid">
@@ -552,8 +567,8 @@ export default function Home() {
           <div className="lp-container">
             <Reveal>
               <span className="lp-eyelet">All capabilities</span>
-              <h2 className="lp-section-title">Everything a professional team expects from production messaging.</h2>
-              <p className="lp-section-sub">Twelve features in one transport. No surprises across environments.</p>
+              <h2 className="lp-section-title">Twelve building blocks.</h2>
+              <p className="lp-section-sub">The primitives we needed when wiring NestJS to JetStream, packaged into a single transport.</p>
             </Reveal>
             <Reveal className="lp-features">
               <div className="lp-feature-group">Delivery</div>
@@ -583,8 +598,8 @@ export default function Home() {
         <section className="lp-section" style={{ padding: '80px 0' }}>
           <div className="lp-container" style={{ textAlign: 'center' }}>
             <Reveal>
-              <h2 className="lp-section-title" style={{ margin: '0 auto 16px' }}>Read the docs. Ship the code.</h2>
-              <p className="lp-section-sub" style={{ margin: '0 auto 32px' }}>Five-minute quick start. Then drop into your existing NestJS module graph.</p>
+              <h2 className="lp-section-title" style={{ margin: '0 auto 16px' }}>Quick start.</h2>
+              <p className="lp-section-sub" style={{ margin: '0 auto 32px' }}>Five minutes to wire up. Drops into your existing NestJS module graph.</p>
               <div className="lp-hero-ctas" style={{ justifyContent: 'center' }}>
                 <Link className="lp-btn lp-btn-primary" to="/docs/getting-started/quick-start">
                   Quick start
@@ -604,7 +619,7 @@ export default function Home() {
                   <BrandMark />
                   <span>nestjs-jetstream</span>
                 </div>
-                <p>A production NATS JetStream transport for NestJS — by Horizon Republic.</p>
+                <p>NATS JetStream as a NestJS transport. Maintained by Horizon Republic.</p>
               </div>
               <div className="lp-footer-col">
                 <h4>Docs</h4>
@@ -631,7 +646,6 @@ export default function Home() {
             <div className="lp-footer-bar">
               <span>MIT · © {new Date().getFullYear()} Horizon Republic</span>
               <span className="lp-footer-meta">
-                <span className="lp-footer-status"><span className="lp-footer-status-dot" /> All systems operational</span>
                 <span><strong>{versionLabel}</strong></span>
               </span>
             </div>

--- a/website/src/pages/landing.css
+++ b/website/src/pages/landing.css
@@ -245,6 +245,13 @@ body[data-page="landing"] .main-wrapper { padding-top: 0 !important; }
 }
 .lp-eyebrow strong { color: var(--lp-fg-0); font-weight: 500; }
 .lp-eyebrow-sep { color: var(--lp-fg-3); }
+.lp-eyebrow-badge {
+  display: inline-flex; align-items: center;
+  line-height: 1;
+  transition: opacity 0.15s ease;
+}
+.lp-eyebrow-badge:hover { opacity: 0.8; }
+.lp-eyebrow-badge img { display: block; border-radius: 3px; }
 
 .lp-hero-title {
   font-family: var(--lp-f-display);
@@ -658,13 +665,6 @@ body[data-page="landing"] .main-wrapper { padding-top: 0 !important; }
 }
 .lp-footer-meta { display: flex; gap: 18px; align-items: center; }
 .lp-footer-meta strong { color: var(--lp-fg-1); font-weight: 500; }
-.lp-footer-status { display: inline-flex; align-items: center; gap: 8px; color: var(--lp-fg-2); }
-.lp-footer-status-dot {
-  width: 6px; height: 6px;
-  border-radius: 999px;
-  background: var(--lp-accent);
-  box-shadow: 0 0 0 3px var(--lp-accent-soft);
-}
 
 
 .lp-cmdk-overlay {


### PR DESCRIPTION
## Summary

Light tone-and-copy pass over the docs landing page plus a small visible quality signal.

**Hero**
- Soften the hero subtitle so the value prop reads as a description rather than a claim
- Add a live coverage badge (Codecov) into the eyebrow meta line; link goes to the full report

**Section headers**
- Trim section headlines that read more like ad copy than navigation labels
- Match the surrounding Diátaxis-style wording — short, descriptive, no superlatives

**Footer**
- Drop the static "All systems operational" indicator (it wasn't backed by any monitor)
- Cleaner brand line under the wordmark

## Test plan

- [x] \`pnpm docs:build\` passes
- [x] Coverage badge renders + links to Codecov (`img.shields.io/codecov/c/github/...` is a live endpoint, no hardcoded value)
- [x] Footer no longer shows the fake status dot
- [ ] Verify visual rhythm on prod after deploy (eyebrow row, headlines centering, footer alignment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codecov coverage badge to the landing page hero section

* **Style**
  * Refreshed landing page copy with updated section headings and descriptions across hero, capabilities, and quick start areas
  * Updated footer description text
  * Removed footer status indicator
  * Enhanced badge styling with hover effects

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HorizonRepublic/nestjs-jetstream/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->