### PR TITLE
fix(dlq): change Dead Letter Queue retention policy to Limits

### DIFF
--- a/src/jetstream.constants.ts
+++ b/src/jetstream.constants.ts
@@ -146,7 +146,7 @@ export const DEFAULT_ORDERED_STREAM_CONFIG: Partial<StreamConfig> = {
 /** Default config for dead-letter queue (DLQ) streams. */
 export const DEFAULT_DLQ_STREAM_CONFIG: Partial<StreamConfig> = {
   ...baseStreamConfig,
-  retention: RetentionPolicy.Workqueue,
+  retention: RetentionPolicy.Limits,
   allow_rollup_hdrs: false,
   max_consumers: 100,
   max_msg_size: 10 * MB,


### PR DESCRIPTION
Currently, our Dead Letter Queue (DLQ) streams are configured with the `WorkQueue` retention policy. At first, I thought this was fine because it successfully stores unacknowledged messages, but it completely breaks DLQ observability when using the NATS UI or standard CLI tools.

When attempting to view messages in the DLQ via the NATS UI, the server rejects the request and returns the following error:

`nats: API error: code=400 err_code=10101 description=consumer must be deliver all on workqueue stream`

By design, NATS JetStream enforces a strict constraint on `WorkQueue` streams: any consumer attached to it must be configured with the `DeliverAll` policy (it must consume destructively from the very beginning).

However, when we open the NATS UI to view messages, the interface attempts to create an ephemeral, paginated consumer to "peek" at a specific subset of messages (e.g., the last 10 messages). Because this ephemeral consumer requests a specific starting sequence rather than `DeliverAll`, the JetStream API immediately rejects the consumer creation request, resulting in the 400 error.

Setting the DLQ retention policy to `Limits` by default would make the library more practical to operate. It allows consumers to start from any sequence, enabling message inspection through standard observability and debugging tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Dead Letter Queue stream retention configuration to use limits-based retention policy, changing how messages are retained in DLQ streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->