### PR TITLE
docs(landing): condense features tile and add Content-Signal

### DIFF
--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -566,31 +566,33 @@ export default function Home() {
         <section className="lp-section">
           <div className="lp-container">
             <Reveal>
-              <span className="lp-eyelet">All capabilities</span>
-              <h2 className="lp-section-title">Twelve building blocks.</h2>
-              <p className="lp-section-sub">The primitives we needed when wiring NestJS to JetStream, packaged into a single transport.</p>
+              <span className="lp-eyelet">Core features</span>
+              <h2 className="lp-section-title">What's in the transport.</h2>
+              <p className="lp-section-sub">Three areas, three primitives each. Each card links to docs and a runnable example.</p>
             </Reveal>
             <Reveal className="lp-features">
-              <div className="lp-feature-group">Delivery</div>
-              <FeatureCard to="/docs/patterns/events" icon={<path d="M3 8l3 3 7-7" />} name="At-least-once events" desc="Workqueue retention with explicit ack after handler resolves." />
-              <FeatureCard to="/docs/patterns/ordered-events" icon={<><circle cx="8" cy="8" r="5.5" /><path d="M8 4v4l3 2" /></>} name="Ordered events" desc="Per-key ordering on the same partition with stable subjects." />
-              <FeatureCard to="/docs/patterns/broadcast" icon={<><circle cx="3" cy="8" r="1.5" /><circle cx="13" cy="3" r="1.5" /><circle cx="13" cy="13" r="1.5" /><path d="M4.5 7L12 4M4.5 9L12 12" /></>} name="Broadcast fan-out" desc="One emit reaches every replica; nothing is shared by accident." />
+              <div className="lp-feature-group">Messaging</div>
+              <FeatureCard to="/docs/patterns/events" icon={<path d="M3 8l3 3 7-7" />} name="At-least-once events" desc="Workqueue retention with explicit ack after the handler resolves." />
+              <FeatureCard to="/docs/patterns/broadcast" icon={<><circle cx="3" cy="8" r="1.5" /><circle cx="13" cy="3" r="1.5" /><circle cx="13" cy="13" r="1.5" /><path d="M4.5 7L12 4M4.5 9L12 12" /></>} name="Broadcast fan-out" desc="One emit reaches every replica without double-processing on the workqueue." />
+              <FeatureCard to="/docs/patterns/rpc" icon={<><path d="M2 5h8M10 5l-2-2M10 5l-2 2" /><path d="M14 11H6M6 11l2-2M6 11l2 2" /></>} name="RPC (Core & JetStream)" desc="Request/reply with deadlines, headers, and typed responses." />
 
               <div className="lp-feature-group">Reliability</div>
+              <FeatureCard to="/docs/patterns/ordered-events" icon={<><circle cx="8" cy="8" r="5.5" /><path d="M8 4v4l3 2" /></>} name="Ordered delivery" desc="Per-key ordering on the same partition with stable subject keys." />
               <FeatureCard to="/docs/guides/dead-letter-queue" icon={<><rect x="3" y="3" width="10" height="10" rx="1.5" /><path d="M6 8h4" /></>} name="Dead-letter queue" desc="Bounded retries, then a typed sink with original headers preserved." />
               <FeatureCard to="/docs/guides/graceful-shutdown" icon={<><path d="M2 12L8 4l6 8" /><path d="M5 12h6" /></>} name="Graceful shutdown" desc="Drains in-flight handlers, flushes acks, closes the connection." />
-              <FeatureCard to="/docs/guides/health-checks" icon={<><circle cx="8" cy="8" r="5.5" /><path d="M5 8l2 2 4-4" /></>} name="Health checks" desc={<>Drop-in <code>isHealthy()</code> indicator for k8s probes.</>} />
-
-              <div className="lp-feature-group">Patterns</div>
-              <FeatureCard to="/docs/patterns/rpc" icon={<><path d="M2 5h8M10 5l-2-2M10 5l-2 2" /><path d="M14 11H6M6 11l2-2M6 11l2 2" /></>} name="RPC (Core & JetStream)" desc="Request/reply with deadlines, headers, and typed responses." />
-              <FeatureCard to="/docs/guides/scheduling" icon={<><circle cx="8" cy="8" r="5.5" /><path d="M8 4v4l3 1" /></>} name="Scheduled messages" desc="Per-message delay or absolute deliver-at, native to the stream." />
-              <FeatureCard to="/docs/guides/per-message-ttl" icon={<><path d="M3 13L13 3" /><circle cx="4" cy="12" r="1" /><circle cx="12" cy="4" r="1" /></>} name="Per-message TTL" desc="Expire stale messages before they reach a consumer." />
 
               <div className="lp-feature-group">Observability</div>
+              <FeatureCard to="/docs/guides/health-checks" icon={<><circle cx="8" cy="8" r="5.5" /><path d="M5 8l2 2 4-4" /></>} name="Health checks" desc={<>Drop-in <code>isHealthy()</code> indicator for k8s probes.</>} />
               <FeatureCard to="/docs/observability/tracing" icon={<><path d="M2 8h12" /><circle cx="5" cy="8" r="1.5" /><circle cx="11" cy="8" r="1.5" /></>} name="Distributed tracing" desc="W3C trace context on every hop. OpenTelemetry-compatible." />
               <FeatureCard to="/docs/observability/metrics" icon={<><path d="M2 13L5 9L8 11L13 4" /><circle cx="13" cy="4" r="1" /></>} name="Prometheus metrics" desc="Throughput, latency, lag — zero-config with prom-client." />
-              <FeatureCard to="/docs/reference/header-contract" icon={<path d="M3 12V4M3 4h6l4 4-4 4H3" />} name="Header contract" desc="Stable, documented header schema for tracing & correlation." />
-              <FeatureCard to="/docs/guides/lifecycle-hooks" icon={<><rect x="2" y="3" width="12" height="10" rx="1.5" /><path d="M2 6h12M5 9h6" /></>} name="Lifecycle hooks" desc={<>Subscribe to <code>TransportEvent</code> for ack, nak, redelivery.</>} />
+            </Reveal>
+            <Reveal style={{ marginTop: 24, textAlign: 'center' }}>
+              <Link className="lp-features-more" to="/docs/">
+                Scheduling, TTL, lifecycle hooks, and more in the docs
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
+                  <path d="M3 8h10M9 4l4 4-4 4" />
+                </svg>
+              </Link>
             </Reveal>
           </div>
         </section>

--- a/website/src/pages/landing.css
+++ b/website/src/pages/landing.css
@@ -579,14 +579,14 @@ body[data-page="landing"] .main-wrapper { padding-top: 0 !important; }
 }
 .lp-feature {
   background: var(--lp-bg-1);
-  padding: 24px;
+  padding: 32px 28px;
   position: relative;
   transition: background var(--lp-m-base);
   cursor: pointer;
   display: block;
 }
 .lp-feature:hover { background: var(--lp-bg-2); }
-.lp-feature-head { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+.lp-feature-head { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
 .lp-feature-icon { width: 14px; height: 14px; color: var(--lp-accent); flex-shrink: 0; }
 .lp-feature-name {
   font-family: var(--lp-f-display);
@@ -605,7 +605,7 @@ body[data-page="landing"] .main-wrapper { padding-top: 0 !important; }
 }
 .lp-feature-arrow {
   position: absolute;
-  top: 24px; right: 24px;
+  top: 32px; right: 28px;
   color: var(--lp-fg-3);
   opacity: 0;
   transform: translate(-3px, 0);
@@ -620,11 +620,29 @@ body[data-page="landing"] .main-wrapper { padding-top: 0 !important; }
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: var(--lp-fg-3);
-  padding: 16px 24px 8px;
+  padding: 18px 28px 10px;
   background: var(--lp-bg-1);
   grid-column: 1 / -1;
   border-bottom: 1px solid var(--lp-line-1);
 }
+
+.lp-features-more {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--lp-f-mono);
+  font-size: 13px;
+  color: var(--lp-fg-2);
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--lp-line-1);
+  transition: color var(--lp-m-fast), border-color var(--lp-m-fast), background var(--lp-m-fast);
+}
+.lp-features-more:hover {
+  color: var(--lp-fg-0);
+  border-color: var(--lp-line-2);
+  background: var(--lp-bg-1);
+  text-decoration: none;
+}
+.lp-features-more svg { width: 12px; height: 12px; }
 
 
 .lp-footer { padding: 56px 0 40px; border-bottom: none; }

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 
 User-agent: Googlebot
 Allow: /


### PR DESCRIPTION
## Summary

**Features tile**
- Reduce the landing feature grid from four uneven groups (12 + 1 cards, with the Observability row breaking the 3-per-row rhythm) to **three balanced groups of three** — `Messaging`, `Reliability`, `Observability`
- Rename the section header from "Twelve building blocks" → "Core features" / "What's in the transport"
- Bump per-card padding for breathing room (24px → 32×28px) and add a pill-link below the grid pointing to docs for scheduling / TTL / lifecycle hooks / header contract so dropped surface remains discoverable

**robots.txt**
- Add `Content-Signal: ai-train=yes, search=yes, ai-input=yes` under `User-agent: *` — opting into LLM training is a discovery channel for an OSS library in the adoption phase

## Test plan

- [x] `pnpm docs:build` passes
- [ ] Local `pnpm docs:dev` — verify grid renders 3×3 cleanly, "more in the docs" link works, group labels and card spacing look right
- [ ] Confirm `/robots.txt` on prod after deploy returns the new `Content-Signal` line