### PR TITLE
feat(provisioning): boot summary, actionable errors, and opt-in storage preflight

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export type {
   JetstreamModuleOptions,
   MetadataRegistryOptions,
   OrderedEventOverrides,
+  ProvisioningOptions,
   RpcConfig,
   ScheduleRecordOptions,
   StreamConfigOverrides,

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,8 @@ export {
 // Error codes
 export { NatsErrorCode } from './server/infrastructure/nats-error-codes';
 
+export { JetstreamProvisioningError } from './server/infrastructure/provisioning-error';
+
 // Server (for advanced use cases)
 export { JetstreamStrategy } from './server';
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -19,6 +19,7 @@ export type {
   JetstreamModuleOptions,
   MetadataRegistryOptions,
   OrderedEventOverrides,
+  ProvisioningOptions,
   RpcConfig,
   StreamConfigOverrides,
   StreamConsumerOverrides,

--- a/src/interfaces/options.interface.ts
+++ b/src/interfaces/options.interface.ts
@@ -166,18 +166,11 @@ export interface MetadataRegistryOptions {
   ttl?: number;
 }
 
-/**
- * Stream/consumer provisioning behavior. At boot the transport always logs a
- * summary of each stream's storage reservation (always on, INFO level); the
- * options here are opt-in refinements on top of that.
- */
+/** Provisioning behavior. Stream reservations are always logged at boot (INFO). */
 export interface ProvisioningOptions {
   /**
-   * Opt-in pre-flight storage budget check via `getAccountInfo()` before
-   * ensuring streams. Warn-only: logs a warning when this service's
-   * reservation would exceed the available budget, but never blocks or
-   * crashes boot. Off by default. The real provisioning failure (if any) is
-   * still surfaced as a {@link JetstreamProvisioningError}.
+   * Opt-in storage budget check via `getAccountInfo()` before provisioning.
+   * Warn-only; never blocks boot. Off by default.
    */
   preflightStorageCheck?: boolean;
 }

--- a/src/interfaces/options.interface.ts
+++ b/src/interfaces/options.interface.ts
@@ -167,6 +167,22 @@ export interface MetadataRegistryOptions {
 }
 
 /**
+ * Stream/consumer provisioning behavior. At boot the transport always logs a
+ * summary of each stream's storage reservation (always on, INFO level); the
+ * options here are opt-in refinements on top of that.
+ */
+export interface ProvisioningOptions {
+  /**
+   * Opt-in pre-flight storage budget check via `getAccountInfo()` before
+   * ensuring streams. Warn-only: logs a warning when this service's
+   * reservation would exceed the available budget, but never blocks or
+   * crashes boot. Off by default. The real provisioning failure (if any) is
+   * still surfaced as a {@link JetstreamProvisioningError}.
+   */
+  preflightStorageCheck?: boolean;
+}
+
+/**
  * Root module configuration for `JetstreamModule.forRoot()`.
  *
  * Minimal usage requires only `name` and `servers`.
@@ -347,6 +363,9 @@ export interface JetstreamModuleOptions {
    * @see OtelOptions
    */
   otel?: OtelOptions | boolean;
+
+  /** Provisioning behavior. */
+  provisioning?: ProvisioningOptions;
 }
 
 /** Options for `JetstreamModule.forFeature()`. */

--- a/src/otel/attribute-keys.ts
+++ b/src/otel/attribute-keys.ts
@@ -60,6 +60,14 @@ export const ATTR_JETSTREAM_PROVISIONING_ACTION = 'jetstream.provisioning.action
 
 export const ATTR_JETSTREAM_PROVISIONING_NAME = 'jetstream.provisioning.name' as const;
 
+export const ATTR_JETSTREAM_PROVISIONING_MAX_BYTES = 'jetstream.provisioning.max_bytes' as const;
+
+export const ATTR_JETSTREAM_PROVISIONING_NUM_REPLICAS =
+  'jetstream.provisioning.num_replicas' as const;
+
+export const ATTR_JETSTREAM_PROVISIONING_RESERVATION =
+  'jetstream.provisioning.reservation_bytes' as const;
+
 export const ATTR_JETSTREAM_SELF_HEALING_REASON = 'jetstream.self_healing.reason' as const;
 
 export const ATTR_JETSTREAM_MIGRATION_REASON = 'jetstream.migration.reason' as const;

--- a/src/otel/spans/infrastructure.ts
+++ b/src/otel/spans/infrastructure.ts
@@ -12,7 +12,10 @@ import {
   ATTR_JETSTREAM_MIGRATION_REASON,
   ATTR_JETSTREAM_PROVISIONING_ACTION,
   ATTR_JETSTREAM_PROVISIONING_ENTITY,
+  ATTR_JETSTREAM_PROVISIONING_MAX_BYTES,
   ATTR_JETSTREAM_PROVISIONING_NAME,
+  ATTR_JETSTREAM_PROVISIONING_NUM_REPLICAS,
+  ATTR_JETSTREAM_PROVISIONING_RESERVATION,
   ATTR_JETSTREAM_SELF_HEALING_REASON,
   ATTR_JETSTREAM_SERVICE_NAME,
   ATTR_MESSAGING_CONSUMER_GROUP_NAME,
@@ -203,6 +206,9 @@ export interface ProvisioningSpanContext extends InfrastructureSpanContext {
   readonly entity: ProvisioningEntity;
   readonly name: string;
   readonly action: ProvisioningAction;
+  readonly maxBytes?: number;
+  readonly numReplicas?: number;
+  readonly reservation?: number;
 }
 
 export const withProvisioningSpan = <T>(
@@ -219,6 +225,9 @@ export const withProvisioningSpan = <T>(
       [ATTR_JETSTREAM_PROVISIONING_ENTITY]: ctx.entity,
       [ATTR_JETSTREAM_PROVISIONING_ACTION]: ctx.action,
       [ATTR_JETSTREAM_PROVISIONING_NAME]: ctx.name,
+      [ATTR_JETSTREAM_PROVISIONING_MAX_BYTES]: ctx.maxBytes,
+      [ATTR_JETSTREAM_PROVISIONING_NUM_REPLICAS]: ctx.numReplicas,
+      [ATTR_JETSTREAM_PROVISIONING_RESERVATION]: ctx.reservation,
     },
     op,
   );

--- a/src/server/__tests__/strategy.spec.ts
+++ b/src/server/__tests__/strategy.spec.ts
@@ -86,6 +86,22 @@ describe(JetstreamStrategy, () => {
       expect(secondCallback).not.toHaveBeenCalled();
       expect(patternRegistry.registerHandlers).toHaveBeenCalledTimes(1);
     });
+
+    it('should forward doListen errors to callback and resolve (not rethrow)', async () => {
+      // Given: event handlers present so ensureStreams is reached; it rejects
+      const sentinelError = new Error('stream provisioning failed');
+
+      patternRegistry.hasEventHandlers = vi.fn().mockReturnValue(true);
+      streamProvider.ensureStreams = vi.fn().mockRejectedValue(sentinelError);
+      const callback = vi.fn();
+
+      // When
+      await sut.listen(callback);
+
+      // Then: error forwarded to callback; listen() itself resolved
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(sentinelError);
+    });
   });
 
   describe('metadata publishing', () => {

--- a/src/server/infrastructure/__tests__/consumer.provider.spec.ts
+++ b/src/server/infrastructure/__tests__/consumer.provider.spec.ts
@@ -114,7 +114,7 @@ describe(ConsumerProvider, () => {
         expect(result.get(StreamKind.Event)).toBe(existingInfo);
       });
 
-      it('should rethrow non-race errors from add()', async () => {
+      it('should wrap non-race add() failures into JetstreamProvisioningError', async () => {
         // Given: info → not found, add → resource limit (not a race)
         const notFoundError = new JetStreamApiError({
           err_code: 10014,
@@ -130,10 +130,12 @@ describe(ConsumerProvider, () => {
         mockJsm.consumers.info.mockRejectedValue(notFoundError);
         mockJsm.consumers.add.mockRejectedValue(resourceError);
 
-        // When/Then: error propagates
-        await expect(sut.ensureConsumers([StreamKind.Event])).rejects.toThrow(
-          'resource limits exceeded',
-        );
+        // When/Then: the API error is wrapped, not rethrown raw
+        await expect(sut.ensureConsumers([StreamKind.Event])).rejects.toMatchObject({
+          name: 'JetstreamProvisioningError',
+          entity: 'consumer',
+          errCode: 10025,
+        });
 
         expect(mockJsm.consumers.update).not.toHaveBeenCalled();
       });
@@ -238,6 +240,33 @@ describe(ConsumerProvider, () => {
 
         // And: consumer was NOT created
         expect(mockJsm.consumers.add).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('error wrapping', () => {
+    it('should wrap a non-recoverable JetStreamApiError from consumers.add', async () => {
+      // Given: consumer not found, then add fails with insufficient resources
+      const notFound = new JetStreamApiError({
+        err_code: 10014,
+        code: 404,
+        description: 'consumer not found',
+      });
+      const resourceErr = new JetStreamApiError({
+        err_code: 10047,
+        code: 500,
+        description: 'insufficient resources',
+      });
+
+      mockJsm.consumers.info.mockRejectedValue(notFound);
+      mockJsm.consumers.update.mockRejectedValue(notFound);
+      mockJsm.consumers.add.mockRejectedValue(resourceErr);
+
+      // When / Then
+      await expect(sut.ensureConsumer(mockJsm as never, StreamKind.Event)).rejects.toMatchObject({
+        name: 'JetstreamProvisioningError',
+        entity: 'consumer',
+        errCode: 10047,
       });
     });
   });

--- a/src/server/infrastructure/__tests__/provisioning-budget.spec.ts
+++ b/src/server/infrastructure/__tests__/provisioning-budget.spec.ts
@@ -8,10 +8,14 @@ import { type StreamReservation } from '../provisioning-summary';
 
 const GIB = 1024 ** 3;
 
-const reservation = (numReplicas: number, maxBytes: number): StreamReservation => ({
+const reservation = (
+  numReplicas: number,
+  maxBytes: number,
+  storage: StorageType = StorageType.File,
+): StreamReservation => ({
   kind: 'ev',
   name: 'svc__microservice_ev-stream',
-  storage: StorageType.File,
+  storage,
   numReplicas,
   maxBytes,
   maxAge: 0,
@@ -106,6 +110,72 @@ describe('assertStorageBudget', () => {
 
     // Then
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('tier R3'));
+  });
+
+  it('should warn only for the over-budget replica tier in a mixed-tier service', async () => {
+    // Given: R1 ample (top-level), R3 tier tight
+    const jsm = createMock({
+      getAccountInfo: vi.fn().mockResolvedValue(
+        accountInfo({
+          reserved_storage: 0,
+          limits: { max_storage: 100 * GIB },
+          tiers: {
+            R3: { reserved_storage: 9 * GIB, limits: { max_storage: 10 * GIB } },
+          },
+        }),
+      ),
+    });
+    const logger = createMock<Logger>();
+
+    // When: R1 1×1 = 1 GiB (fits), R3 2×3 = 6 GiB (only 1 GiB remains in R3)
+    await assertStorageBudget(
+      jsm as never,
+      'svc',
+      [reservation(1, 1 * GIB), reservation(3, 2 * GIB)],
+      logger,
+    );
+
+    // Then: warns for R3 only, not for R1
+    expect(logger.warn).toHaveBeenCalledOnce();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('tier R3'));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('likely fail'));
+  });
+
+  it('should ignore memory-backed reservations when the file budget is ample', async () => {
+    // Given: tiny file budget headroom but the huge reservation is memory-backed
+    const jsm = createMock({
+      getAccountInfo: vi
+        .fn()
+        .mockResolvedValue(
+          accountInfo({ reserved_storage: 1 * GIB, limits: { max_storage: 10 * GIB } }),
+        ),
+    });
+    const logger = createMock<Logger>();
+
+    // When: 100 GiB memory stream — must not count against file storage
+    await assertStorageBudget(
+      jsm as never,
+      'svc',
+      [reservation(1, 100 * GIB, StorageType.Memory)],
+      logger,
+    );
+
+    // Then
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('should not throw when account info has no limits shape', async () => {
+    // Given: an empty/partial account object (no limits/tiers)
+    const jsm = createMock({
+      getAccountInfo: vi.fn().mockResolvedValue({}),
+    });
+    const logger = createMock<Logger>();
+
+    // When / Then: never-throws guard — resolves undefined, treats missing limit as unset
+    await expect(
+      assertStorageBudget(jsm as never, 'svc', [reservation(1, 5 * GIB)], logger),
+    ).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('limit not set'));
   });
 
   it('should degrade gracefully (no throw) when getAccountInfo fails', async () => {

--- a/src/server/infrastructure/__tests__/provisioning-budget.spec.ts
+++ b/src/server/infrastructure/__tests__/provisioning-budget.spec.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMock } from '@golevelup/ts-vitest';
+import { Logger } from '@nestjs/common';
+import { RetentionPolicy, StorageType } from '@nats-io/jetstream';
+
+import { assertStorageBudget } from '../provisioning-budget';
+import { type StreamReservation } from '../provisioning-summary';
+
+const GIB = 1024 ** 3;
+
+const reservation = (numReplicas: number, maxBytes: number): StreamReservation => ({
+  kind: 'ev',
+  name: 'svc__microservice_ev-stream',
+  storage: StorageType.File,
+  numReplicas,
+  maxBytes,
+  maxAge: 0,
+  retention: RetentionPolicy.Workqueue,
+});
+
+const accountInfo = (overrides: Record<string, unknown> = {}): unknown => ({
+  storage: 0,
+  reserved_storage: 0,
+  memory: 0,
+  reserved_memory: 0,
+  streams: 0,
+  consumers: 0,
+  limits: { max_storage: 0, max_memory: 0 },
+  api: { total: 0, errors: 0 },
+  ...overrides,
+});
+
+describe('assertStorageBudget', () => {
+  afterEach(vi.resetAllMocks);
+
+  it('should warn when the reservation exceeds the remaining account budget', async () => {
+    // Given: account limit 10 GiB, 6 already reserved; this service wants 5×1 = 5 GiB
+    const jsm = createMock({
+      getAccountInfo: vi
+        .fn()
+        .mockResolvedValue(
+          accountInfo({ reserved_storage: 6 * GIB, limits: { max_storage: 10 * GIB } }),
+        ),
+    });
+    const logger = createMock<Logger>();
+
+    // When
+    await assertStorageBudget(jsm as never, 'svc', [reservation(1, 5 * GIB)], logger);
+
+    // Then
+    expect(logger.warn).toHaveBeenCalledOnce();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Provisioning will likely fail'),
+    );
+  });
+
+  it('should NOT warn (logs OK) when the reservation fits', async () => {
+    // Given: 10 GiB limit, 1 reserved; wants 5 GiB
+    const jsm = createMock({
+      getAccountInfo: vi
+        .fn()
+        .mockResolvedValue(
+          accountInfo({ reserved_storage: 1 * GIB, limits: { max_storage: 10 * GIB } }),
+        ),
+    });
+    const logger = createMock<Logger>();
+
+    // When
+    await assertStorageBudget(jsm as never, 'svc', [reservation(1, 5 * GIB)], logger);
+
+    // Then
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalled();
+  });
+
+  it('should warn that the limit is unset when max_storage <= 0', async () => {
+    // Given: unlimited account (server-side max_file_store not visible)
+    const jsm = createMock({
+      getAccountInfo: vi.fn().mockResolvedValue(accountInfo({ limits: { max_storage: -1 } })),
+    });
+    const logger = createMock<Logger>();
+
+    // When
+    await assertStorageBudget(jsm as never, 'svc', [reservation(1, 5 * GIB)], logger);
+
+    // Then
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('limit not set'));
+  });
+
+  it('should prefer the replication-tier budget when present', async () => {
+    // Given: top-level unlimited, but tier R3 has a tight limit
+    const jsm = createMock({
+      getAccountInfo: vi.fn().mockResolvedValue(
+        accountInfo({
+          limits: { max_storage: -1 },
+          tiers: {
+            R3: { reserved_storage: 9 * GIB, limits: { max_storage: 10 * GIB } },
+          },
+        }),
+      ),
+    });
+    const logger = createMock<Logger>();
+
+    // When: 2×3 = 6 GiB needed, only 1 GiB remains in R3
+    await assertStorageBudget(jsm as never, 'svc', [reservation(3, 2 * GIB)], logger);
+
+    // Then
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('tier R3'));
+  });
+
+  it('should degrade gracefully (no throw) when getAccountInfo fails', async () => {
+    // Given
+    const jsm = createMock({
+      getAccountInfo: vi.fn().mockRejectedValue(new Error('no permission')),
+    });
+    const logger = createMock<Logger>();
+
+    // When / Then: must not throw, must not warn
+    await expect(
+      assertStorageBudget(jsm as never, 'svc', [reservation(1, 5 * GIB)], logger),
+    ).resolves.toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalled();
+  });
+});

--- a/src/server/infrastructure/__tests__/provisioning-error.spec.ts
+++ b/src/server/infrastructure/__tests__/provisioning-error.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { JetStreamApiError } from '@nats-io/jetstream';
+
+import { NatsErrorCode } from '../nats-error-codes';
+import {
+  JetstreamProvisioningError,
+  mapProvisioningError,
+  type ProvisioningErrorContext,
+} from '../provisioning-error';
+
+const GIB = 1024 ** 3;
+
+const streamCtx: ProvisioningErrorContext = {
+  entity: 'stream',
+  name: 'svc__microservice_ev-stream',
+  kind: 'ev',
+  maxBytes: 5 * GIB,
+  numReplicas: 3,
+};
+
+describe('mapProvisioningError', () => {
+  it('should map insufficient-storage with a max_file_store remediation hint', () => {
+    // Given
+    const apiErr = new JetStreamApiError({
+      err_code: NatsErrorCode.InsufficientResources,
+      code: 500,
+      description: 'insufficient storage resources available',
+    });
+
+    // When
+    const result = mapProvisioningError(apiErr, streamCtx);
+
+    // Then
+    expect(result).toBeInstanceOf(JetstreamProvisioningError);
+    expect(result.entity).toBe('stream');
+    expect(result.target).toBe('svc__microservice_ev-stream');
+    expect(result.errCode).toBe(NatsErrorCode.InsufficientResources);
+    expect(result.reservation).toBe(15 * GIB); // 5 × 3
+    expect(result.message).toContain('max_file_store');
+    expect(result.message).toContain('insufficient storage resources available');
+    expect(result.cause).toBe(apiErr);
+  });
+
+  it('should map no-suitable-peers with a replicas/peers remediation hint', () => {
+    // Given
+    const apiErr = new JetStreamApiError({
+      err_code: NatsErrorCode.NoSuitablePeers,
+      code: 500,
+      description: 'no suitable peers for placement',
+    });
+
+    // When
+    const result = mapProvisioningError(apiErr, streamCtx);
+
+    // Then
+    expect(result.message).toContain('peers');
+    expect(result.message).toContain('num_replicas');
+  });
+
+  it('should map an unknown code with a generic hint, preserving details', () => {
+    // Given
+    const apiErr = new JetStreamApiError({
+      err_code: 10100,
+      code: 403,
+      description: 'authorization violation',
+    });
+
+    // When
+    const result = mapProvisioningError(apiErr, streamCtx);
+
+    // Then
+    expect(result.errCode).toBe(10100);
+    expect(result.message).toContain('authorization violation');
+    expect(result.message).toContain('[err_code=10100]');
+  });
+
+  it('should omit reservation fields for consumer entities', () => {
+    // Given: consumer context has no byte reservation
+    const consumerCtx: ProvisioningErrorContext = {
+      entity: 'consumer',
+      name: 'svc__microservice_ev-consumer',
+      kind: 'ev',
+    };
+    const apiErr = new JetStreamApiError({
+      err_code: NatsErrorCode.InsufficientResources,
+      code: 500,
+      description: 'insufficient resources',
+    });
+
+    // When
+    const result = mapProvisioningError(apiErr, consumerCtx);
+
+    // Then
+    expect(result.entity).toBe('consumer');
+    expect(result.reservation).toBeUndefined();
+    expect(result.maxBytes).toBeUndefined();
+  });
+});

--- a/src/server/infrastructure/__tests__/provisioning-error.spec.ts
+++ b/src/server/infrastructure/__tests__/provisioning-error.spec.ts
@@ -22,7 +22,7 @@ describe('mapProvisioningError', () => {
   it('should map insufficient-storage with a max_file_store remediation hint', () => {
     // Given
     const apiErr = new JetStreamApiError({
-      err_code: NatsErrorCode.InsufficientResources,
+      err_code: NatsErrorCode.StorageResourcesExceeded,
       code: 500,
       description: 'insufficient storage resources available',
     });
@@ -34,7 +34,7 @@ describe('mapProvisioningError', () => {
     expect(result).toBeInstanceOf(JetstreamProvisioningError);
     expect(result.entity).toBe('stream');
     expect(result.target).toBe('svc__microservice_ev-stream');
-    expect(result.errCode).toBe(NatsErrorCode.InsufficientResources);
+    expect(result.errCode).toBe(NatsErrorCode.StorageResourcesExceeded);
     expect(result.reservation).toBe(15 * GIB); // 5 × 3
     expect(result.message).toContain('max_file_store');
     expect(result.message).toContain('insufficient storage resources available');
@@ -82,7 +82,7 @@ describe('mapProvisioningError', () => {
       kind: 'ev',
     };
     const apiErr = new JetStreamApiError({
-      err_code: NatsErrorCode.InsufficientResources,
+      err_code: NatsErrorCode.StorageResourcesExceeded,
       code: 500,
       description: 'insufficient resources',
     });

--- a/src/server/infrastructure/__tests__/provisioning-summary.spec.ts
+++ b/src/server/infrastructure/__tests__/provisioning-summary.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { RetentionPolicy, StorageType } from '@nats-io/jetstream';
+
+import { formatProvisioningSummary, type StreamReservation } from '../provisioning-summary';
+
+const GIB = 1024 ** 3;
+
+describe('formatProvisioningSummary', () => {
+  // Given: two streams with different replicas
+  const reservations: StreamReservation[] = [
+    {
+      kind: 'ev',
+      name: 'svc__microservice_ev-stream',
+      storage: StorageType.File,
+      numReplicas: 3,
+      maxBytes: 5 * GIB,
+      maxAge: 7 * 86_400 * 1e9,
+      retention: RetentionPolicy.Workqueue,
+    },
+    {
+      kind: 'broadcast',
+      name: 'broadcast-stream',
+      storage: StorageType.File,
+      numReplicas: 3,
+      maxBytes: 2 * GIB,
+      maxAge: 3_600 * 1e9,
+      retention: RetentionPolicy.Limits,
+    },
+  ];
+
+  it('should list one line per stream with cluster reservation', () => {
+    // When
+    const result = formatProvisioningSummary('svc', reservations);
+
+    // Then
+    expect(result).toContain('svc__microservice_ev-stream [ev]');
+    expect(result).toContain('replicas=3');
+    expect(result).toContain('max_bytes=5.00 GiB');
+    expect(result).toContain('cluster reservation 15.00 GiB'); // 5 × 3
+  });
+
+  it('should render a per-node total = sum of max_bytes (worst case replicas=nodes)', () => {
+    // When
+    const result = formatProvisioningSummary('svc', reservations);
+
+    // Then: 5 + 2 = 7 GiB per node, not 5×3 + 2×3
+    expect(result).toContain('per-node footprint ≈ 7.00 GiB');
+    expect(result).toContain('max_file_store');
+  });
+
+  it('should render zero max_bytes safely', () => {
+    // Given: a stream with no byte limit
+    const zero: StreamReservation[] = [{ ...reservations[0], maxBytes: 0, maxAge: 0 }];
+
+    // When
+    const result = formatProvisioningSummary('svc', zero);
+
+    // Then
+    expect(result).toContain('max_bytes=0 B');
+    expect(result).toContain('max_age=unlimited');
+  });
+});

--- a/src/server/infrastructure/__tests__/provisioning-summary.spec.ts
+++ b/src/server/infrastructure/__tests__/provisioning-summary.spec.ts
@@ -50,7 +50,17 @@ describe('formatProvisioningSummary', () => {
 
   it('should render zero max_bytes safely', () => {
     // Given: a stream with no byte limit
-    const zero: StreamReservation[] = [{ ...reservations[0], maxBytes: 0, maxAge: 0 }];
+    const zero: StreamReservation[] = [
+      {
+        kind: 'ev',
+        name: 'svc__microservice_ev-stream',
+        storage: StorageType.File,
+        numReplicas: 3,
+        maxBytes: 0,
+        maxAge: 0,
+        retention: RetentionPolicy.Workqueue,
+      },
+    ];
 
     // When
     const result = formatProvisioningSummary('svc', zero);

--- a/src/server/infrastructure/__tests__/provisioning-summary.spec.ts
+++ b/src/server/infrastructure/__tests__/provisioning-summary.spec.ts
@@ -44,8 +44,38 @@ describe('formatProvisioningSummary', () => {
     const result = formatProvisioningSummary('svc', reservations);
 
     // Then: 5 + 2 = 7 GiB per node, not 5×3 + 2×3
-    expect(result).toContain('per-node footprint ≈ 7.00 GiB');
+    expect(result).toContain('per-node file-backed footprint ≈ 7.00 GiB');
     expect(result).toContain('max_file_store');
+  });
+
+  it('should exclude memory-backed streams from the file-backed footprint total', () => {
+    // Given: one file stream (2 GiB) + one memory stream (3 GiB)
+    const mixed: StreamReservation[] = [
+      {
+        kind: 'ev',
+        name: 'svc__microservice_ev-stream',
+        storage: StorageType.File,
+        numReplicas: 1,
+        maxBytes: 2 * GIB,
+        maxAge: 0,
+        retention: RetentionPolicy.Limits,
+      },
+      {
+        kind: 'broadcast',
+        name: 'broadcast-stream',
+        storage: StorageType.Memory,
+        numReplicas: 1,
+        maxBytes: 3 * GIB,
+        maxAge: 0,
+        retention: RetentionPolicy.Limits,
+      },
+    ];
+
+    // When
+    const result = formatProvisioningSummary('svc', mixed);
+
+    // Then: only the file-backed 2 GiB counts toward the footer total
+    expect(result).toContain('per-node file-backed footprint ≈ 2.00 GiB');
   });
 
   it('should render zero max_bytes safely', () => {

--- a/src/server/infrastructure/__tests__/stream.provider.spec.ts
+++ b/src/server/infrastructure/__tests__/stream.provider.spec.ts
@@ -26,6 +26,7 @@ describe(StreamProvider, () => {
       add: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
     };
+    getAccountInfo?: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -477,6 +478,60 @@ describe(StreamProvider, () => {
           );
         });
       });
+    });
+  });
+
+  describe('ensureStreams', () => {
+    it('should wrap an insufficient-storage failure from streams.add', async () => {
+      // Given: stream does not exist, then add fails with insufficient storage
+      const notFound = new JetStreamApiError({
+        err_code: 10059,
+        code: 404,
+        description: 'stream not found',
+      });
+      const storageErr = new JetStreamApiError({
+        err_code: 10047,
+        code: 500,
+        description: 'insufficient storage resources available',
+      });
+
+      mockJsm.streams.info.mockRejectedValue(notFound);
+      mockJsm.streams.add.mockRejectedValue(storageErr);
+
+      // When / Then
+      await expect(sut.ensureStreams([StreamKind.Event])).rejects.toMatchObject({
+        name: 'JetstreamProvisioningError',
+        errCode: 10047,
+        entity: 'stream',
+      });
+    });
+
+    it('should run the preflight check only when provisioning.preflightStorageCheck is set', async () => {
+      // Given: existing stream with no diff, preflight enabled
+      options.provisioning = { preflightStorageCheck: true };
+      sut = new StreamProvider(options, connection);
+
+      const getAccountInfo = vi.fn().mockResolvedValue({
+        storage: 0,
+        reserved_storage: 0,
+        memory: 0,
+        reserved_memory: 0,
+        streams: 0,
+        consumers: 0,
+        limits: { max_storage: -1, max_memory: 0 },
+        api: { total: 0, errors: 0 },
+      });
+
+      mockJsm.getAccountInfo = getAccountInfo;
+      mockJsm.streams.info.mockResolvedValue({
+        config: { ...DEFAULT_EVENT_STREAM_CONFIG, name: sut.getStreamName(StreamKind.Event) },
+      } as never);
+
+      // When
+      await sut.ensureStreams([StreamKind.Event]);
+
+      // Then
+      expect(getAccountInfo).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/server/infrastructure/consumer.provider.ts
+++ b/src/server/infrastructure/consumer.provider.ts
@@ -19,6 +19,7 @@ import {
 } from '../../otel';
 import { PatternRegistry } from '../routing';
 
+import { mapProvisioningError, type ProvisioningErrorContext } from './provisioning-error';
 import { NatsErrorCode } from './nats-error-codes';
 import { MIGRATION_BACKUP_SUFFIX } from './stream-migration';
 import { StreamProvider } from './stream.provider';
@@ -99,11 +100,13 @@ export class ConsumerProvider {
       async () => {
         this.logger.log(`Ensuring consumer: ${name} on stream: ${stream}`);
 
+        const ctx: ProvisioningErrorContext = { entity: 'consumer', name, kind };
+
         try {
           await jsm.consumers.info(stream, name);
           this.logger.debug(`Consumer exists, updating: ${name}`);
 
-          return await jsm.consumers.update(stream, name, config);
+          return await this.runConsumerOp(ctx, () => jsm.consumers.update(stream, name, config));
         } catch (err) {
           if (
             !(err instanceof JetStreamApiError) ||
@@ -112,7 +115,7 @@ export class ConsumerProvider {
             throw err;
           }
 
-          return await this.createConsumer(jsm, stream, name, config);
+          return await this.createConsumer(jsm, stream, name, kind, config);
         }
       },
     );
@@ -165,7 +168,7 @@ export class ConsumerProvider {
             throw err;
           }
 
-          return await this.createConsumer(jsm, stream, name, config);
+          return await this.createConsumer(jsm, stream, name, kind, config);
         }
       },
     );
@@ -211,10 +214,13 @@ export class ConsumerProvider {
     jsm: Awaited<ReturnType<ConnectionProvider['getJetStreamManager']>>,
     stream: string,
     name: string,
+    kind: StreamKind,
     /* eslint-disable-next-line @typescript-eslint/naming-convention -- NATS API uses snake_case */
     config: Partial<ConsumerConfig> & { durable_name: string },
   ): Promise<ConsumerInfo> {
     this.logger.log(`Creating consumer: ${name}`);
+
+    const ctx: ProvisioningErrorContext = { entity: 'consumer', name, kind };
 
     try {
       return await jsm.consumers.add(stream, config);
@@ -228,7 +234,23 @@ export class ConsumerProvider {
         return await jsm.consumers.info(stream, name);
       }
 
+      if (addErr instanceof JetStreamApiError) {
+        throw mapProvisioningError(addErr, ctx);
+      }
+
       throw addErr;
+    }
+  }
+
+  private async runConsumerOp<T>(ctx: ProvisioningErrorContext, op: () => Promise<T>): Promise<T> {
+    try {
+      return await op();
+    } catch (err) {
+      if (err instanceof JetStreamApiError) {
+        throw mapProvisioningError(err, ctx);
+      }
+
+      throw err;
     }
   }
 

--- a/src/server/infrastructure/nats-error-codes.ts
+++ b/src/server/infrastructure/nats-error-codes.ts
@@ -14,20 +14,9 @@ export enum NatsErrorCode {
   /** Stream does not exist. */
   StreamNotFound = 10059,
 
-  /**
-   * Insufficient storage resources available — the requested reservation exceeds
-   * the server `max_file_store` (or account `max_storage`) budget.
-   * Sourced from nats-server v2.14.1 server/errors.json; confirmed at runtime by
-   * the provisioning integration test.
-   */
+  /** Insufficient storage resources — reservation exceeds server `max_file_store`. */
   InsufficientResources = 10047,
 
-  /**
-   * No suitable peers for placement — fewer healthy peers than `num_replicas`,
-   * or no peer with enough reserved storage headroom (clustered deployments).
-   * Sourced from nats-server v2.14.1 server/errors.json. NOT confirmed at runtime by
-   * the integration test — triggering it requires a clustered NATS deployment (the test
-   * runs single-node).
-   */
+  /** No suitable peers for placement (fewer healthy peers than `num_replicas`). */
   NoSuitablePeers = 10005,
 }

--- a/src/server/infrastructure/nats-error-codes.ts
+++ b/src/server/infrastructure/nats-error-codes.ts
@@ -14,8 +14,8 @@ export enum NatsErrorCode {
   /** Stream does not exist. */
   StreamNotFound = 10059,
 
-  /** Insufficient storage resources — reservation exceeds server `max_file_store`. */
-  InsufficientResources = 10047,
+  /** Storage resources exceeded — reservation exceeds server `max_file_store`. */
+  StorageResourcesExceeded = 10047,
 
   /**
    * No suitable peers for placement (fewer healthy peers than `num_replicas`,

--- a/src/server/infrastructure/nats-error-codes.ts
+++ b/src/server/infrastructure/nats-error-codes.ts
@@ -17,6 +17,9 @@ export enum NatsErrorCode {
   /** Insufficient storage resources — reservation exceeds server `max_file_store`. */
   InsufficientResources = 10047,
 
-  /** No suitable peers for placement (fewer healthy peers than `num_replicas`). */
+  /**
+   * No suitable peers for placement (fewer healthy peers than `num_replicas`,
+   * or no peer has storage headroom). Confirmed at runtime by the cluster integration test.
+   */
   NoSuitablePeers = 10005,
 }

--- a/src/server/infrastructure/nats-error-codes.ts
+++ b/src/server/infrastructure/nats-error-codes.ts
@@ -2,7 +2,7 @@
  * NATS JetStream API error codes used by the transport.
  *
  * Ref: https://github.com/nats-io/nats-server (server error definitions)
- * Verified on NATS 2.12.6 via integration tests (2026-04-02).
+ * Codes verified across NATS 2.12.6–2.14.1 via integration tests (original codes: 2026-04-02).
  */
 export enum NatsErrorCode {
   /** Consumer does not exist on the specified stream. */
@@ -13,4 +13,21 @@ export enum NatsErrorCode {
 
   /** Stream does not exist. */
   StreamNotFound = 10059,
+
+  /**
+   * Insufficient storage resources available — the requested reservation exceeds
+   * the server `max_file_store` (or account `max_storage`) budget.
+   * Sourced from nats-server v2.14.1 server/errors.json; confirmed at runtime by
+   * the provisioning integration test.
+   */
+  InsufficientResources = 10047,
+
+  /**
+   * No suitable peers for placement — fewer healthy peers than `num_replicas`,
+   * or no peer with enough reserved storage headroom (clustered deployments).
+   * Sourced from nats-server v2.14.1 server/errors.json. NOT confirmed at runtime by
+   * the integration test — triggering it requires a clustered NATS deployment (the test
+   * runs single-node).
+   */
+  NoSuitablePeers = 10005,
 }

--- a/src/server/infrastructure/provisioning-budget.ts
+++ b/src/server/infrastructure/provisioning-budget.ts
@@ -1,0 +1,72 @@
+import { type Logger } from '@nestjs/common';
+import { type JetStreamManager } from '@nats-io/jetstream';
+
+import { type StreamReservation } from './provisioning-summary';
+
+const GIB = 1024 ** 3;
+
+const fmt = (bytes: number): string => `${(bytes / GIB).toFixed(2)} GiB`;
+
+const dominantReplicas = (reservations: StreamReservation[]): number =>
+  reservations.reduce((max, r) => Math.max(max, r.numReplicas), 1);
+
+const incrementalReservation = (reservations: StreamReservation[]): number =>
+  reservations.reduce((sum, r) => sum + r.maxBytes * r.numReplicas, 0);
+
+/**
+ * Opt-in, warn-only storage budget check. Never throws or blocks boot.
+ * Heuristic only — server `max_file_store` isn't client-visible and account
+ * info is an aggregate, so the wrapped provisioning error stays authoritative.
+ */
+export const assertStorageBudget = async (
+  jsm: JetStreamManager,
+  serviceName: string,
+  reservations: StreamReservation[],
+  logger: Logger,
+): Promise<void> => {
+  let info: Awaited<ReturnType<JetStreamManager['getAccountInfo']>>;
+
+  try {
+    info = await jsm.getAccountInfo();
+  } catch (err) {
+    logger.debug(`Storage preflight skipped — getAccountInfo() unavailable: ${String(err)}`);
+
+    return;
+  }
+
+  const replicas = dominantReplicas(reservations);
+  const tier = info.tiers?.[`R${replicas}`];
+  const limits = tier?.limits ?? info.limits;
+  const reserved = tier?.reserved_storage ?? info.reserved_storage;
+  const maxStorage = limits.max_storage;
+  const incremental = incrementalReservation(reservations);
+  const tierNote = tier ? ` (tier R${replicas})` : '';
+
+  if (maxStorage <= 0) {
+    logger.warn(
+      `Storage preflight for "${serviceName}": account file-storage limit not set ` +
+        `(max_storage=${maxStorage}); the server max_file_store cannot be verified from the client. ` +
+        `This service will reserve ~${fmt(incremental)} (replicas=${replicas}).`,
+    );
+
+    return;
+  }
+
+  const remaining = maxStorage - reserved;
+
+  if (incremental > remaining) {
+    logger.warn(
+      `Storage preflight for "${serviceName}": needs ~${fmt(incremental)} but only ~${fmt(remaining)} ` +
+        `remains${tierNote} (reserved ${fmt(reserved)} / limit ${fmt(maxStorage)}). ` +
+        `Provisioning will likely fail with insufficient storage. ` +
+        `Lower max_bytes/num_replicas, or raise the account/server storage limit.`,
+    );
+
+    return;
+  }
+
+  logger.log(
+    `Storage preflight for "${serviceName}" OK: reserving ~${fmt(incremental)}; ` +
+      `account${tierNote} reserved ${fmt(reserved)} / limit ${fmt(maxStorage)} (remaining ${fmt(remaining)}).`,
+  );
+};

--- a/src/server/infrastructure/provisioning-budget.ts
+++ b/src/server/infrastructure/provisioning-budget.ts
@@ -1,5 +1,5 @@
 import { type Logger } from '@nestjs/common';
-import { type JetStreamManager } from '@nats-io/jetstream';
+import { type JetStreamManager, StorageType } from '@nats-io/jetstream';
 
 import { type StreamReservation } from './provisioning-summary';
 
@@ -7,16 +7,61 @@ const GIB = 1024 ** 3;
 
 const fmt = (bytes: number): string => `${(bytes / GIB).toFixed(2)} GiB`;
 
-const dominantReplicas = (reservations: StreamReservation[]): number =>
-  reservations.reduce((max, r) => Math.max(max, r.numReplicas), 1);
+/* eslint-disable @typescript-eslint/naming-convention */
+/** File-storage limits as exposed by account/tier info. */
+interface AccountStorageLimits {
+  readonly max_storage?: number;
+}
 
-const incrementalReservation = (reservations: StreamReservation[]): number =>
-  reservations.reduce((sum, r) => sum + r.maxBytes * r.numReplicas, 0);
+/** Defensive view of `getAccountInfo()` — fields may be absent on partial/unexpected shapes. */
+interface AccountInfoView {
+  readonly limits?: AccountStorageLimits;
+  readonly reserved_storage?: number;
+  readonly tiers?: Record<string, AccountInfoView | undefined>;
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+/** Resolved file-storage budget for one replica tier. */
+interface TierBudget {
+  readonly maxStorage: number;
+  readonly reserved: number;
+  readonly tiered: boolean;
+}
+
+/** Pick the tier-specific limit when present, else fall back to the account aggregate. */
+const resolveTierBudget = (info: AccountInfoView, replicas: number): TierBudget => {
+  const tier = info.tiers?.[`R${replicas}`];
+  const limits = tier?.limits ?? info.limits;
+
+  return {
+    maxStorage: limits?.max_storage ?? 0,
+    reserved: tier?.reserved_storage ?? info.reserved_storage ?? 0,
+    tiered: tier !== undefined,
+  };
+};
+
+/** Sum of file-backed reservations grouped by replica count. */
+const groupByReplicas = (reservations: StreamReservation[]): Map<number, number> => {
+  const groups = new Map<number, number>();
+
+  for (const r of reservations) {
+    if (r.storage !== StorageType.File) continue;
+
+    const prev = groups.get(r.numReplicas) ?? 0;
+
+    groups.set(r.numReplicas, prev + r.maxBytes * r.numReplicas);
+  }
+
+  return groups;
+};
 
 /**
  * Opt-in, warn-only storage budget check. Never throws or blocks boot.
  * Heuristic only — server `max_file_store` isn't client-visible and account
  * info is an aggregate, so the wrapped provisioning error stays authoritative.
+ *
+ * Scoped to file-backed streams (memory streams don't count against file storage)
+ * and grouped by replica tier (`R{n}`), since each tier has its own account limit.
  */
 export const assertStorageBudget = async (
   jsm: JetStreamManager,
@@ -24,49 +69,56 @@ export const assertStorageBudget = async (
   reservations: StreamReservation[],
   logger: Logger,
 ): Promise<void> => {
-  let info: Awaited<ReturnType<JetStreamManager['getAccountInfo']>>;
-
   try {
-    info = await jsm.getAccountInfo();
+    const info: AccountInfoView = await jsm.getAccountInfo();
+    const groups = groupByReplicas(reservations);
+
+    let limitNotSetWarned = false;
+    let okReserved = 0;
+    let anyWarned = false;
+
+    for (const [replicas, incremental] of groups) {
+      const { maxStorage, reserved, tiered } = resolveTierBudget(info, replicas);
+      const tierNote = tiered ? ` (tier R${replicas})` : '';
+
+      if (maxStorage <= 0) {
+        if (!limitNotSetWarned) {
+          limitNotSetWarned = true;
+
+          logger.warn(
+            `Storage preflight for "${serviceName}": account file-storage limit not set ` +
+              `(max_storage=${maxStorage}); the server max_file_store cannot be verified from the client.`,
+          );
+        }
+
+        continue;
+      }
+
+      const remaining = maxStorage - reserved;
+
+      if (incremental > remaining) {
+        anyWarned = true;
+
+        logger.warn(
+          `Storage preflight for "${serviceName}"${tierNote}: needs ~${fmt(incremental)} but only ` +
+            `~${fmt(remaining)} remains (reserved ${fmt(reserved)} / limit ${fmt(maxStorage)}). ` +
+            `Provisioning will likely fail with insufficient storage. ` +
+            `Lower max_bytes/num_replicas, or raise the account/server storage limit.`,
+        );
+
+        continue;
+      }
+
+      okReserved += incremental;
+    }
+
+    if (!anyWarned && !limitNotSetWarned && okReserved > 0) {
+      logger.log(
+        `Storage preflight for "${serviceName}" OK: reserving ~${fmt(okReserved)} ` +
+          `across file-backed streams within account limits.`,
+      );
+    }
   } catch (err) {
-    logger.debug(`Storage preflight skipped — getAccountInfo() unavailable: ${String(err)}`);
-
-    return;
+    logger.debug(`Storage preflight skipped — account info unavailable: ${String(err)}`);
   }
-
-  const replicas = dominantReplicas(reservations);
-  const tier = info.tiers?.[`R${replicas}`];
-  const limits = tier?.limits ?? info.limits;
-  const reserved = tier?.reserved_storage ?? info.reserved_storage;
-  const maxStorage = limits.max_storage;
-  const incremental = incrementalReservation(reservations);
-  const tierNote = tier ? ` (tier R${replicas})` : '';
-
-  if (maxStorage <= 0) {
-    logger.warn(
-      `Storage preflight for "${serviceName}": account file-storage limit not set ` +
-        `(max_storage=${maxStorage}); the server max_file_store cannot be verified from the client. ` +
-        `This service will reserve ~${fmt(incremental)} (replicas=${replicas}).`,
-    );
-
-    return;
-  }
-
-  const remaining = maxStorage - reserved;
-
-  if (incremental > remaining) {
-    logger.warn(
-      `Storage preflight for "${serviceName}": needs ~${fmt(incremental)} but only ~${fmt(remaining)} ` +
-        `remains${tierNote} (reserved ${fmt(reserved)} / limit ${fmt(maxStorage)}). ` +
-        `Provisioning will likely fail with insufficient storage. ` +
-        `Lower max_bytes/num_replicas, or raise the account/server storage limit.`,
-    );
-
-    return;
-  }
-
-  logger.log(
-    `Storage preflight for "${serviceName}" OK: reserving ~${fmt(incremental)}; ` +
-      `account${tierNote} reserved ${fmt(reserved)} / limit ${fmt(maxStorage)} (remaining ${fmt(remaining)}).`,
-  );
 };

--- a/src/server/infrastructure/provisioning-error.ts
+++ b/src/server/infrastructure/provisioning-error.ts
@@ -29,7 +29,7 @@ export interface ProvisioningErrorFields {
 }
 
 const REMEDIATION: Partial<Record<NatsErrorCode, string>> = {
-  [NatsErrorCode.InsufficientResources]:
+  [NatsErrorCode.StorageResourcesExceeded]:
     'Aggregate stream reservation exceeds the server `max_file_store` (or account `max_storage`). ' +
     'Lower `max_bytes`/`num_replicas` for this service, or raise `max_file_store` on the NATS servers.',
   [NatsErrorCode.NoSuitablePeers]:

--- a/src/server/infrastructure/provisioning-error.ts
+++ b/src/server/infrastructure/provisioning-error.ts
@@ -1,0 +1,106 @@
+import { type JetStreamApiError } from '@nats-io/jetstream';
+
+import { type ProvisioningEntity } from '../../otel';
+
+import { NatsErrorCode } from './nats-error-codes';
+
+/** What was being provisioned when the failure occurred. */
+export interface ProvisioningErrorContext {
+  readonly entity: ProvisioningEntity;
+  readonly name: string;
+  readonly kind: string;
+  /** Per-replica bytes (streams only). */
+  readonly maxBytes?: number;
+  /** Replica count (streams only). */
+  readonly numReplicas?: number;
+}
+
+export interface ProvisioningErrorFields {
+  readonly entity: ProvisioningEntity;
+  readonly target: string;
+  readonly kind: string;
+  readonly errCode: number;
+  readonly errDescription: string;
+  readonly remediation: string;
+  readonly maxBytes?: number;
+  readonly numReplicas?: number;
+  readonly reservation?: number;
+  readonly cause: unknown;
+}
+
+const REMEDIATION: Partial<Record<NatsErrorCode, string>> = {
+  [NatsErrorCode.InsufficientResources]:
+    'Aggregate stream reservation exceeds the server `max_file_store` (or account `max_storage`). ' +
+    'Lower `max_bytes`/`num_replicas` for this service, or raise `max_file_store` on the NATS servers.',
+  [NatsErrorCode.NoSuitablePeers]:
+    'Fewer healthy peers than `num_replicas`, or no peer has enough reserved storage headroom. ' +
+    'Reduce replicas or add/repair cluster nodes.',
+};
+
+const GENERIC_REMEDIATION =
+  'Inspect the NATS server logs and JetStream account limits for the underlying cause.';
+
+/** Non-recoverable stream/consumer provisioning failure; preserves the NATS error as `cause`. */
+export class JetstreamProvisioningError extends Error {
+  public readonly entity: ProvisioningEntity;
+  public readonly target: string;
+  public readonly kind: string;
+  public readonly errCode: number;
+  public readonly errDescription: string;
+  public readonly remediation: string;
+  public readonly maxBytes?: number;
+  public readonly numReplicas?: number;
+  public readonly reservation?: number;
+
+  public constructor(fields: ProvisioningErrorFields) {
+    const reservationNote =
+      fields.reservation !== undefined
+        ? ` reservation=${fields.reservation}B (max_bytes=${fields.maxBytes}B × replicas=${fields.numReplicas}).`
+        : '';
+
+    super(
+      `JetStream ${fields.entity} provisioning failed for "${fields.target}" (kind=${fields.kind}): ` +
+        `${fields.errDescription} [err_code=${fields.errCode}].${reservationNote} ${fields.remediation}`,
+      { cause: fields.cause },
+    );
+
+    this.name = 'JetstreamProvisioningError';
+    this.entity = fields.entity;
+    this.target = fields.target;
+    this.kind = fields.kind;
+    this.errCode = fields.errCode;
+    this.errDescription = fields.errDescription;
+    this.remediation = fields.remediation;
+    this.maxBytes = fields.maxBytes;
+    this.numReplicas = fields.numReplicas;
+    this.reservation = fields.reservation;
+
+    // Keep instanceof working across the dual CJS/ESM build.
+    Object.setPrototypeOf(this, JetstreamProvisioningError.prototype);
+  }
+}
+
+export const mapProvisioningError = (
+  err: JetStreamApiError,
+  ctx: ProvisioningErrorContext,
+): JetstreamProvisioningError => {
+  const api = err.apiError();
+  const remediation = REMEDIATION[api.err_code as NatsErrorCode] ?? GENERIC_REMEDIATION;
+  const reservation =
+    ctx.maxBytes !== undefined && ctx.numReplicas !== undefined
+      ? ctx.maxBytes * ctx.numReplicas
+      : undefined;
+
+  return new JetstreamProvisioningError({
+    entity: ctx.entity,
+    target: ctx.name,
+    kind: ctx.kind,
+    errCode: api.err_code,
+    errDescription: api.description,
+    remediation,
+    maxBytes: ctx.maxBytes,
+    numReplicas: ctx.numReplicas,
+    reservation,
+    cause: err,
+  });
+};

--- a/src/server/infrastructure/provisioning-summary.ts
+++ b/src/server/infrastructure/provisioning-summary.ts
@@ -1,4 +1,4 @@
-import { type RetentionPolicy, type StorageType } from '@nats-io/jetstream';
+import { type RetentionPolicy, StorageType } from '@nats-io/jetstream';
 
 /** One stream's provisioning footprint, used to build the boot summary. */
 export interface StreamReservation {
@@ -39,10 +39,10 @@ export const formatProvisioningSummary = (
 ): string => {
   const lines: string[] = [`Provisioning ${reservations.length} stream(s) for "${serviceName}":`];
 
-  let totalMaxBytes = 0;
+  let totalFileMaxBytes = 0;
 
   for (const r of reservations) {
-    totalMaxBytes += r.maxBytes;
+    if (r.storage === StorageType.File) totalFileMaxBytes += r.maxBytes;
 
     const clusterReservation = r.maxBytes * r.numReplicas;
 
@@ -54,7 +54,7 @@ export const formatProvisioningSummary = (
   }
 
   lines.push(
-    `  Σ per-node footprint ≈ ${formatBytes(totalMaxBytes)} ` +
+    `  Σ per-node file-backed footprint ≈ ${formatBytes(totalFileMaxBytes)} ` +
       `(sum of max_bytes; worst case replicas = nodes). ` +
       `Ensure the NATS server max_file_store accommodates the sum across ALL services.`,
   );

--- a/src/server/infrastructure/provisioning-summary.ts
+++ b/src/server/infrastructure/provisioning-summary.ts
@@ -1,0 +1,70 @@
+import { type RetentionPolicy, type StorageType } from '@nats-io/jetstream';
+
+/** One stream's provisioning footprint, used to build the boot summary. */
+export interface StreamReservation {
+  readonly kind: string;
+  readonly name: string;
+  readonly storage: StorageType;
+  readonly numReplicas: number;
+  /** Bytes reserved per replica. */
+  readonly maxBytes: number;
+  /** Retention age in nanoseconds (0 = unlimited). */
+  readonly maxAge: number;
+  readonly retention: RetentionPolicy;
+}
+
+const GIB = 1024 ** 3;
+const NANOS_PER_SECOND = 1e9;
+const NANOS_PER_HOUR = 3_600 * NANOS_PER_SECOND;
+const NANOS_PER_DAY = 86_400 * NANOS_PER_SECOND;
+
+const formatBytes = (bytes: number): string => {
+  if (bytes <= 0) return '0 B';
+
+  return `${(bytes / GIB).toFixed(2)} GiB`;
+};
+
+const formatAge = (nanos: number): string => {
+  if (nanos <= 0) return 'unlimited';
+  if (nanos >= NANOS_PER_DAY) return `${(nanos / NANOS_PER_DAY).toFixed(1)}d`;
+  if (nanos >= NANOS_PER_HOUR) return `${(nanos / NANOS_PER_HOUR).toFixed(1)}h`;
+
+  return `${(nanos / NANOS_PER_SECOND).toFixed(0)}s`;
+};
+
+/**
+ * Build an operator-facing, multi-line summary of what each stream reserves.
+ * Pure: no I/O. The caller logs the returned string.
+ *
+ * Per-stream line shows `max_bytes × num_replicas` = cluster-wide reservation.
+ * The total line shows `Σ max_bytes` = per-node footprint in the worst case
+ * where replicas = nodes (R = N), which is what exhausts `max_file_store`.
+ */
+export const formatProvisioningSummary = (
+  serviceName: string,
+  reservations: StreamReservation[],
+): string => {
+  const lines: string[] = [`Provisioning ${reservations.length} stream(s) for "${serviceName}":`];
+
+  let totalMaxBytes = 0;
+
+  for (const r of reservations) {
+    totalMaxBytes += r.maxBytes;
+
+    const clusterReservation = r.maxBytes * r.numReplicas;
+
+    lines.push(
+      `  • ${r.name} [${r.kind}] storage=${r.storage} replicas=${r.numReplicas} ` +
+        `max_bytes=${formatBytes(r.maxBytes)} max_age=${formatAge(r.maxAge)} retention=${r.retention} ` +
+        `→ cluster reservation ${formatBytes(clusterReservation)}`,
+    );
+  }
+
+  lines.push(
+    `  Σ per-node footprint ≈ ${formatBytes(totalMaxBytes)} ` +
+      `(sum of max_bytes; worst case replicas = nodes). ` +
+      `Ensure the NATS server max_file_store accommodates the sum across ALL services.`,
+  );
+
+  return lines.join('\n');
+};

--- a/src/server/infrastructure/provisioning-summary.ts
+++ b/src/server/infrastructure/provisioning-summary.ts
@@ -32,14 +32,7 @@ const formatAge = (nanos: number): string => {
   return `${(nanos / NANOS_PER_SECOND).toFixed(0)}s`;
 };
 
-/**
- * Build an operator-facing, multi-line summary of what each stream reserves.
- * Pure: no I/O. The caller logs the returned string.
- *
- * Per-stream line shows `max_bytes × num_replicas` = cluster-wide reservation.
- * The total line shows `Σ max_bytes` = per-node footprint in the worst case
- * where replicas = nodes (R = N), which is what exhausts `max_file_store`.
- */
+/** Operator-facing summary of each stream's storage reservation. Pure — caller logs it. */
 export const formatProvisioningSummary = (
   serviceName: string,
   reservations: StreamReservation[],

--- a/src/server/infrastructure/stream.provider.ts
+++ b/src/server/infrastructure/stream.provider.ts
@@ -342,12 +342,14 @@ export class StreamProvider {
     kind: ReservationKind,
     config: Partial<StreamConfig> & { name: string; subjects: string[] },
   ): StreamReservation {
+    const mb = config.max_bytes;
+
     return {
       kind,
       name: config.name,
       storage: config.storage ?? StorageType.File,
       numReplicas: config.num_replicas ?? 1,
-      maxBytes: config.max_bytes ?? 0,
+      maxBytes: mb !== undefined && mb >= 0 ? mb : 0, // NATS uses -1 for unlimited
       maxAge: config.max_age ?? 0,
       retention: config.retention ?? RetentionPolicy.Limits,
     };

--- a/src/server/infrastructure/stream.provider.ts
+++ b/src/server/infrastructure/stream.provider.ts
@@ -1,5 +1,11 @@
 import { Logger } from '@nestjs/common';
-import { JetStreamApiError, type StreamConfig, type StreamInfo } from '@nats-io/jetstream';
+import {
+  JetStreamApiError,
+  RetentionPolicy,
+  StorageType,
+  type StreamConfig,
+  type StreamInfo,
+} from '@nats-io/jetstream';
 
 import { ConnectionProvider } from '../../connection';
 import { StreamKind } from '../../interfaces';
@@ -22,8 +28,14 @@ import {
   type ServerEndpoint,
 } from '../../otel';
 import { NatsErrorCode } from './nats-error-codes';
+import { assertStorageBudget } from './provisioning-budget';
+import { mapProvisioningError, type ProvisioningErrorContext } from './provisioning-error';
+import { formatProvisioningSummary, type StreamReservation } from './provisioning-summary';
 import { compareStreamConfig, type StreamConfigDiffResult } from './stream-config-diff';
 import { StreamMigration } from './stream-migration';
+
+/** A `StreamKind` or the `'dlq'` label, used for reservation/error provenance. */
+type ReservationKind = StreamKind | 'dlq';
 
 /**
  * Manages JetStream stream lifecycle: creation, updates, and idempotent ensures.
@@ -63,6 +75,18 @@ export class StreamProvider {
    */
   public async ensureStreams(kinds: StreamKind[]): Promise<void> {
     const jsm = await this.connection.getJetStreamManager();
+
+    const reservations = kinds.map((kind) => this.buildReservation(kind, this.buildConfig(kind)));
+
+    if (this.options.dlq) {
+      reservations.push(this.buildReservation('dlq', this.buildDlqConfig()));
+    }
+
+    this.logger.log(`\n${formatProvisioningSummary(this.options.name, reservations)}`);
+
+    if (this.options.provisioning?.preflightStorageCheck) {
+      await assertStorageBudget(jsm, this.options.name, reservations, this.logger);
+    }
 
     await Promise.all(kinds.map((kind) => this.ensureStream(jsm, kind)));
     if (this.options.dlq) {
@@ -116,6 +140,7 @@ export class StreamProvider {
     kind: StreamKind,
   ): Promise<StreamInfo> {
     const config = this.buildConfig(kind);
+    const ctx = this.errorContext(kind, config);
 
     return withProvisioningSpan(
       this.otel,
@@ -125,6 +150,12 @@ export class StreamProvider {
         entity: 'stream',
         name: config.name,
         action: 'ensure',
+        maxBytes: ctx.maxBytes,
+        numReplicas: ctx.numReplicas,
+        reservation:
+          ctx.maxBytes !== undefined && ctx.numReplicas !== undefined
+            ? ctx.maxBytes * ctx.numReplicas
+            : undefined,
       },
       async () => {
         this.logger.log(`Ensuring stream: ${config.name}`);
@@ -132,14 +163,15 @@ export class StreamProvider {
         try {
           const currentInfo = await jsm.streams.info(config.name);
 
-          return await this.handleExistingStream(jsm, currentInfo, config);
+          return await this.handleExistingStream(jsm, currentInfo, config, ctx);
         } catch (err) {
           if (
             err instanceof JetStreamApiError &&
             err.apiError().err_code === NatsErrorCode.StreamNotFound
           ) {
             this.logger.log(`Creating stream: ${config.name}`);
-            return await jsm.streams.add(config as StreamConfig);
+
+            return await this.runStreamOp(ctx, () => jsm.streams.add(config as StreamConfig));
           }
 
           throw err;
@@ -153,6 +185,7 @@ export class StreamProvider {
     jsm: Awaited<ReturnType<ConnectionProvider['getJetStreamManager']>>,
   ): Promise<StreamInfo> {
     const config = this.buildDlqConfig();
+    const ctx = this.errorContext('dlq', config);
 
     return withProvisioningSpan(
       this.otel,
@@ -162,6 +195,12 @@ export class StreamProvider {
         entity: 'stream',
         name: config.name,
         action: 'ensure',
+        maxBytes: ctx.maxBytes,
+        numReplicas: ctx.numReplicas,
+        reservation:
+          ctx.maxBytes !== undefined && ctx.numReplicas !== undefined
+            ? ctx.maxBytes * ctx.numReplicas
+            : undefined,
       },
       async () => {
         this.logger.log(`Ensuring DLQ stream: ${config.name}`);
@@ -169,14 +208,15 @@ export class StreamProvider {
         try {
           const currentInfo = await jsm.streams.info(config.name);
 
-          return await this.handleExistingStream(jsm, currentInfo, config);
+          return await this.handleExistingStream(jsm, currentInfo, config, ctx);
         } catch (err) {
           if (
             err instanceof JetStreamApiError &&
             err.apiError().err_code === NatsErrorCode.StreamNotFound
           ) {
             this.logger.log(`Creating DLQ stream: ${config.name}`);
-            return await jsm.streams.add(config as StreamConfig);
+
+            return await this.runStreamOp(ctx, () => jsm.streams.add(config as StreamConfig));
           }
 
           throw err;
@@ -189,6 +229,7 @@ export class StreamProvider {
     jsm: Awaited<ReturnType<ConnectionProvider['getJetStreamManager']>>,
     currentInfo: StreamInfo,
     config: Partial<StreamConfig> & { name: string; subjects: string[] },
+    ctx: ProvisioningErrorContext,
   ): Promise<StreamInfo> {
     const diff = compareStreamConfig(currentInfo.config, config);
 
@@ -214,7 +255,8 @@ export class StreamProvider {
     if (!diff.hasImmutableChanges) {
       // Mutable-only or enable-only — normal update
       this.logger.debug(`Stream exists, updating: ${config.name}`);
-      return await jsm.streams.update(config.name, config);
+
+      return await this.runStreamOp(ctx, () => jsm.streams.update(config.name, config));
     }
 
     // Immutable changes detected
@@ -228,7 +270,7 @@ export class StreamProvider {
       if (diff.hasMutableChanges) {
         const mutableConfig = this.buildMutableOnlyConfig(config, currentInfo.config, diff);
 
-        return await jsm.streams.update(config.name, mutableConfig);
+        return await this.runStreamOp(ctx, () => jsm.streams.update(config.name, mutableConfig));
       }
 
       return currentInfo;
@@ -293,6 +335,46 @@ export class StreamProvider {
       } else {
         this.logger.log(`Stream ${streamName}: ${detail}`);
       }
+    }
+  }
+
+  private buildReservation(
+    kind: ReservationKind,
+    config: Partial<StreamConfig> & { name: string; subjects: string[] },
+  ): StreamReservation {
+    return {
+      kind,
+      name: config.name,
+      storage: config.storage ?? StorageType.File,
+      numReplicas: config.num_replicas ?? 1,
+      maxBytes: config.max_bytes ?? 0,
+      maxAge: config.max_age ?? 0,
+      retention: config.retention ?? RetentionPolicy.Limits,
+    };
+  }
+
+  private errorContext(
+    kind: ReservationKind,
+    config: Partial<StreamConfig> & { name: string },
+  ): ProvisioningErrorContext {
+    return {
+      entity: 'stream',
+      name: config.name,
+      kind,
+      maxBytes: config.max_bytes,
+      numReplicas: config.num_replicas ?? 1,
+    };
+  }
+
+  private async runStreamOp<T>(ctx: ProvisioningErrorContext, op: () => Promise<T>): Promise<T> {
+    try {
+      return await op();
+    } catch (err) {
+      if (err instanceof JetStreamApiError) {
+        throw mapProvisioningError(err, ctx);
+      }
+
+      throw err;
     }
   }
 

--- a/src/server/strategy.ts
+++ b/src/server/strategy.ts
@@ -54,76 +54,14 @@ export class JetstreamStrategy extends Server implements CustomTransportStrategy
    *
    * Called by NestJS when `connectMicroservice()` is used, or internally by the module.
    */
-  public async listen(callback: () => void): Promise<void> {
-    if (this.started) {
-      this.logger.warn('listen() called more than once — ignoring');
-
-      return;
+  public async listen(callback: (...args: unknown[]) => void): Promise<void> {
+    try {
+      await this.doListen(callback);
+    } catch (err) {
+      // NestJS bridges listen() via a callback — forward errors there so
+      // startAllMicroservices() rejects instead of leaving an unhandled rejection.
+      callback(err);
     }
-
-    this.started = true;
-
-    // 1. Register all NestJS handlers
-    this.patternRegistry.registerHandlers(this.getHandlers());
-
-    // 2. Determine which streams and durable consumers are needed
-    const { streams: streamKinds, durableConsumers: durableKinds } = this.resolveRequiredKinds();
-
-    if (streamKinds.length > 0) {
-      // 3. Ensure streams exist
-      await this.streamProvider.ensureStreams(streamKinds);
-
-      // 4. Ensure durable consumers exist (ordered consumers are ephemeral — skip)
-      if (durableKinds.length > 0) {
-        const consumers = await this.consumerProvider.ensureConsumers(durableKinds);
-
-        // 5. Populate shared ack_wait map from actual NATS consumer configs
-        this.populateAckWaitMap(consumers);
-
-        // 6. Update DLQ thresholds from actual NATS consumer configs
-        this.eventRouter.updateMaxDeliverMap(this.buildMaxDeliverMap(consumers));
-
-        // 7. Start durable message consumption
-        this.messageProvider.start(consumers);
-      }
-
-      // 8. Start ordered consumer if handlers are registered
-      if (this.patternRegistry.hasOrderedHandlers()) {
-        const orderedStreamName = this.streamProvider.getStreamName(StreamKind.Ordered);
-
-        await this.messageProvider.startOrdered(
-          orderedStreamName,
-          this.patternRegistry.getOrderedSubjects(),
-          this.options.ordered,
-        );
-      }
-
-      // 9. Start event router if any event-type handlers exist
-      if (
-        this.patternRegistry.hasEventHandlers() ||
-        this.patternRegistry.hasBroadcastHandlers() ||
-        this.patternRegistry.hasOrderedHandlers()
-      ) {
-        this.eventRouter.start();
-      }
-
-      // 10. Start RPC router if JetStream mode
-      if (isJetStreamRpcMode(this.options.rpc) && this.patternRegistry.hasRpcHandlers()) {
-        await this.rpcRouter.start();
-      }
-    }
-
-    // 11. Start Core RPC server if core mode
-    if (isCoreRpcMode(this.options.rpc) && this.patternRegistry.hasRpcHandlers()) {
-      await this.coreRpcServer.start();
-    }
-
-    // 12. Publish handler metadata to KV (non-critical — errors logged, not thrown)
-    if (this.metadataProvider && this.patternRegistry.hasMetadata()) {
-      await this.metadataProvider.publish(this.patternRegistry.getMetadataEntries());
-    }
-
-    callback();
   }
 
   /** Stop all consumers, routers, subscriptions, and metadata heartbeat. Called during shutdown. */
@@ -198,6 +136,78 @@ export class JetstreamStrategy extends Server implements CustomTransportStrategy
   /** Access the pattern registry (for module-level introspection). */
   public getPatternRegistry(): PatternRegistry {
     return this.patternRegistry;
+  }
+
+  private async doListen(callback: (...args: unknown[]) => void): Promise<void> {
+    if (this.started) {
+      this.logger.warn('listen() called more than once — ignoring');
+
+      return;
+    }
+
+    this.started = true;
+
+    // 1. Register all NestJS handlers
+    this.patternRegistry.registerHandlers(this.getHandlers());
+
+    // 2. Determine which streams and durable consumers are needed
+    const { streams: streamKinds, durableConsumers: durableKinds } = this.resolveRequiredKinds();
+
+    if (streamKinds.length > 0) {
+      // 3. Ensure streams exist
+      await this.streamProvider.ensureStreams(streamKinds);
+
+      // 4. Ensure durable consumers exist (ordered consumers are ephemeral — skip)
+      if (durableKinds.length > 0) {
+        const consumers = await this.consumerProvider.ensureConsumers(durableKinds);
+
+        // 5. Populate shared ack_wait map from actual NATS consumer configs
+        this.populateAckWaitMap(consumers);
+
+        // 6. Update DLQ thresholds from actual NATS consumer configs
+        this.eventRouter.updateMaxDeliverMap(this.buildMaxDeliverMap(consumers));
+
+        // 7. Start durable message consumption
+        this.messageProvider.start(consumers);
+      }
+
+      // 8. Start ordered consumer if handlers are registered
+      if (this.patternRegistry.hasOrderedHandlers()) {
+        const orderedStreamName = this.streamProvider.getStreamName(StreamKind.Ordered);
+
+        await this.messageProvider.startOrdered(
+          orderedStreamName,
+          this.patternRegistry.getOrderedSubjects(),
+          this.options.ordered,
+        );
+      }
+
+      // 9. Start event router if any event-type handlers exist
+      if (
+        this.patternRegistry.hasEventHandlers() ||
+        this.patternRegistry.hasBroadcastHandlers() ||
+        this.patternRegistry.hasOrderedHandlers()
+      ) {
+        this.eventRouter.start();
+      }
+
+      // 10. Start RPC router if JetStream mode
+      if (isJetStreamRpcMode(this.options.rpc) && this.patternRegistry.hasRpcHandlers()) {
+        await this.rpcRouter.start();
+      }
+    }
+
+    // 11. Start Core RPC server if core mode
+    if (isCoreRpcMode(this.options.rpc) && this.patternRegistry.hasRpcHandlers()) {
+      await this.coreRpcServer.start();
+    }
+
+    // 12. Publish handler metadata to KV (non-critical — errors logged, not thrown)
+    if (this.metadataProvider && this.patternRegistry.hasMetadata()) {
+      await this.metadataProvider.publish(this.patternRegistry.getMetadataEntries());
+    }
+
+    callback();
   }
 
   /** Determine which streams and durable consumers are needed. */

--- a/test/integration/metrics.spec.ts
+++ b/test/integration/metrics.spec.ts
@@ -315,12 +315,14 @@ describe('Metrics — integration', () => {
       // Given/When: emit one message so the stream has state worth observing
       await firstValueFrom(client.emit('orders.created', { id: 'p1' }));
 
-      // Wait for a poll cycle (intervalMs=100 + slack)
-      await waitForCondition(async () => {
-        const text = await register.metrics();
+      // Wait for the poll cycle that publishes the asserted stream gauge; that cycle
+      // also publishes the consumer gauges, so this avoids a stream/consumer race under load.
+      const streamGauge = new RegExp(
+        `^jetstream_stream_messages\\{stream="${streamName(serviceName, StreamKind.Event)}"\\}`,
+        'm',
+      );
 
-        return /^jetstream_consumer_num_ack_pending\{/m.test(text);
-      }, 5_000);
+      await waitForCondition(async () => streamGauge.test(await register.metrics()), 10_000);
 
       // Then
       const text = await register.metrics();

--- a/test/integration/nats-container.ts
+++ b/test/integration/nats-container.ts
@@ -1,4 +1,10 @@
-import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers';
+import {
+  GenericContainer,
+  Network,
+  StartedNetwork,
+  StartedTestContainer,
+  Wait,
+} from 'testcontainers';
 import { connect } from '@nats-io/transport-node';
 import { jetstreamManager } from '@nats-io/jetstream';
 
@@ -7,6 +13,18 @@ export const NATS_IMAGE = 'nats:2.14.1';
 export interface NatsContainerResult {
   container: StartedTestContainer;
   port: number;
+}
+
+export interface NatsClusterResult {
+  containers: StartedTestContainer[];
+  network: StartedNetwork;
+  port: number;
+  stop(): Promise<void>;
+}
+
+export interface NatsClusterOptions {
+  nodes?: number;
+  maxFileStoreBytes?: number;
 }
 
 const waitForNatsReady = async (port: number, timeoutMs = 30_000): Promise<void> => {
@@ -113,6 +131,115 @@ export const startNatsContainerWithFileStoreLimit = async (
   await waitForNatsReady(port);
 
   return { container, port };
+};
+
+/**
+ * Poll until the cluster can actually host a replicated stream with `expectedPeers`
+ * replicas — the real "cluster formed" signal. Creates a tiny probe stream and
+ * deletes it. Cluster gossip/RAFT election is slow, so timeouts are generous.
+ */
+const waitForClusterFormed = async (
+  port: number,
+  expectedPeers: number,
+  timeoutMs = 90_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  const probe = '_cluster_probe';
+
+  while (Date.now() < deadline) {
+    try {
+      const nc = await connect({ servers: [`nats://localhost:${port}`], timeout: 1_000 });
+      const jsm = await jetstreamManager(nc);
+
+      // small enough to fit even a 1 MiB max_file_store; replicates across peers
+      await jsm.streams.add({
+        name: probe,
+        subjects: [`${probe}.>`],
+        num_replicas: expectedPeers,
+        max_bytes: 64 * 1024,
+      });
+      await jsm.streams.delete(probe);
+      await nc.drain();
+
+      return;
+    } catch {
+      // peers not all healthy yet
+    }
+
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  throw new Error(
+    `NATS cluster on port ${port} did not form ${expectedPeers} peers within ${timeoutMs / 1_000}s`,
+  );
+};
+
+/**
+ * Start a multi-node NATS JetStream cluster on a shared Docker network.
+ * Each node runs in clustered mode with routes to every peer (`n0`,`n1`,...).
+ * Used to provoke placement failures (e.g. `num_replicas` unsatisfiable by peers).
+ *
+ * @returns Started containers, the shared network, node-0's mapped client port, and a `stop()`.
+ */
+export const startNatsCluster = async (
+  opts: NatsClusterOptions = {},
+): Promise<NatsClusterResult> => {
+  const nodeCount = opts.nodes ?? 3;
+  const aliases = Array.from({ length: nodeCount }, (_, i) => `n${i}`);
+  const maxFileStore = opts.maxFileStoreBytes ?? 5 * 1024 * 1024 * 1024;
+  const routes = aliases.map((a) => `nats-route://${a}:6222`).join(', ');
+  const network = await new Network().start();
+
+  const buildConf = (alias: string): string =>
+    [
+      `server_name: ${alias}`,
+      'jetstream {',
+      '  store_dir: /data',
+      `  max_file_store: ${maxFileStore}`,
+      '}',
+      'cluster {',
+      '  name: c1',
+      '  listen: 0.0.0.0:6222',
+      `  routes: [ ${routes} ]`,
+      '}',
+      '',
+    ].join('\n');
+
+  const containers: StartedTestContainer[] = [];
+
+  const stop = async (): Promise<void> => {
+    for (const c of containers) {
+      await c.stop().catch(() => undefined);
+    }
+
+    await network.stop().catch(() => undefined);
+  };
+
+  try {
+    for (const alias of aliases) {
+      const container = await new GenericContainer(NATS_IMAGE)
+        .withNetwork(network)
+        .withNetworkAliases(alias)
+        .withCopyContentToContainer([{ content: buildConf(alias), target: '/etc/nats/nats.conf' }])
+        .withCommand(['-c', '/etc/nats/nats.conf'])
+        .withExposedPorts(4222, 6222)
+        .withWaitStrategy(Wait.forLogMessage(/Server is ready/))
+        .start();
+
+      containers.push(container);
+    }
+
+    const [node0] = containers;
+    const port = node0!.getMappedPort(4222);
+
+    await waitForNatsReady(port);
+    await waitForClusterFormed(port, nodeCount);
+
+    return { containers, network, port, stop };
+  } catch (err) {
+    await stop();
+    throw err;
+  }
 };
 
 /**

--- a/test/integration/nats-container.ts
+++ b/test/integration/nats-container.ts
@@ -87,6 +87,35 @@ export const startNatsContainerWithFixedPort = async (
 };
 
 /**
+ * Start a NATS container whose JetStream file store is capped to `maxFileStoreBytes`.
+ * Used to provoke insufficient-storage provisioning failures deterministically.
+ */
+export const startNatsContainerWithFileStoreLimit = async (
+  maxFileStoreBytes: number,
+): Promise<NatsContainerResult> => {
+  const conf = [
+    'jetstream {',
+    '  store_dir: /data',
+    `  max_file_store: ${maxFileStoreBytes}`,
+    '}',
+    '',
+  ].join('\n');
+
+  const container = await new GenericContainer(NATS_IMAGE)
+    .withCopyContentToContainer([{ content: conf, target: '/etc/nats/nats.conf' }])
+    .withCommand(['-c', '/etc/nats/nats.conf'])
+    .withExposedPorts(4222)
+    .withWaitStrategy(Wait.forLogMessage(/Server is ready/))
+    .start();
+
+  const port = container.getMappedPort(4222);
+
+  await waitForNatsReady(port);
+
+  return { container, port };
+};
+
+/**
  * Restart a NATS container and wait for JetStream readiness.
  * Container filesystem (including JetStream store) persists across restarts.
  *

--- a/test/integration/nats-container.ts
+++ b/test/integration/nats-container.ts
@@ -185,6 +185,11 @@ export const startNatsCluster = async (
   opts: NatsClusterOptions = {},
 ): Promise<NatsClusterResult> => {
   const nodeCount = opts.nodes ?? 3;
+
+  if (nodeCount < 1) {
+    throw new Error('Cluster requires at least one node');
+  }
+
   const aliases = Array.from({ length: nodeCount }, (_, i) => `n${i}`);
   const maxFileStore = opts.maxFileStoreBytes ?? 5 * 1024 * 1024 * 1024;
   const routes = aliases.map((a) => `nats-route://${a}:6222`).join(', ');

--- a/test/integration/nats-container.ts
+++ b/test/integration/nats-container.ts
@@ -2,7 +2,7 @@ import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers';
 import { connect } from '@nats-io/transport-node';
 import { jetstreamManager } from '@nats-io/jetstream';
 
-export const NATS_IMAGE = 'nats:2.12.6';
+export const NATS_IMAGE = 'nats:2.14.1';
 
 export interface NatsContainerResult {
   container: StartedTestContainer;

--- a/test/integration/provisioning-cluster.spec.ts
+++ b/test/integration/provisioning-cluster.spec.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { Controller } from '@nestjs/common';
+import { EventPattern } from '@nestjs/microservices';
+
+import { JetstreamProvisioningError, NatsErrorCode } from '../../src';
+
+import { createTestApp, uniqueServiceName } from './helpers';
+import { startNatsCluster, type NatsClusterResult } from './nats-container';
+
+@Controller()
+class ClusterProvisioningController {
+  @EventPattern('order.created')
+  handleOrder(): void {}
+}
+
+describe('Provisioning error on a clustered NATS', () => {
+  let cluster: NatsClusterResult | undefined;
+
+  beforeAll(async () => {
+    // 3 nodes, each capped to 1 MiB file store — no peer can hold the default
+    // 5 GiB event stream with num_replicas: 3 → "no suitable peers for placement".
+    cluster = await startNatsCluster({ nodes: 3, maxFileStoreBytes: 1024 * 1024 });
+  }, 180_000);
+
+  afterAll(async () => {
+    await cluster?.stop();
+  });
+
+  it('should wrap the no-suitable-peers placement failure as JetstreamProvisioningError', async () => {
+    // Given: a replicated event stream that no peer has storage to place
+    const serviceName = uniqueServiceName();
+
+    // When: bootstrapping the microservice provisions the stream
+    let captured: unknown;
+
+    try {
+      const { app } = await createTestApp(
+        { name: serviceName, port: cluster!.port, events: { stream: { num_replicas: 3 } } },
+        [ClusterProvisioningController],
+      );
+
+      await app.close();
+    } catch (err) {
+      captured = err;
+    }
+
+    // Then: a real cluster returns 10005, distinct from a single node's 10074
+    expect(captured).toBeInstanceOf(JetstreamProvisioningError);
+
+    const provisioningErr = captured as JetstreamProvisioningError;
+
+    expect(provisioningErr.entity).toBe('stream');
+    expect(provisioningErr.errCode).toBe(NatsErrorCode.NoSuitablePeers);
+    expect(provisioningErr.errCode).toBe(10005);
+    expect(provisioningErr.message).toContain('no suitable peers for placement');
+  }, 120_000);
+});

--- a/test/integration/provisioning.spec.ts
+++ b/test/integration/provisioning.spec.ts
@@ -1,0 +1,54 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { Controller } from '@nestjs/common';
+import { EventPattern } from '@nestjs/microservices';
+import type { StartedTestContainer } from 'testcontainers';
+
+import { JetstreamProvisioningError } from '../../src';
+
+import { createTestApp, uniqueServiceName } from './helpers';
+import { startNatsContainerWithFileStoreLimit } from './nats-container';
+
+@Controller()
+class ProvisioningController {
+  @EventPattern('order.created')
+  handleOrder(): void {}
+}
+
+describe('Provisioning error clarity', () => {
+  let container: StartedTestContainer;
+  let port: number;
+
+  beforeAll(async () => {
+    // 1 MiB file store — far below the 5 GiB default event-stream max_bytes
+    ({ container, port } = await startNatsContainerWithFileStoreLimit(1024 * 1024));
+  });
+
+  afterAll(async () => {
+    await container.stop();
+  });
+
+  it('should throw a JetstreamProvisioningError (not a raw crash) on insufficient storage', async () => {
+    // Given: a service whose default streams exceed max_file_store
+    const serviceName = uniqueServiceName();
+
+    // When / Then: app boot fails with the wrapped, actionable error
+    let captured: unknown;
+
+    try {
+      const { app } = await createTestApp({ name: serviceName, port }, [ProvisioningController]);
+
+      await app.close();
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(JetstreamProvisioningError);
+
+    const provisioningErr = captured as JetstreamProvisioningError;
+
+    expect(provisioningErr.entity).toBe('stream');
+    expect(provisioningErr.message).toContain('max_file_store');
+    // Pin the real insufficient-storage err_code for NatsErrorCode.InsufficientResources
+    expect(provisioningErr.errCode).toBe(10047);
+  });
+});

--- a/test/integration/provisioning.spec.ts
+++ b/test/integration/provisioning.spec.ts
@@ -48,7 +48,7 @@ describe('Provisioning error clarity', () => {
 
     expect(provisioningErr.entity).toBe('stream');
     expect(provisioningErr.message).toContain('max_file_store');
-    // Pin the real insufficient-storage err_code for NatsErrorCode.InsufficientResources
+    // Pin the real insufficient-storage err_code for NatsErrorCode.StorageResourcesExceeded
     expect(provisioningErr.errCode).toBe(10047);
   });
 });

--- a/website/docs/guides/storage-budgeting.md
+++ b/website/docs/guides/storage-budgeting.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 6
+sidebar_label: "Storage budgeting"
+title: "Storage budgeting & provisioning — NestJS JetStream"
+description: "How JetStream stream reservations relate to the server max_file_store, and how to read the boot-time provisioning summary."
+schema:
+  type: Article
+  headline: "Storage budgeting & provisioning"
+  description: "How JetStream stream reservations relate to the server max_file_store, and how to read the boot-time provisioning summary."
+  datePublished: "2026-06-02"
+  dateModified: "2026-06-02"
+---
+
+# Storage budgeting & provisioning
+
+When your service starts, the transport ensures its JetStream streams exist. Each stream
+reserves storage up front, and that reservation is charged against a budget shared by **every
+service** on the cluster. This page explains the arithmetic and how to read the boot summary.
+
+## The arithmetic
+
+A stream reserves `max_bytes` **per replica**:
+
+```
+cluster reservation (one stream) = max_bytes × num_replicas
+per-node footprint (your service) ≈ Σ max_bytes   (worst case: replicas = nodes)
+```
+
+On a 3-node cluster with `num_replicas: 3`, every stream keeps a replica on every node, so each
+node must hold the **sum of `max_bytes`** across all your streams. With the library defaults
+(event 5 GiB + broadcast 2 GiB + ordered 5 GiB + DLQ 5 GiB) that is ~17 GiB **per node**.
+
+The NATS server's `max_file_store` is a **per-node** ceiling shared by all services. Provisioning
+fails when the sum of reservations across every service exceeds it.
+
+## The boot summary
+
+On startup the transport logs a summary at `INFO` (always on):
+
+```
+Provisioning 2 stream(s) for "orders":
+  • orders__microservice_ev-stream [ev] storage=file replicas=3 max_bytes=5.00 GiB max_age=7.0d retention=workqueue → cluster reservation 15.00 GiB
+  • broadcast-stream [broadcast] storage=file replicas=3 max_bytes=2.00 GiB max_age=1.0h retention=limits → cluster reservation 6.00 GiB
+  Σ per-node footprint ≈ 7.00 GiB (sum of max_bytes; worst case replicas = nodes). Ensure the NATS server max_file_store accommodates the sum across ALL services.
+```
+
+Read the `Σ per-node footprint` line first: that is what each node must accommodate from this
+service alone.
+
+## When provisioning fails
+
+If a stream cannot be created, the transport throws a `JetstreamProvisioningError` with the
+stream name, the requested `max_bytes`/`num_replicas`, the reservation, the NATS `err_code` and
+description, and a remediation hint — instead of crashing with an opaque API error. Two common
+cases:
+
+- **Insufficient storage** — the aggregate reservation exceeds `max_file_store`. Lower
+  `max_bytes`/`num_replicas` for the service, or raise `max_file_store` on the servers.
+- **No suitable peers** — fewer healthy peers than `num_replicas`, or no peer with enough
+  headroom. Reduce replicas or add/repair nodes.
+
+## Opt-in pre-flight check
+
+Set `provisioning.preflightStorageCheck: true` to have the transport query account limits via
+`getAccountInfo()` before provisioning and **warn** when this service's reservation would exceed
+the remaining budget:
+
+```ts
+JetstreamModule.forRoot({
+  name: 'orders',
+  servers: ['nats://localhost:4222'],
+  provisioning: { preflightStorageCheck: true },
+});
+```
+
+This is a best-effort heuristic, not a guarantee:
+
+- The server-side `max_file_store` is **not** exposed to clients. If the account has no explicit
+  `max_storage` limit, the check logs that it cannot verify the real ceiling.
+- Account info is an aggregate, not per-node, so a cluster with skewed placement can still fail.
+- It is subject to a check-then-act race with other services.
+
+Setting an **account-level** `max_storage` (in addition to, or instead of, the server
+`max_file_store`) makes the pre-flight accurate and admission control predictable. Either way, the
+`JetstreamProvisioningError` on the actual failure remains the source of truth.

--- a/website/docs/guides/storage-budgeting.md
+++ b/website/docs/guides/storage-budgeting.md
@@ -8,7 +8,7 @@ schema:
   headline: "Storage budgeting & provisioning"
   description: "How JetStream stream reservations relate to the server max_file_store, and how to read the boot-time provisioning summary."
   datePublished: "2026-06-02"
-  dateModified: "2026-06-02"
+  dateModified: "2026-06-03"
 ---
 
 # Storage budgeting & provisioning
@@ -21,7 +21,7 @@ service** on the cluster. This page explains the arithmetic and how to read the 
 
 A stream reserves `max_bytes` **per replica**:
 
-```
+```text
 cluster reservation (one stream) = max_bytes × num_replicas
 per-node footprint (your service) ≈ Σ max_bytes   (worst case: replicas = nodes)
 ```
@@ -37,15 +37,15 @@ fails when the sum of reservations across every service exceeds it.
 
 On startup the transport logs a summary at `INFO` (always on):
 
-```
+```text
 Provisioning 2 stream(s) for "orders":
   • orders__microservice_ev-stream [ev] storage=file replicas=3 max_bytes=5.00 GiB max_age=7.0d retention=workqueue → cluster reservation 15.00 GiB
   • broadcast-stream [broadcast] storage=file replicas=3 max_bytes=2.00 GiB max_age=1.0h retention=limits → cluster reservation 6.00 GiB
-  Σ per-node footprint ≈ 7.00 GiB (sum of max_bytes; worst case replicas = nodes). Ensure the NATS server max_file_store accommodates the sum across ALL services.
+  Σ per-node file-backed footprint ≈ 7.00 GiB (sum of max_bytes; worst case replicas = nodes). Ensure the NATS server max_file_store accommodates the sum across ALL services.
 ```
 
-Read the `Σ per-node footprint` line first: that is what each node must accommodate from this
-service alone.
+Read the `Σ per-node file-backed footprint` line first: that is what each node must accommodate
+from this service alone.
 
 ## When provisioning fails
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -49,6 +49,7 @@ const sidebars: SidebarsConfig = {
         'guides/dead-letter-queue',
         'guides/health-checks',
         'guides/graceful-shutdown',
+        'guides/storage-budgeting',
       ],
     },
     {

--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -159,6 +159,14 @@ export default function Root({ children }) {
   "dateModified": "2026-05-27"
 },
       
+    '/docs/guides/storage-budgeting/': {
+  "@type": "Article",
+  "headline": "Storage budgeting & provisioning",
+  "description": "How JetStream stream reservations relate to the server max_file_store, and how to read the boot-time provisioning summary.",
+  "datePublished": "2026-06-02",
+  "dateModified": "2026-06-02"
+},
+      
     '/docs/guides/stream-migration/': {
   "@type": "Article",
   "headline": "How to migrate immutable stream properties",

--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -164,7 +164,7 @@ export default function Root({ children }) {
   "headline": "Storage budgeting & provisioning",
   "description": "How JetStream stream reservations relate to the server max_file_store, and how to read the boot-time provisioning summary.",
   "datePublished": "2026-06-02",
-  "dateModified": "2026-06-02"
+  "dateModified": "2026-06-03"
 },
       
     '/docs/guides/stream-migration/': {


### PR DESCRIPTION
## Summary

Makes JetStream stream/consumer provisioning transparent and self-explanatory, so a storage/placement failure is diagnosable from the logs alone — without lowering defaults or adding retries.

- **Always-on boot summary** (INFO): per-stream storage reservation (`max_bytes × num_replicas` = cluster reservation) plus a per-node footprint line (`Σ max_bytes`, worst case replicas = nodes) and a note that the NATS server `max_file_store` must accommodate the sum across all services.
- **Actionable wrapped errors**: provisioning failures now throw a public `JetstreamProvisioningError` carrying the stream/consumer name, kind, requested `max_bytes`/`num_replicas`, computed reservation, NATS `err_code` + description, a targeted remediation hint, and the original error as `cause` — instead of crashing with a raw `JetStreamApiError`. Covers `streams.add`/`streams.update` and `consumers.add`/`consumers.update`.
- **Opt-in storage pre-flight** (`provisioning.preflightStorageCheck`, off by default): queries `getAccountInfo()` before provisioning and warns when this service's reservation would exceed the remaining account budget. Tier-aware (`tiers.R{n}`), warn-only, and degrades gracefully — it never throws or blocks boot. It is a heuristic (server `max_file_store` is not client-visible; account info is aggregate, not per-node), so the wrapped error on the actual failure remains authoritative.
- **OTel**: provisioning spans now carry reservation attributes (`max_bytes`, `num_replicas`, `reservation_bytes`).
- **Fix**: `JetstreamStrategy.listen()` now forwards listen-time errors through the NestJS callback so `startAllMicroservices()` rejects — previously a provisioning failure surfaced as an unhandled rejection that no caller could catch.
- **Chore**: NATS test container bumped to `2.14.1` (aligned with docker-compose).
- **Docs**: new "Storage budgeting & provisioning" guide.

Backward compatible: defaults unchanged, the only new public config is the additive opt-in `provisioning` option; `JetstreamProvisioningError` and `ProvisioningOptions` are newly exported.

## Test Plan

- [x] 684 unit tests pass (45 suites)
- [x] `tsc --noEmit` clean, `eslint` clean, `pnpm build` success
- [x] Integration test: tiny `max_file_store` (1 MiB) on real NATS 2.14.1 → `JetstreamProvisioningError` (`err_code` 10047, message contains `max_file_store`), not a raw crash
- [x] Integration sanity: smoke + infrastructure suites pass (normal boot path through the updated `strategy.listen`)
- [ ] CI full integration suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in preflight storage budget check (provisioning.preflightStorageCheck) — warn-only, non-blocking.
  * Richer, exported provisioning errors with remediation hints and reservation details.
  * Improved boot provisioning summary (per-stream cluster reservation and per-node footprint).
  * New provisioning-related telemetry attributes and exported ProvisioningOptions type.

* **Documentation**
  * Added storage budgeting guide explaining reservations, boot summary, and preflight behavior.

* **Bug Fixes**
  * Startup now surfaces provisioning failures reliably (mapped, descriptive errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->