### PR TITLE
fix(observability): unify metrics and otel under the factory result

### DIFF
--- a/src/interfaces/options.interface.ts
+++ b/src/interfaces/options.interface.ts
@@ -341,9 +341,12 @@ export interface JetstreamModuleOptions {
    * consuming application, all tracer calls are no-ops — there is no
    * runtime cost.
    *
+   * Accepts a full {@link OtelOptions} object, or the boolean shorthand
+   * `true` (== defaults) / `false` (== `{ enabled: false }`).
+   *
    * @see OtelOptions
    */
-  otel?: OtelOptions;
+  otel?: OtelOptions | boolean;
 }
 
 /** Options for `JetstreamModule.forFeature()`. */
@@ -369,16 +372,6 @@ export type JetstreamModuleAsyncOptions = {
 
   /** Additional module imports (e.g., ConfigModule). */
   imports?: ModuleMetadata['imports'];
-
-  /**
-   * Built-in Prometheus metrics. Specified at the async-options level (parallel
-   * to {@link name}) because module composition is decided synchronously before
-   * the async factory runs. Use `true` for defaults, a {@link MetricsConfig}
-   * object for full control, or omit/`false` to disable entirely.
-   *
-   * @see JetstreamModuleOptions.metrics
-   */
-  metrics?: MetricsOption;
 } & (
   | {
       useFactory(

--- a/src/jetstream.module.ts
+++ b/src/jetstream.module.ts
@@ -110,7 +110,7 @@ export class JetstreamModule implements OnApplicationShutdown {
     return {
       module: JetstreamModule,
       global: true,
-      imports: options.metrics ? [JetstreamMetricsModule.forFeature(options.metrics)] : [],
+      imports: [JetstreamMetricsModule.forFeature()],
       providers,
       exports: [
         JETSTREAM_CONNECTION,
@@ -137,14 +137,11 @@ export class JetstreamModule implements OnApplicationShutdown {
   public static forRootAsync(asyncOptions: JetstreamModuleAsyncOptions): DynamicModule {
     const asyncProviders = this.createAsyncOptionsProvider(asyncOptions);
     const coreProviders = this.createCoreDependentProviders();
-    const metricsImports = asyncOptions.metrics
-      ? [JetstreamMetricsModule.forFeature(asyncOptions.metrics)]
-      : [];
 
     return {
       module: JetstreamModule,
       global: true,
-      imports: [...(asyncOptions.imports ?? []), ...metricsImports],
+      imports: [...(asyncOptions.imports ?? []), JetstreamMetricsModule.forFeature()],
       providers: [...asyncProviders, ...coreProviders],
       exports: [
         JETSTREAM_CONNECTION,

--- a/src/metrics/__tests__/metrics.module.spec.ts
+++ b/src/metrics/__tests__/metrics.module.spec.ts
@@ -39,7 +39,7 @@ const compile = async (
   class TestRootModule {}
 
   return Test.createTestingModule({
-    imports: [TestRootModule, JetstreamMetricsModule.forFeature(options.metrics)],
+    imports: [TestRootModule, JetstreamMetricsModule.forFeature()],
   }).compile();
 };
 
@@ -125,21 +125,23 @@ describe(JetstreamMetricsModule, () => {
   });
 
   describe('edge cases', () => {
-    it('should compile as an empty shell when metrics option is disabled', async () => {
+    it('should resolve config to null when metrics option is disabled', async () => {
       // Given/When
       const moduleRef = await compile({ ...baseOptions, metrics: false }, eventBus);
 
-      // Then: no metrics service or config providers exist
-      expect(() => moduleRef.get(JetstreamMetricsService)).toThrow();
-      expect(() => moduleRef.get(JETSTREAM_METRICS_CONFIG)).toThrow();
+      // Then: providers exist (module is always imported) but resolve to null,
+      // so prom-client is never loaded and the service self-disables on bootstrap.
+      expect(moduleRef.get(JETSTREAM_METRICS_CONFIG)).toBeNull();
+      expect(moduleRef.get(JetstreamMetricsService)).toBeInstanceOf(JetstreamMetricsService);
     });
 
-    it('should compile as an empty shell when metrics option is omitted', async () => {
+    it('should resolve config to null when metrics option is omitted', async () => {
       // Given/When
       const moduleRef = await compile(baseOptions, eventBus);
 
       // Then
-      expect(() => moduleRef.get(JetstreamMetricsService)).toThrow();
+      expect(moduleRef.get(JETSTREAM_METRICS_CONFIG)).toBeNull();
+      expect(moduleRef.get(JetstreamMetricsService)).toBeInstanceOf(JetstreamMetricsService);
     });
   });
 });

--- a/src/metrics/__tests__/metrics.service.spec.ts
+++ b/src/metrics/__tests__/metrics.service.spec.ts
@@ -115,7 +115,7 @@ describe(JetstreamMetricsService, () => {
     eventBus = createMock<EventBus>();
     register = new Registry();
     promClient = { Counter, Histogram, Gauge };
-    options = { name: 'orders', servers: ['nats://localhost:4222'] };
+    options = { name: 'orders', servers: ['nats://localhost:4222'], metrics: true };
   });
 
   afterEach(() => {

--- a/src/metrics/metrics.module.ts
+++ b/src/metrics/metrics.module.ts
@@ -49,21 +49,19 @@ const normalizeMetricsConfig = (
 };
 
 /**
- * Internal module activated by `JetstreamModule` when `metrics` is enabled.
- * Provides `JetstreamMetricsService` plus the resolved config, registry, and
- * dynamically loaded `prom-client` runtime via DI tokens. Returns an empty
- * shell when `metrics` is `false`/omitted so the peer is never loaded.
+ * Internal module wired unconditionally by `JetstreamModule`. Providers gate
+ * themselves on `JETSTREAM_OPTIONS.metrics` at resolution time — when metrics
+ * are disabled they resolve to `null` and `prom-client` is never loaded, so
+ * the peer dependency stays truly optional.
  */
 @Module({})
 export class JetstreamMetricsModule {
-  public static forFeature(metricsOption: MetricsOption | undefined): DynamicModule {
-    if (!metricsOption) {
-      return { module: JetstreamMetricsModule, providers: [], exports: [] };
-    }
-
+  public static forFeature(): DynamicModule {
     const promClientProvider: Provider = {
       provide: JETSTREAM_METRICS_PROM_CLIENT,
-      useFactory: async (): Promise<PromClientRuntime> => {
+      inject: [JETSTREAM_OPTIONS],
+      useFactory: async (opts: JetstreamModuleOptions): Promise<PromClientRuntime | null> => {
+        if (!opts.metrics) return null;
         const mod = await resolvePromClient();
 
         /* eslint-disable @typescript-eslint/naming-convention */
@@ -74,17 +72,19 @@ export class JetstreamMetricsModule {
 
     const configProvider: Provider = {
       provide: JETSTREAM_METRICS_CONFIG,
-      useFactory: async (): Promise<MetricsConfig> => {
+      inject: [JETSTREAM_OPTIONS],
+      useFactory: async (opts: JetstreamModuleOptions): Promise<MetricsConfig | null> => {
+        if (!opts.metrics) return null;
         const mod = await resolvePromClient();
 
-        return normalizeMetricsConfig(metricsOption, mod);
+        return normalizeMetricsConfig(opts.metrics, mod);
       },
     };
 
     const registryProvider: Provider = {
       provide: JETSTREAM_METRICS_REGISTRY,
       inject: [JETSTREAM_METRICS_CONFIG],
-      useFactory: (cfg: MetricsConfig) => cfg.register,
+      useFactory: (cfg: MetricsConfig | null) => cfg?.register ?? null,
     };
 
     const serviceProvider: Provider = {
@@ -99,8 +99,8 @@ export class JetstreamMetricsModule {
       ],
       useFactory: (
         eventBus: EventBus,
-        cfg: MetricsConfig,
-        runtime: PromClientRuntime,
+        cfg: MetricsConfig | null,
+        runtime: PromClientRuntime | null,
         opts: JetstreamModuleOptions,
         patternRegistry: PatternRegistry | null,
         connection: ConnectionProvider | null,

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -65,8 +65,8 @@ export class JetstreamMetricsService implements OnApplicationBootstrap, OnModule
 
   public constructor(
     private readonly eventBus: EventBus,
-    @Inject(JETSTREAM_METRICS_CONFIG) private readonly config: MetricsConfig,
-    @Inject(JETSTREAM_METRICS_PROM_CLIENT) private readonly promClient: PromClientRuntime,
+    @Inject(JETSTREAM_METRICS_CONFIG) private readonly config: MetricsConfig | null,
+    @Inject(JETSTREAM_METRICS_PROM_CLIENT) private readonly promClient: PromClientRuntime | null,
     @Inject(JETSTREAM_OPTIONS) private readonly options: JetstreamModuleOptions,
     @Optional() private readonly patternRegistry: PatternRegistry | null,
     @Optional()
@@ -76,6 +76,11 @@ export class JetstreamMetricsService implements OnApplicationBootstrap, OnModule
 
   public async onApplicationBootstrap(): Promise<void> {
     if (this.metrics !== null) return;
+
+    // Disabled — `metrics` was omitted/false. prom-client is never resolved
+    // in this branch, so the service is a no-op for publisher-only or
+    // metrics-off deployments.
+    if (!this.options.metrics || !this.config || !this.promClient) return;
 
     if (!this.config.register) {
       throw new Error(
@@ -106,7 +111,7 @@ export class JetstreamMetricsService implements OnApplicationBootstrap, OnModule
 
   /** @internal Visible for tests. `0` disables polling. */
   public getEffectivePollInterval(): number {
-    return this.config.pollInterval ?? DEFAULT_POLL_INTERVAL_MS;
+    return this.config?.pollInterval ?? DEFAULT_POLL_INTERVAL_MS;
   }
 
   /**

--- a/src/otel/__tests__/config.spec.ts
+++ b/src/otel/__tests__/config.spec.ts
@@ -47,6 +47,25 @@ describe('resolveOtelOptions', () => {
     });
   });
 
+  describe('boolean shorthand', () => {
+    it('should treat `true` as the all-defaults form', () => {
+      // When
+      const sut = resolveOtelOptions(true);
+
+      // Then
+      expect(sut.enabled).toBe(true);
+      expect([...sut.traces]).toEqual([...DEFAULT_TRACES]);
+    });
+
+    it('should treat `false` as a global kill switch', () => {
+      // When
+      const sut = resolveOtelOptions(false);
+
+      // Then
+      expect(sut.enabled).toBe(false);
+    });
+  });
+
   describe('traces option', () => {
     it('should expand the "default" preset to DEFAULT_TRACES', () => {
       // When

--- a/src/otel/config.ts
+++ b/src/otel/config.ts
@@ -353,7 +353,10 @@ const resolveCaptureBody = (
  * this layer's job — the NestJS / NATS infra above us owns config
  * integrity.
  */
-export const resolveOtelOptions = (options: OtelOptions = {}): ResolvedOtelOptions => {
+export const resolveOtelOptions = (options: OtelOptions | boolean = {}): ResolvedOtelOptions => {
+  if (options === true) options = {};
+  if (options === false) options = { enabled: false };
+
   return {
     enabled: options.enabled ?? true,
     traces: expandTracesOption(options.traces),

--- a/src/otel/internal-utils.ts
+++ b/src/otel/internal-utils.ts
@@ -135,7 +135,7 @@ export interface DerivedOtelAttrs {
  * keys rather than inventing a value.
  */
 export const deriveOtelAttrs = (options: {
-  readonly otel?: OtelOptions;
+  readonly otel?: OtelOptions | boolean;
   readonly name: string;
   readonly servers: readonly string[];
 }): DerivedOtelAttrs => ({

--- a/website/docs/observability/metrics.md
+++ b/website/docs/observability/metrics.md
@@ -38,7 +38,7 @@ pnpm add prom-client
 
 The transport declares `prom-client` as an **optional peer**. If you do not enable metrics, the package is never imported. Tested against `prom-client@^15`.
 
-Enable metrics in `forRoot` (or `forRootAsync`):
+Enable metrics in `forRoot`:
 
 ```ts
 import { JetstreamModule } from '@horizon-republic/nestjs-jetstream';
@@ -53,6 +53,20 @@ import { JetstreamModule } from '@horizon-republic/nestjs-jetstream';
   ],
 })
 export class AppModule {}
+```
+
+…or with `forRootAsync`:
+
+```ts
+JetstreamModule.forRootAsync({
+  name: 'orders',
+  imports: [ConfigModule],
+  inject: [ConfigService],
+  useFactory: (config: ConfigService) => ({
+    servers: config.get<string[]>('NATS_SERVERS')!,
+    metrics: true,
+  }),
+})
 ```
 
 That's the whole integration. Metrics write to `prom-client`'s global `register`. To expose them at `/metrics`, pair the transport with `@willsoto/nestjs-prometheus`:
@@ -100,8 +114,7 @@ JetstreamModule.forRoot({
 
 When the `metrics` option is omitted or set to `false`:
 
-- `JetstreamMetricsModule` is not registered.
-- `prom-client` is never imported (the dynamic `import()` does not run).
+- `prom-client` is never imported (the dynamic `import()` only runs when `metrics` is truthy).
 - The transport's hot paths add ~30 nanoseconds per message (a single `Map.get` to check if a listener exists) — effectively free.
 
 Production deployments that don't need metrics pay nothing for the feature.

--- a/website/docs/observability/tracing.md
+++ b/website/docs/observability/tracing.md
@@ -98,10 +98,12 @@ JetstreamModule.forRoot({
 
 Use `traces: 'all'` to enable every kind, `traces: 'none'` to suppress span emission entirely while keeping context propagation alive.
 
+For an env-driven toggle, the option also accepts a plain boolean — `otel: true` for defaults, `otel: false` for `{ enabled: false }`.
+
 ## Configuration reference
 
 ```ts
-otel?: {
+otel?: boolean | {
   /** Master kill switch. @default true */
   enabled?: boolean;
 


### PR DESCRIPTION
Both observability switches now live in the runtime config object — forRoot, or the forRootAsync factory return. JetstreamMetricsModule wires unconditionally and gates on JETSTREAM_OPTIONS.metrics, keeping prom-client unloaded when off. otel accepts a boolean shorthand: true == defaults, false == { enabled: false }.

## Test plan

- [x] pnpm vitest run — 801/801
- [x] npx tsc --noEmit clean
- [x] pnpm lint clean
- [x] pnpm docs:build clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry `otel` configuration now accepts boolean values as shorthand: `true` applies default settings, `false` disables tracing.

* **Documentation**
  * Updated observability documentation with clearer metrics setup examples for both synchronous and asynchronous configurations, and enhanced tracing configuration reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HorizonRepublic/nestjs-jetstream/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->