### PR TITLE
fix(client): publish each scheduled message to a unique schedule subject

### DIFF
--- a/src/client/__tests__/jetstream.client.spec.ts
+++ b/src/client/__tests__/jetstream.client.spec.ts
@@ -314,12 +314,15 @@ describe(JetstreamClient, () => {
         // When: event emitted with schedule
         await firstValueFrom(sut.emit('order.reminder', record));
 
-        // Then: published to _sch namespace (not matched by consumer)
-        const expectedScheduleSubject = `${targetName}__microservice._sch.order.reminder`;
+        // Then: published to _sch namespace (not matched by consumer) with a
+        // per-message unique suffix — ADR-51 allows one active schedule per subject
+        const expectedScheduleSubject = new RegExp(
+          `^${targetName}__microservice\\._sch\\.order\\.reminder\\.[A-Za-z0-9]+$`,
+        );
         const expectedEventSubject = `${targetName}__microservice.ev.order.reminder`;
 
         expect(mockJs.publish).toHaveBeenCalledWith(
-          expectedScheduleSubject,
+          expect.stringMatching(expectedScheduleSubject),
           codec.encode(data),
           expect.objectContaining({
             schedule: {
@@ -339,12 +342,12 @@ describe(JetstreamClient, () => {
         // When: broadcast event emitted with schedule
         await firstValueFrom(sut.emit('broadcast:config.updated', record));
 
-        // Then: published to broadcast._sch namespace
-        const expectedScheduleSubject = 'broadcast._sch.config.updated';
+        // Then: published to broadcast._sch namespace with a unique suffix
+        const expectedScheduleSubject = /^broadcast\._sch\.config\.updated\.[A-Za-z0-9]+$/;
         const expectedBroadcastTarget = 'broadcast.config.updated';
 
         expect(mockJs.publish).toHaveBeenCalledWith(
-          expectedScheduleSubject,
+          expect.stringMatching(expectedScheduleSubject),
           codec.encode(data),
           expect.objectContaining({
             schedule: {
@@ -364,12 +367,14 @@ describe(JetstreamClient, () => {
         // When: ordered event emitted with schedule
         await firstValueFrom(sut.emit('ordered:order.status', record));
 
-        // Then: published to _sch namespace with ordered target
-        const expectedScheduleSubject = `${targetName}__microservice._sch.order.status`;
+        // Then: published to _sch namespace with ordered target and a unique suffix
+        const expectedScheduleSubject = new RegExp(
+          `^${targetName}__microservice\\._sch\\.order\\.status\\.[A-Za-z0-9]+$`,
+        );
         const expectedOrderedTarget = `${targetName}__microservice.ordered.order.status`;
 
         expect(mockJs.publish).toHaveBeenCalledWith(
-          expectedScheduleSubject,
+          expect.stringMatching(expectedScheduleSubject),
           codec.encode(data),
           expect.objectContaining({
             schedule: {
@@ -378,6 +383,23 @@ describe(JetstreamClient, () => {
             },
           }),
         );
+      });
+
+      it('should use a distinct schedule subject for each message of the same pattern', async () => {
+        // Given: two records scheduled on the same pattern
+        const futureDate = new Date(Date.now() + 60_000);
+        const recordA = new JetstreamRecordBuilder({ orderId: 1 }).scheduleAt(futureDate).build();
+        const recordB = new JetstreamRecordBuilder({ orderId: 2 }).scheduleAt(futureDate).build();
+
+        // When: both emitted while the first schedule would still be pending
+        await firstValueFrom(sut.emit('order.reminder', recordA));
+        await firstValueFrom(sut.emit('order.reminder', recordB));
+
+        // Then: each publish used its own schedule subject (no rollup replacement)
+        const subjects = mockJs.publish.mock.calls.map((call) => call[0]);
+
+        expect(subjects).toHaveLength(2);
+        expect(subjects[0]).not.toBe(subjects[1]);
       });
 
       it('should NOT include schedule in publish options when not set', async () => {

--- a/src/client/jetstream.client.ts
+++ b/src/client/jetstream.client.ts
@@ -781,13 +781,17 @@ export class JetstreamClient extends ClientProxy {
    * uses a separate `_sch` namespace that is NOT matched by any consumer filter.
    * NATS holds the message and publishes it to the target subject after the delay.
    *
+   * A unique per-message suffix is appended because the server stores schedules
+   * as rollup messages — one active schedule per subject (ADR-51). Without it,
+   * concurrent schedules of the same pattern would silently replace each other.
+   *
    * Examples:
-   * - `{svc}__microservice.ev.order.reminder` → `{svc}__microservice._sch.order.reminder`
-   * - `broadcast.config.updated` → `broadcast._sch.config.updated`
+   * - `{svc}__microservice.ev.order.reminder` → `{svc}__microservice._sch.order.reminder.<nuid>`
+   * - `broadcast.config.updated` → `broadcast._sch.config.updated.<nuid>`
    */
   private buildScheduleSubject(eventSubject: string): string {
     if (eventSubject.startsWith('broadcast.')) {
-      return eventSubject.replace('broadcast.', 'broadcast._sch.');
+      return `${eventSubject.replace('broadcast.', 'broadcast._sch.')}.${nuid.next()}`;
     }
 
     // For event/ordered subjects: {svc}__microservice.{kind}.{pattern}
@@ -808,6 +812,6 @@ export class JetstreamClient extends ClientProxy {
 
     const pattern = withoutPrefix.slice(dotIndex + 1);
 
-    return `${targetPrefix}_sch.${pattern}`;
+    return `${targetPrefix}_sch.${pattern}.${nuid.next()}`;
   }
 }

--- a/test/integration/otel-message-kinds.spec.ts
+++ b/test/integration/otel-message-kinds.spec.ts
@@ -183,7 +183,7 @@ describe('OTel message-kind attributes integration — broadcast, ordered, sched
       expect(publish).toBeDefined();
       expect(publish!.attributes['jetstream.schedule.target']).toMatch(/orders\.scheduled$/u);
       expect(publish!.attributes['messaging.destination.name']).toMatch(
-        /_sch\..*orders\.scheduled$/u,
+        /_sch\..*orders\.scheduled\.[A-Za-z0-9]+$/u,
       );
 
       // Consumer span sees the original subject after the broker redelivers

--- a/test/integration/scheduling.spec.ts
+++ b/test/integration/scheduling.spec.ts
@@ -3,10 +3,18 @@ import { Controller, INestApplication } from '@nestjs/common';
 import { ClientProxy, Ctx, EventPattern, Payload } from '@nestjs/microservices';
 import { TestingModule } from '@nestjs/testing';
 import type { NatsConnection } from '@nats-io/transport-node';
+import { jetstreamManager } from '@nats-io/jetstream';
 import { firstValueFrom } from 'rxjs';
 import type { StartedTestContainer } from 'testcontainers';
 
-import { getClientToken, JetstreamRecordBuilder, RpcContext } from '../../src';
+import {
+  getClientToken,
+  internalName,
+  JetstreamRecordBuilder,
+  RpcContext,
+  StreamKind,
+  streamName,
+} from '../../src';
 
 import {
   cleanupStreams,
@@ -281,8 +289,6 @@ describe('Message Scheduling (Delayed Jobs)', () => {
 
     it('should deliver all scheduled messages on different subjects', async () => {
       // Given: three messages scheduled at staggered delays on different subjects
-      // (NATS scheduling replaces previous schedule per _sch subject, so each
-      //  message uses a distinct event pattern to avoid replacement)
       const now = Date.now();
 
       const recordA = new JetstreamRecordBuilder({ orderId: 1 })
@@ -314,6 +320,93 @@ describe('Message Scheduling (Delayed Jobs)', () => {
       expect(receivedOrderIds).toContain(1);
       expect(receivedOrderIds).toContain(2);
       expect(receivedOrderIds).toContain(3);
+    });
+  });
+
+  describe('concurrent schedules of the same pattern', () => {
+    let app: INestApplication;
+    let module: TestingModule;
+    let client: ClientProxy;
+    let serviceName: string;
+    let controller: ScheduledEventController;
+
+    beforeEach(async () => {
+      serviceName = uniqueServiceName();
+
+      ({ app, module } = await createTestApp(
+        {
+          name: serviceName,
+          port,
+          events: {
+            stream: { allow_msg_schedules: true },
+          },
+        },
+        [ScheduledEventController],
+        [serviceName],
+      ));
+
+      client = module.get<ClientProxy>(getClientToken(serviceName));
+      controller = module.get(ScheduledEventController);
+    });
+
+    afterEach(async () => {
+      await app.close();
+      await cleanupStreams(nc, serviceName);
+    });
+
+    it('should deliver every pending schedule of the same pattern instead of replacing it', async () => {
+      // Given: three messages scheduled on the SAME pattern while earlier ones are pending.
+      // ADR-51 rollup semantics allow one active schedule per subject, so the schedule
+      // subject must be unique per message — otherwise only the last schedule survives.
+      const now = Date.now();
+
+      const records = [1, 2, 3].map((orderId) =>
+        new JetstreamRecordBuilder({ orderId }).scheduleAt(new Date(now + 2_000)).build(),
+      );
+
+      // When: emit all three before the first one fires
+      for (const record of records) {
+        await firstValueFrom(client.emit('order.reminder', record));
+      }
+
+      // Then: all three arrive
+      await waitForCondition(() => controller.received.length >= 3, 15_000);
+
+      const receivedOrderIds = controller.received.map((r) => (r as { orderId: number }).orderId);
+
+      expect(receivedOrderIds.toSorted((a, b) => a - b)).toEqual([1, 2, 3]);
+    });
+
+    it('should purge fired schedule messages so unique subjects do not accumulate', async () => {
+      // Given: two messages scheduled on the same pattern
+      const now = Date.now();
+
+      const records = [1, 2].map((orderId) =>
+        new JetstreamRecordBuilder({ orderId }).scheduleAt(new Date(now + 1_000)).build(),
+      );
+
+      for (const record of records) {
+        await firstValueFrom(client.emit('order.reminder', record));
+      }
+
+      // When: both schedules fire and are delivered
+      await waitForCondition(() => controller.received.length >= 2, 15_000);
+
+      // Then: the server self-purges one-shot @at schedule holders after firing,
+      // so per-message unique _sch subjects leave no residue in the workqueue stream
+      const jsm = await jetstreamManager(nc);
+      const stream = streamName(serviceName, StreamKind.Event);
+      const scheduleFilter = `${internalName(serviceName)}._sch.>`;
+
+      const countScheduleMessages = async (): Promise<number> => {
+        const info = await jsm.streams.info(stream, { subjects_filter: scheduleFilter });
+
+        return Object.values(info.state.subjects ?? {}).reduce((sum, n) => sum + n, 0);
+      };
+
+      await waitForCondition(async () => (await countScheduleMessages()) === 0, 10_000);
+
+      expect(await countScheduleMessages()).toBe(0);
     });
   });
 

--- a/website/docs/guides/scheduling.md
+++ b/website/docs/guides/scheduling.md
@@ -8,7 +8,7 @@ schema:
   headline: "How to schedule delayed messages with NestJS JetStream"
   description: "One-shot delayed message delivery via the Nats-Schedule header (NATS 2.12, ADR-51)."
   datePublished: "2026-04-01"
-  dateModified: "2026-05-27"
+  dateModified: "2026-06-10"
 ---
 
 import Since from '@site/src/components/Since';
@@ -70,15 +70,15 @@ handleReminder(@Payload() data: OrderReminder) {
 ## How it works
 
 1. `scheduleAt(date)` stores the delivery time in the record
-2. On publish, the library routes to a `_sch` subject within the event stream (a library convention to separate scheduled messages from regular events)
-3. The publish includes `Nats-Schedule` and `Nats-Schedule-Target` headers ([ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md)) — the server uses these headers, not the subject, to manage scheduling
-4. NATS holds the message until the scheduled time, then publishes a **new message** to the target event subject
+2. On publish, the library routes to a per-message unique `_sch` subject within the event stream (a library convention to separate scheduled messages from regular events). The unique suffix matters: the server stores schedules as rollup messages — one active schedule per subject ([ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md)) — so a shared subject would silently replace a pending schedule on every publish
+3. The publish includes `Nats-Schedule` and `Nats-Schedule-Target` headers (ADR-51) — the server uses these headers, not the subject, to manage scheduling
+4. NATS holds the message until the scheduled time, then publishes a **new message** to the target event subject and purges the fired schedule holder, so unique `_sch` subjects do not accumulate
 5. The event consumer processes it normally
 
 ```mermaid
 flowchart LR
     subgraph stream["Event stream"]
-        sch["{svc}._sch.order.reminder"]
+        sch["{svc}._sch.order.reminder.&lt;id&gt;"]
         ev["{svc}.ev.order.reminder"]
     end
 

--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -156,7 +156,7 @@ export default function Root({ children }) {
   "headline": "How to schedule delayed messages with NestJS JetStream",
   "description": "One-shot delayed message delivery via the Nats-Schedule header (NATS 2.12, ADR-51).",
   "datePublished": "2026-04-01",
-  "dateModified": "2026-05-27"
+  "dateModified": "2026-06-10"
 },
       
     '/docs/guides/stream-migration/': {


### PR DESCRIPTION
## Problem

`client.emit(pattern, payload).scheduleAt(date)` silently dropped concurrent scheduled messages of the same event pattern. When a second message was scheduled while a previous schedule of the same pattern was still pending, only the last one survived — no error, no warning, no DLQ entry.

**Root cause:** the schedule subject was derived deterministically from the event pattern (`{svc}__microservice._sch.<pattern>`), so every scheduled message of a given pattern landed on one shared subject. Per [ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md), the server stores schedules as rollup messages (`Nats-Rollup: sub` is auto-applied) — a subject holds at most one active schedule, so each new schedule purged the previous one.

Reported with a production incident: hourly-delayed analytics events were wiped by every subsequent purchase notification, effectively never firing during active traffic.

## Fix

Append a per-message NUID suffix to the schedule subject, exactly as ADR-51 recommends:

```
{svc}__microservice._sch.order.reminder.<nuid>
broadcast._sch.config.updated.<nuid>
```

- No stream config changes needed — streams already subscribe to the `_sch.>` wildcard.
- No garbage accumulation — the server purges one-shot `@at` schedule holders after firing (verified by an integration test, not just docs).
- `Nats-Schedule-Target` still carries the real event subject, so consumer routing is unaffected.
- `Nats-Msg-Id` deduplication is stream-level, so it keeps working across unique subjects (existing test still passes).

## Tests (TDD)

- **New e2e:** three `scheduleAt()` of the same pattern while earlier ones are pending → all three delivered (reproduced the data loss on the old code before the fix).
- **New e2e:** fired schedule holders leave no residue on `_sch.>` subjects.
- **New unit:** two scheduled publishes of one pattern use distinct subjects; existing subject-shape assertions updated to the new contract.
- Full suite: 804/804 passing.

## Docs

Updated the scheduling guide ("How it works" + mermaid diagram) to document the per-message unique `_sch` subject and why it is required by ADR-51 rollup semantics.