### PR TITLE
fix: close silent data-loss and reliability gaps across the transport

### DIFF
--- a/src/client/__tests__/jetstream.client.spec.ts
+++ b/src/client/__tests__/jetstream.client.spec.ts
@@ -956,6 +956,35 @@ describe(JetstreamClient, () => {
     });
   });
 
+  describe('duplicate publish detection (JetStream RPC mode)', () => {
+    beforeEach(async () => {
+      vi.useFakeTimers();
+
+      options.rpc = { mode: 'jetstream' };
+      sut = new JetstreamClient(options, targetName, connection, codec, eventBus);
+      await sut.connect();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should fail fast when the command publish is deduplicated by the stream', async () => {
+      // Given: the stream reports the publish as a duplicate — the original
+      // command owns the reply, this correlation id will never receive one
+      mockJs.publish.mockResolvedValue(createMock<PubAck>({ duplicate: true, seq: 5 }));
+
+      // When: sending an RPC whose messageId was already used
+      const result = firstValueFrom(sut.send('rpc.dup', {}));
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Then: rejected immediately instead of hanging until the RPC timeout
+      await vi.advanceTimersByTimeAsync(DEFAULT_JETSTREAM_RPC_TIMEOUT);
+      await expect(result).rejects.toThrow(/duplicate/i);
+    });
+  });
+
   describe('disconnect handling (JetStream RPC mode)', () => {
     beforeEach(async () => {
       vi.useFakeTimers();

--- a/src/client/__tests__/jetstream.client.spec.ts
+++ b/src/client/__tests__/jetstream.client.spec.ts
@@ -976,12 +976,14 @@ describe(JetstreamClient, () => {
 
       // When: sending an RPC whose messageId was already used
       const result = firstValueFrom(sut.send('rpc.dup', {}));
+      // Attach the expectation before the rejection settles
+      const assertion = expect(result).rejects.toThrow(/duplicate/i);
 
       await vi.advanceTimersByTimeAsync(0);
 
       // Then: rejected immediately instead of hanging until the RPC timeout
       await vi.advanceTimersByTimeAsync(DEFAULT_JETSTREAM_RPC_TIMEOUT);
-      await expect(result).rejects.toThrow(/duplicate/i);
+      await assertion;
     });
   });
 

--- a/src/client/__tests__/jetstream.client.spec.ts
+++ b/src/client/__tests__/jetstream.client.spec.ts
@@ -385,6 +385,29 @@ describe(JetstreamClient, () => {
         );
       });
 
+      it('should apply ttl to the delivered message, not the schedule holder', async () => {
+        // Given: a scheduled record with a per-message TTL
+        const data = { orderId: faker.number.int() };
+        const futureDate = new Date(Date.now() + 60_000);
+        const record = new JetstreamRecordBuilder(data)
+          .scheduleAt(futureDate)
+          .ttl(30 * 1_000_000_000)
+          .build();
+
+        // When: event emitted with schedule + ttl
+        await firstValueFrom(sut.emit('order.reminder', record));
+
+        // Then: ttl rides on the schedule (Nats-Schedule-TTL) — a top-level ttl
+        // would become Nats-TTL on the holder and cancel the schedule on expiry
+        const publishOpts = mockJs.publish.mock.calls[0]![2]!;
+
+        expect(publishOpts.ttl).toBeUndefined();
+        expect(publishOpts.schedule).toMatchObject({
+          specification: futureDate,
+          ttl: '30s',
+        });
+      });
+
       it('should use a distinct schedule subject for each message of the same pattern', async () => {
         // Given: two records scheduled on the same pattern
         const futureDate = new Date(Date.now() + 60_000);

--- a/src/client/__tests__/jetstream.client.spec.ts
+++ b/src/client/__tests__/jetstream.client.spec.ts
@@ -358,31 +358,20 @@ describe(JetstreamClient, () => {
         );
       });
 
-      it('should publish ordered schedule to _sch subject with ordered target', async () => {
-        // Given: ordered event with schedule
+      it('should reject scheduleAt for ordered patterns', async () => {
+        // Given: ordered event with schedule — the schedule holder would land
+        // in the event stream while the target lives in the ordered stream,
+        // which the server rejects (schedule target must share the stream)
         const data = { status: faker.lorem.word() };
         const futureDate = new Date(Date.now() + 60_000);
         const record = new JetstreamRecordBuilder(data).scheduleAt(futureDate).build();
 
-        // When: ordered event emitted with schedule
-        await firstValueFrom(sut.emit('ordered:order.status', record));
-
-        // Then: published to _sch namespace with ordered target and a unique suffix
-        const expectedScheduleSubject = new RegExp(
-          `^${targetName}__microservice\\._sch\\.order\\.status\\.[A-Za-z0-9]+$`,
+        // When/Then: emit rejects with a descriptive error, nothing is published
+        await expect(firstValueFrom(sut.emit('ordered:order.status', record))).rejects.toThrow(
+          /scheduleAt.*ordered/i,
         );
-        const expectedOrderedTarget = `${targetName}__microservice.ordered.order.status`;
 
-        expect(mockJs.publish).toHaveBeenCalledWith(
-          expect.stringMatching(expectedScheduleSubject),
-          codec.encode(data),
-          expect.objectContaining({
-            schedule: {
-              specification: futureDate,
-              target: expectedOrderedTarget,
-            },
-          }),
-        );
+        expect(mockJs.publish).not.toHaveBeenCalled();
       });
 
       it('should apply ttl to the delivered message, not the schedule holder', async () => {

--- a/src/client/__tests__/jetstream.record.spec.ts
+++ b/src/client/__tests__/jetstream.record.spec.ts
@@ -300,6 +300,17 @@ describe(JetstreamRecordBuilder, () => {
           expect(() => sut.setHeader(header, 'value')).toThrow(/reserved/i);
         },
       );
+
+      it.each(['Nats-Rollup', 'Nats-TTL', 'Nats-Msg-Id', 'Nats-Schedule', 'nats-expected-stream'])(
+        'should reject the NATS server control header %s',
+        (header) => {
+          // Nats-* headers drive server behavior: Nats-Rollup purges every
+          // pending message on the subject, Nats-TTL expires the message,
+          // Nats-Msg-Id is owned by setMessageId(). All of them have dedicated
+          // builder APIs or are not meant to be set on application messages.
+          expect(() => sut.setHeader(header, 'value')).toThrow(/reserved/i);
+        },
+      );
     });
 
     describe('when setting reserved headers via setHeaders()', () => {

--- a/src/client/jetstream.client.ts
+++ b/src/client/jetstream.client.ts
@@ -275,15 +275,18 @@ export class JetstreamClient extends ClientProxy {
           };
 
           if (schedule) {
+            // ttl belongs to the delivered message (Nats-Schedule-TTL). As a
+            // top-level option it would become Nats-TTL on the schedule holder
+            // and cancel the schedule once it elapses.
             const ack = await this.connection
               .getJetStreamClient()
               .publish(publishSubject, encoded, {
                 headers: msgHeaders,
                 msgID: effectiveMsgId,
-                ttl,
                 schedule: {
                   specification: schedule.at,
                   target: eventSubject,
+                  ttl,
                 },
               });
 

--- a/src/client/jetstream.client.ts
+++ b/src/client/jetstream.client.ts
@@ -566,12 +566,24 @@ export class JetstreamClient extends ClientProxy {
       // Run the publish under the CLIENT span's context so any handler /
       // interceptor spans around the publish itself nest under the CLIENT
       // round-trip span rather than the ambient context.
-      await context.with(spanHandle.activeContext, () =>
+      const ack = await context.with(spanHandle.activeContext, () =>
         this.connection.getJetStreamClient().publish(subject, encoded, {
           headers: hdrs,
           msgID: messageId ?? nuid.next(),
         }),
       );
+
+      if (ack.duplicate) {
+        // The stream dropped this publish as a duplicate (messageId reused
+        // within the dedup window). The original command owns the reply — this
+        // correlation id will never receive one, so fail now instead of
+        // burning the full RPC timeout.
+        throw new Error(
+          `Duplicate RPC publish for ${subject}: the messageId was already used within the ` +
+            'stream dedup window, so the reply belongs to the original request',
+        );
+      }
+
       // Publish leg succeeded; RpcCompleted fires from the inbox reply or
       // the timeout branch once the round-trip settles.
       this.reportPublished(declaredPattern, StreamKind.Command, startedAt, 'success');

--- a/src/client/jetstream.client.ts
+++ b/src/client/jetstream.client.ts
@@ -231,6 +231,19 @@ export class JetstreamClient extends ClientProxy {
     if (!this.readyForPublish) await this.connect();
     const { data, hdrs, messageId, schedule, ttl } = this.extractRecordData(packet.data);
 
+    const publishKind = detectEventKind(packet.pattern);
+
+    if (schedule && publishKind === PublishKind.Ordered) {
+      // The schedule holder lives in the event stream's _sch namespace, but the
+      // target subject belongs to the ordered stream — the server requires the
+      // schedule target to be a subject of the same stream, so this can never
+      // be delivered. Fail loudly instead of dropping the message.
+      throw new Error(
+        `scheduleAt() is not supported for ordered events (pattern: ${packet.pattern}). ` +
+          'Scheduled delivery is available for workqueue events and broadcasts.',
+      );
+    }
+
     const eventSubject = this.buildEventSubject(packet.pattern);
     // Replace kind segment with _sch: {svc}.ev.{pattern} → {svc}._sch.{pattern}
     // For broadcast: broadcast.{pattern} → broadcast._sch.{pattern}
@@ -241,7 +254,6 @@ export class JetstreamClient extends ClientProxy {
     const record =
       packet.data instanceof JetstreamRecord ? packet.data : new JetstreamRecord(data, new Map());
 
-    const publishKind = detectEventKind(packet.pattern);
     const declaredPattern = declaredEventPattern(packet.pattern);
     const streamKind = eventStreamKind(publishKind);
     const startedAt = performance.now();

--- a/src/client/jetstream.record.ts
+++ b/src/client/jetstream.record.ts
@@ -1,5 +1,5 @@
 import type { ScheduleRecordOptions } from '../interfaces';
-import { RESERVED_HEADERS } from '../jetstream.constants';
+import { NATS_CONTROL_HEADER_PREFIX, RESERVED_HEADERS } from '../jetstream.constants';
 
 /**
  * Immutable message record for JetStream transport.
@@ -208,7 +208,17 @@ export class JetstreamRecordBuilder<TData = unknown> {
    * lockstep. `RESERVED_HEADERS` is defined as an all-lowercase set.
    */
   private validateHeaderKey(key: string): void {
-    if (RESERVED_HEADERS.has(key.toLowerCase())) {
+    const normalized = key.toLowerCase();
+
+    if (normalized.startsWith(NATS_CONTROL_HEADER_PREFIX)) {
+      throw new Error(
+        `Header "${key}" is reserved for the NATS server and cannot be set manually. ` +
+          'Use setMessageId() for deduplication, ttl() for per-message expiry, ' +
+          'and scheduleAt() for delayed delivery.',
+      );
+    }
+
+    if (RESERVED_HEADERS.has(normalized)) {
       throw new Error(
         `Header "${key}" is reserved by the JetStream transport and cannot be set manually. ` +
           `Reserved headers: ${[...RESERVED_HEADERS].join(', ')}`,

--- a/src/codec/__tests__/json.codec.spec.ts
+++ b/src/codec/__tests__/json.codec.spec.ts
@@ -26,6 +26,22 @@ describe(JsonCodec, () => {
       });
     });
 
+    describe('when encoding undefined (void handler results, payload-less emits)', () => {
+      it('should roundtrip undefined through an empty payload', () => {
+        // Given/When: undefined encoded and decoded back
+        const encoded = sut.encode(undefined);
+        const decoded = sut.decode(encoded);
+
+        // Then: empty wire payload, decodes back to undefined instead of throwing
+        expect(encoded).toHaveLength(0);
+        expect(decoded).toBeUndefined();
+      });
+
+      it('should decode an empty payload from a foreign publisher as undefined', () => {
+        expect(sut.decode(new Uint8Array(0))).toBeUndefined();
+      });
+    });
+
     describe('when encoding primitives', () => {
       it.each([
         ['string', faker.lorem.word()],

--- a/src/codec/__tests__/msgpack.codec.spec.ts
+++ b/src/codec/__tests__/msgpack.codec.spec.ts
@@ -82,8 +82,21 @@ describe(MsgpackCodec, () => {
       };
       const sut = new MsgpackCodec(packr);
 
+      // When + Then: non-empty input — empty payloads short-circuit to undefined
+      expect(() => sut.decode(new Uint8Array([0x91]))).toThrow('truncated frame');
+    });
+
+    it('should decode an empty payload as undefined without calling unpack', () => {
+      // Given
+      const packr: PackrLike = {
+        pack: vi.fn(),
+        unpack: vi.fn(),
+      };
+      const sut = new MsgpackCodec(packr);
+
       // When + Then
-      expect(() => sut.decode(new Uint8Array())).toThrow('truncated frame');
+      expect(sut.decode(new Uint8Array(0))).toBeUndefined();
+      expect(packr.unpack).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/codec/json.codec.ts
+++ b/src/codec/json.codec.ts
@@ -18,10 +18,16 @@ const decoder = new TextDecoder();
  */
 export class JsonCodec implements Codec {
   public encode(data: unknown): Uint8Array {
+    // JSON.stringify(undefined) returns undefined, which TextEncoder turns
+    // into an empty payload — the symmetric decode() guard restores it.
     return encoder.encode(JSON.stringify(data));
   }
 
   public decode(data: Uint8Array): unknown {
+    // Empty payloads come from void handler replies, payload-less emits, and
+    // foreign publishers. JSON.parse('') would throw on all of them.
+    if (data.length === 0) return undefined;
+
     return JSON.parse(decoder.decode(data));
   }
 }

--- a/src/codec/msgpack.codec.ts
+++ b/src/codec/msgpack.codec.ts
@@ -48,6 +48,10 @@ export class MsgpackCodec implements Codec {
   }
 
   public decode(data: Uint8Array): unknown {
+    // Mirror JsonCodec: empty payloads (payload-less emits from foreign
+    // publishers) decode to undefined instead of throwing.
+    if (data.length === 0) return undefined;
+
     return this.packr.unpack(data);
   }
 }

--- a/src/interfaces/routing.interface.ts
+++ b/src/interfaces/routing.interface.ts
@@ -43,8 +43,11 @@ export interface DeadLetterConfig {
    * Used to detect when a message from a given stream has exhausted all delivery attempts.
    */
   maxDeliverByStream: Map<string, number>;
-  /** Async callback invoked when a message exhausts all deliveries. */
-  onDeadLetter(info: DeadLetterInfo): Promise<void>;
+  /**
+   * Async callback invoked when a message exhausts all deliveries.
+   * Optional: in dlq-only mode dead letters go to the DLQ stream without a callback.
+   */
+  onDeadLetter?(info: DeadLetterInfo): Promise<void>;
 }
 
 /** Options for configuring RPC processing behavior. */

--- a/src/jetstream.constants.ts
+++ b/src/jetstream.constants.ts
@@ -265,6 +265,14 @@ export const RESERVED_HEADERS = new Set<string>([
 ]);
 
 /**
+ * Lowercase prefix of NATS server control headers (Nats-Msg-Id, Nats-TTL,
+ * Nats-Rollup, Nats-Schedule-*, Nats-Expected-*). These drive server-side
+ * behavior — a stray Nats-Rollup purges every pending message on the
+ * subject — so they are managed exclusively through builder APIs.
+ */
+export const NATS_CONTROL_HEADER_PREFIX = 'nats-';
+
+/**
  * Build the internal service name with microservice suffix.
  *
  * @param name - Service name from `forRoot({ name })`.

--- a/src/jetstream.module.ts
+++ b/src/jetstream.module.ts
@@ -388,12 +388,15 @@ export class JetstreamModule implements OnApplicationShutdown {
         ): EventRouter | null => {
           if (options.consumer === false) return null;
 
-          const deadLetterConfig: DeadLetterConfig | undefined = options.onDeadLetter
-            ? {
-                maxDeliverByStream: new Map(),
-                onDeadLetter: options.onDeadLetter,
-              }
-            : undefined;
+          // Dead-letter detection is needed for both capture mechanisms:
+          // the DLQ stream (options.dlq) and the onDeadLetter callback.
+          const deadLetterConfig: DeadLetterConfig | undefined =
+            options.onDeadLetter || options.dlq
+              ? {
+                  maxDeliverByStream: new Map(),
+                  onDeadLetter: options.onDeadLetter,
+                }
+              : undefined;
 
           const processingConfig: EventProcessingConfig = {
             events: {

--- a/src/server/__tests__/strategy.spec.ts
+++ b/src/server/__tests__/strategy.spec.ts
@@ -104,6 +104,25 @@ describe(JetstreamStrategy, () => {
     });
   });
 
+  describe('startup ordering', () => {
+    it('should subscribe routers before starting consumption', async () => {
+      // Given: event handlers exist, so a durable consumer will be started
+      patternRegistry.hasEventHandlers.mockReturnValue(true);
+
+      // When: transport starts
+      await sut.listen(vi.fn());
+
+      // Then: the router observes the message subjects before the consumer
+      // begins delivering — consumers flush pending backlog immediately, and
+      // a Subject with no observers drops messages silently
+      expect(eventRouter.start).toHaveBeenCalled();
+      expect(messageProvider.start).toHaveBeenCalled();
+      expect(eventRouter.start.mock.invocationCallOrder[0]!).toBeLessThan(
+        messageProvider.start.mock.invocationCallOrder[0]!,
+      );
+    });
+  });
+
   describe('metadata publishing', () => {
     it('should publish metadata when handlers have meta', async () => {
       // Given: pattern registry has metadata

--- a/src/server/infrastructure/__tests__/stream-migration.spec.ts
+++ b/src/server/infrastructure/__tests__/stream-migration.spec.ts
@@ -26,8 +26,14 @@ describe(StreamMigration.name, () => {
     num_replicas: 1,
   };
 
+  /** A drained source entry as the server reports it after a full sync. */
+  const drainedSources = [
+    { name: testStreamName, lag: 0, active: 1_000 },
+    { name: backupStreamName, lag: 0, active: 1_000 },
+  ];
+
   const buildMockJsm = (messageCount: number): JetStreamManager => {
-    const mockInfo = createMock<StreamInfo>({
+    const streamInfo = createMock<StreamInfo>({
       config: {
         name: testStreamName,
         storage: StorageType.File,
@@ -36,37 +42,46 @@ describe(StreamMigration.name, () => {
         num_replicas: 1,
       } as StreamConfig,
       state: { messages: messageCount } as StreamInfo['state'],
+      sources: drainedSources,
     });
 
-    let infoCallCount = 0;
+    let backupExists = false;
 
     return createMock<JetStreamManager>({
       streams: {
         info: vi.fn().mockImplementation(async (name: string) => {
           if (name === backupStreamName) {
-            // Orphan check — not found (first call), subsequent: has messages
-            if (infoCallCount++ === 0) {
-              throw streamNotFoundError;
-            }
+            if (!backupExists) throw streamNotFoundError;
 
-            return {
-              ...mockInfo,
-              config: { ...mockInfo.config, name },
-              state: { messages: messageCount },
-            };
+            return createMock<StreamInfo>({
+              config: {
+                name: backupStreamName,
+                sources: [{ name: testStreamName }],
+              } as unknown as StreamConfig,
+              state: { messages: messageCount } as StreamInfo['state'],
+              sources: drainedSources,
+            });
           }
 
-          return mockInfo;
+          return streamInfo;
         }),
-        add: vi.fn().mockResolvedValue(mockInfo),
-        update: vi.fn().mockResolvedValue(mockInfo),
-        delete: vi.fn().mockResolvedValue(true),
+        add: vi.fn().mockImplementation(async (config: StreamConfig) => {
+          if (config.name === backupStreamName) backupExists = true;
+
+          return createMock<StreamInfo>();
+        }),
+        update: vi.fn().mockResolvedValue(createMock<StreamInfo>()),
+        delete: vi.fn().mockImplementation(async (name: string) => {
+          if (name === backupStreamName) backupExists = false;
+
+          return true;
+        }),
       },
     });
   };
 
   describe('empty stream', () => {
-    it('should delete and create without sourcing', async () => {
+    it('should quiesce, then delete and create without sourcing', async () => {
       // Given
       const sut = new StreamMigration();
       const jsm = buildMockJsm(0);
@@ -74,17 +89,21 @@ describe(StreamMigration.name, () => {
       // When
       await sut.migrate(jsm, testStreamName, newConfig);
 
-      // Then: delete + create, no backup sourcing
+      // Then: intake stopped before the count snapshot
+      const firstUpdate = vi.mocked(jsm.streams.update).mock.calls[0]!;
+
+      expect(firstUpdate[0]).toBe(testStreamName);
+      expect(firstUpdate[1]).toMatchObject({ subjects: [] });
+
+      // And: delete + create, no backup sourcing
       expect(jsm.streams.delete).toHaveBeenCalledWith(testStreamName);
       expect(jsm.streams.add).toHaveBeenCalledWith(newConfig);
-
-      // No backup stream created (only the new stream via add)
       expect(jsm.streams.add).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('stream with messages', () => {
-    it('should create backup, delete, create new, restore, cleanup', async () => {
+    it('should quiesce, back up, delete, create new, restore, cleanup', async () => {
       // Given
       const sut = new StreamMigration();
       const jsm = buildMockJsm(100);
@@ -92,61 +111,69 @@ describe(StreamMigration.name, () => {
       // When
       await sut.migrate(jsm, testStreamName, newConfig);
 
-      // Then: Phase 1 — backup created with sources
+      // Then: backup created with sources and the migration metadata stamp
       const addCalls = vi.mocked(jsm.streams.add).mock.calls;
 
       expect(addCalls[0]![0]).toMatchObject({
         name: backupStreamName,
         subjects: [],
+        sources: [{ name: testStreamName }],
       });
+      expect(
+        (addCalls[0]![0] as StreamConfig).metadata?.['nestjs-jetstream-migration-started-at'],
+      ).toBeDefined();
 
-      // Phase 2 — delete original
+      // And: original deleted, new stream created
       expect(jsm.streams.delete).toHaveBeenCalledWith(testStreamName);
-
-      // Phase 3 — create new
       expect(addCalls[1]![0]).toMatchObject(newConfig);
 
-      // Phase 4 — restore via sources, then remove sources, then delete backup
-      expect(jsm.streams.update).toHaveBeenCalled();
+      // And: restored from the backup, backup removed
       expect(jsm.streams.delete).toHaveBeenCalledWith(backupStreamName);
     });
-  });
 
-  describe('orphaned backup cleanup', () => {
-    it('should delete orphaned backup before starting migration', async () => {
-      // Given: backup stream exists from previous failed migration
+    it('should clear backup sources before restore to prevent a sourcing cycle', async () => {
+      // Given
       const sut = new StreamMigration();
-      const jsm = buildMockJsm(0);
-
-      // Override: backup exists on first info call
-      vi.mocked(jsm.streams.info).mockImplementation(async (name: string) => {
-        if (name === backupStreamName) {
-          return createMock<StreamInfo>({ state: { messages: 0 } as StreamInfo['state'] });
-        }
-
-        return createMock<StreamInfo>({
-          state: { messages: 0 } as StreamInfo['state'],
-          config: { name: testStreamName } as StreamConfig,
-        });
-      });
+      const jsm = buildMockJsm(100);
 
       // When
       await sut.migrate(jsm, testStreamName, newConfig);
 
-      // Then: backup deleted before migration
-      const deleteCalls = vi.mocked(jsm.streams.delete).mock.calls.map((c) => c[0]);
+      // Then: updates ordered quiesce → clear backup sources → attach restore
+      const updateCalls = vi.mocked(jsm.streams.update).mock.calls;
 
-      expect(deleteCalls).toContain(backupStreamName);
+      expect(updateCalls[0]![0]).toBe(testStreamName);
+      expect(updateCalls[0]![1]).toMatchObject({ subjects: [] });
+
+      expect(updateCalls[1]![0]).toBe(backupStreamName);
+      expect(updateCalls[1]![1]).toMatchObject({ sources: [] });
+
+      expect(updateCalls[2]![0]).toBe(testStreamName);
+      expect(updateCalls[2]![1]).toMatchObject({ sources: [{ name: backupStreamName }] });
     });
-  });
 
-  describe('Phase 2 failure (delete original fails)', () => {
-    it('should cleanup backup and rethrow when delete original throws', async () => {
-      // Given: stream with 100 messages, backup successfully created
+    it('should delete the backup before detaching the restore source', async () => {
+      // The surviving order is what makes interrupted-restore recovery safe:
+      // "backup present with no source attached" can only mean the restore
+      // never started.
       const sut = new StreamMigration();
       const jsm = buildMockJsm(100);
 
-      // Override: delete throws on original stream name
+      await sut.migrate(jsm, testStreamName, newConfig);
+
+      const deleteBackupOrder = vi.mocked(jsm.streams.delete).mock.invocationCallOrder.at(-1)!;
+      const detachOrder = vi.mocked(jsm.streams.update).mock.invocationCallOrder.at(-1)!;
+
+      expect(deleteBackupOrder).toBeLessThan(detachOrder);
+    });
+  });
+
+  describe('failure before the original is deleted', () => {
+    it('should roll back the quiesce, drop the backup, and rethrow', async () => {
+      // Given: deleting the original fails
+      const sut = new StreamMigration();
+      const jsm = buildMockJsm(100);
+
       vi.mocked(jsm.streams.delete).mockImplementation(async (name: string) => {
         if (name !== backupStreamName) {
           throw new Error('permission denied');
@@ -155,137 +182,182 @@ describe(StreamMigration.name, () => {
         return true;
       });
 
-      // When/Then: error is rethrown
+      // When/Then
       await expect(sut.migrate(jsm, testStreamName, newConfig)).rejects.toThrow(
         'permission denied',
       );
 
-      // And: cleanup — backup delete was called
+      // And: the original's subjects were restored and the backup removed
+      const lastUpdate = vi.mocked(jsm.streams.update).mock.calls.at(-1)!;
+
+      expect(lastUpdate[0]).toBe(testStreamName);
+      expect(lastUpdate[1]).toMatchObject({ subjects: ['test.ev.>'] });
       expect(jsm.streams.delete).toHaveBeenCalledWith(backupStreamName);
     });
   });
 
-  describe('Phase 3 failure (create new stream fails)', () => {
-    it('should PRESERVE backup and rethrow (backup is the only copy after Phase 2)', async () => {
-      // Given: stream with messages, backup + delete succeed, Phase 3 fails
+  describe('failure after the original is deleted', () => {
+    it('should preserve the backup (it is the only copy) and rethrow', async () => {
+      // Given: creating the new stream fails after the delete
       const sut = new StreamMigration();
       const jsm = buildMockJsm(100);
 
       let addCallCount = 0;
+      const originalAdd = vi.mocked(jsm.streams.add).getMockImplementation()!;
 
-      // Override: second add call (new stream creation) throws
-      vi.mocked(jsm.streams.add).mockImplementation(async () => {
+      vi.mocked(jsm.streams.add).mockImplementation(async (config) => {
         addCallCount++;
+
         if (addCallCount === 2) {
           throw new Error('resource limit exceeded');
         }
 
-        return createMock<StreamInfo>();
+        return originalAdd(config);
       });
 
-      // When/Then: error is rethrown
+      // When/Then
       await expect(sut.migrate(jsm, testStreamName, newConfig)).rejects.toThrow(
         'resource limit exceeded',
       );
 
-      // And: backup NOT deleted — it's the only copy after original was deleted in Phase 2
+      // And: backup NOT deleted
       const deleteCalls = vi.mocked(jsm.streams.delete).mock.calls.map((c) => c[0]);
 
       expect(deleteCalls).not.toContain(backupStreamName);
     });
   });
 
-  describe('Phase 4 backup sources clearing', () => {
-    it('should clear backup sources before restore to prevent detected-cycle error', async () => {
-      // Given: stream with 100 messages
-      const sut = new StreamMigration();
-      const jsm = buildMockJsm(100);
-
-      // When
-      await sut.migrate(jsm, testStreamName, newConfig);
-
-      // Then: first update call clears backup sources (cycle prevention)
-      const updateCalls = vi.mocked(jsm.streams.update).mock.calls;
-      const firstUpdateName = updateCalls[0]![0];
-      const firstUpdateConfig = updateCalls[0]![1];
-
-      expect(firstUpdateName).toBe(backupStreamName);
-      expect(firstUpdateConfig).toMatchObject({ sources: [] });
-
-      // And: second update call restores with backup as source
-      const secondUpdateName = updateCalls[1]![0];
-      const secondUpdateConfig = updateCalls[1]![1];
-
-      expect(secondUpdateName).toBe(testStreamName);
-      expect(secondUpdateConfig).toMatchObject({
-        sources: [{ name: backupStreamName }],
-      });
-    });
-
-    it('should include full newConfig properties in restore update call', async () => {
-      // Given: stream with 100 messages
-      const sut = new StreamMigration();
-      const jsm = buildMockJsm(100);
-
-      // When
-      await sut.migrate(jsm, testStreamName, newConfig);
-
-      // Then: restore update passes full config AND sources
-      const updateCalls = vi.mocked(jsm.streams.update).mock.calls;
-      const restoreCall = updateCalls[1]![1];
-
-      expect(restoreCall).toMatchObject({
-        name: newConfig.name,
-        subjects: newConfig.subjects,
-        storage: newConfig.storage,
-        retention: newConfig.retention,
-        num_replicas: newConfig.num_replicas,
-        sources: [{ name: backupStreamName }],
-      });
-    });
-  });
-
   describe('sourcing timeout', () => {
-    it('should throw and cleanup backup on timeout', async () => {
-      // Given: backup never reaches expected message count
-      const sut = new StreamMigration(1_000); // 1s timeout for test speed
+    it('should roll back and rethrow when the backup never drains', async () => {
+      // Given: the backup's source entry never reports activity
+      const sut = new StreamMigration(500);
+      const jsm = buildMockJsm(100);
+      const original = vi.mocked(jsm.streams.info).getMockImplementation()!;
 
-      let backupCreated = false;
+      vi.mocked(jsm.streams.info).mockImplementation(async (name: string) => {
+        const info = (await original(name)) as StreamInfo;
 
-      const jsm = createMock<JetStreamManager>({
-        streams: {
-          info: vi.fn().mockImplementation(async (name: string) => {
-            if (name === backupStreamName && !backupCreated) {
-              throw streamNotFoundError;
-            }
+        if (name === backupStreamName) {
+          return { ...info, sources: [{ name: testStreamName, lag: 0, active: -1 }] };
+        }
 
-            if (name === backupStreamName && backupCreated) {
-              // Always returns 0 messages — simulates stuck sourcing
-              return createMock<StreamInfo>({ state: { messages: 0 } as StreamInfo['state'] });
-            }
-
-            return createMock<StreamInfo>({
-              state: { messages: 100 } as StreamInfo['state'],
-              config: { name: testStreamName } as StreamConfig,
-            });
-          }),
-          add: vi.fn().mockImplementation(async () => {
-            backupCreated = true;
-
-            return createMock<StreamInfo>();
-          }),
-          update: vi.fn().mockResolvedValue(createMock<StreamInfo>()),
-          delete: vi.fn().mockResolvedValue(true),
-        },
+        return info;
       });
 
-      // When/Then: should throw timeout error
+      // When/Then
       await expect(sut.migrate(jsm, testStreamName, newConfig)).rejects.toThrow(
         /sourcing timeout/i,
       );
 
-      // And: backup cleaned up — original stream was NOT deleted (Phase 1 timeout)
+      // And: the original was not deleted; our backup was cleaned up
+      const deleteCalls = vi.mocked(jsm.streams.delete).mock.calls.map((c) => c[0]);
+
+      expect(deleteCalls).toContain(backupStreamName);
+      expect(deleteCalls).not.toContain(testStreamName);
+    });
+  });
+
+  describe('concurrent migration protection', () => {
+    const freshBackupInfo = (): StreamInfo =>
+      createMock<StreamInfo>({
+        config: {
+          name: backupStreamName,
+          metadata: { 'nestjs-jetstream-migration-started-at': new Date().toISOString() },
+        } as unknown as StreamConfig,
+        state: { messages: 5 } as StreamInfo['state'],
+      });
+
+    it("should leave another instance's live backup alone during recovery", async () => {
+      // Given: a backup stamped moments ago — a peer is migrating right now
+      const sut = new StreamMigration(200, 200);
+      const jsm = createMock<JetStreamManager>({
+        streams: {
+          info: vi.fn().mockResolvedValue(freshBackupInfo()),
+          add: vi.fn(),
+          update: vi.fn(),
+          delete: vi.fn(),
+        },
+      });
+
+      // When
+      const recovered = await sut.recoverInterrupted(jsm, testStreamName, newConfig);
+
+      // Then: nothing was touched
+      expect(recovered).toBe(false);
+      expect(jsm.streams.delete).not.toHaveBeenCalled();
+      expect(jsm.streams.add).not.toHaveBeenCalled();
+      expect(jsm.streams.update).not.toHaveBeenCalled();
+    });
+
+    it('should wait out a peer backup in migrate() and never delete it', async () => {
+      // Given: the peer's backup never clears within the wait budget
+      const sut = new StreamMigration(200, 200);
+      const jsm = createMock<JetStreamManager>({
+        streams: {
+          info: vi.fn().mockImplementation(async (name: string) => {
+            if (name === backupStreamName) return freshBackupInfo();
+
+            return createMock<StreamInfo>();
+          }),
+          add: vi.fn(),
+          update: vi.fn(),
+          delete: vi.fn(),
+        },
+      });
+
+      // When/Then: migrate gives up loudly instead of deleting the peer's data
+      await expect(sut.migrate(jsm, testStreamName, newConfig)).rejects.toThrow(/did not clear/);
+
+      expect(jsm.streams.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('interrupted-migration recovery', () => {
+    it('should delete a stale empty backup when the stream is healthy', async () => {
+      // Given: an empty leftover backup without a freshness stamp
+      const sut = new StreamMigration();
+      const jsm = createMock<JetStreamManager>({
+        streams: {
+          info: vi.fn().mockImplementation(async (name: string) => {
+            if (name === backupStreamName) {
+              return createMock<StreamInfo>({
+                config: { name: backupStreamName } as StreamConfig,
+                state: { messages: 0 } as StreamInfo['state'],
+              });
+            }
+
+            return createMock<StreamInfo>({
+              config: { name: testStreamName } as StreamConfig,
+            });
+          }),
+          add: vi.fn(),
+          update: vi.fn(),
+          delete: vi.fn().mockResolvedValue(true),
+        },
+      });
+
+      // When
+      const recovered = await sut.recoverInterrupted(jsm, testStreamName, newConfig);
+
+      // Then
+      expect(recovered).toBe(true);
       expect(jsm.streams.delete).toHaveBeenCalledWith(backupStreamName);
+    });
+
+    it('should report no recovery when no backup exists', async () => {
+      // Given
+      const sut = new StreamMigration();
+      const jsm = createMock<JetStreamManager>({
+        streams: {
+          info: vi.fn().mockRejectedValue(streamNotFoundError),
+          add: vi.fn(),
+          update: vi.fn(),
+          delete: vi.fn(),
+        },
+      });
+
+      // When/Then
+      await expect(sut.recoverInterrupted(jsm, testStreamName, newConfig)).resolves.toBe(false);
     });
   });
 });

--- a/src/server/infrastructure/__tests__/stream-migration.spec.ts
+++ b/src/server/infrastructure/__tests__/stream-migration.spec.ts
@@ -312,7 +312,148 @@ describe(StreamMigration.name, () => {
     });
   });
 
+  describe('peer migration completed while waiting', () => {
+    it('should apply the config without recreating when the peer result is compatible', async () => {
+      // Given: the peer's backup clears on the second poll, and the stream it
+      // left behind already matches the desired immutable properties
+      const sut = new StreamMigration(200, 2_000);
+
+      let backupPolls = 0;
+
+      const jsm = createMock<JetStreamManager>({
+        streams: {
+          info: vi.fn().mockImplementation(async (name: string) => {
+            if (name === backupStreamName) {
+              backupPolls++;
+
+              if (backupPolls > 1) throw streamNotFoundError;
+
+              return createMock<StreamInfo>({
+                config: { name: backupStreamName } as StreamConfig,
+              });
+            }
+
+            return createMock<StreamInfo>({
+              config: { ...newConfig } as StreamConfig,
+            });
+          }),
+          add: vi.fn(),
+          update: vi.fn().mockResolvedValue(createMock<StreamInfo>()),
+          delete: vi.fn(),
+        },
+      });
+
+      // When
+      await sut.migrate(jsm, testStreamName, newConfig);
+
+      // Then: mutable reconciliation only — nothing recreated
+      expect(jsm.streams.update).toHaveBeenCalledWith(testStreamName, newConfig);
+      expect(jsm.streams.add).not.toHaveBeenCalled();
+      expect(jsm.streams.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rollback failure', () => {
+    it('should propagate the original error when the rollback itself fails', async () => {
+      // Given: deleting the original fails AND the quiesce rollback fails too
+      const sut = new StreamMigration();
+      const jsm = buildMockJsm(100);
+
+      vi.mocked(jsm.streams.delete).mockRejectedValue(new Error('permission denied'));
+      vi.mocked(jsm.streams.update).mockImplementation(async () => {
+        // The first update is the quiesce; subsequent ones include the rollback
+        if (vi.mocked(jsm.streams.update).mock.calls.length > 1) {
+          throw new Error('connection lost');
+        }
+
+        return createMock<StreamInfo>();
+      });
+
+      // When/Then: the caller sees the migration failure, not the rollback one
+      await expect(sut.migrate(jsm, testStreamName, newConfig)).rejects.toThrow(
+        'permission denied',
+      );
+    });
+  });
+
   describe('interrupted-migration recovery', () => {
+    it('should recreate the stream and drop an empty backup after a delete/create crash', async () => {
+      // Given: only an empty stale backup exists — the original was deleted
+      // and held no messages when the process died
+      const sut = new StreamMigration();
+      const jsm = createMock<JetStreamManager>({
+        streams: {
+          info: vi.fn().mockImplementation(async (name: string) => {
+            if (name === backupStreamName) {
+              return createMock<StreamInfo>({
+                config: { name: backupStreamName } as StreamConfig,
+                state: { messages: 0 } as StreamInfo['state'],
+              });
+            }
+
+            throw streamNotFoundError;
+          }),
+          add: vi.fn().mockResolvedValue(createMock<StreamInfo>()),
+          update: vi.fn(),
+          delete: vi.fn().mockResolvedValue(true),
+        },
+      });
+
+      // When
+      const recovered = await sut.recoverInterrupted(jsm, testStreamName, newConfig);
+
+      // Then: stream recreated, backup removed, no restore wiring
+      expect(recovered).toBe(true);
+      expect(jsm.streams.add).toHaveBeenCalledWith(newConfig);
+      expect(jsm.streams.delete).toHaveBeenCalledWith(backupStreamName);
+      expect(jsm.streams.update).not.toHaveBeenCalled();
+    });
+
+    it('should finish a restore whose source is still attached', async () => {
+      // Given: the stream still sources from the backup — the process died
+      // mid-restore and the server kept the source position
+      const sut = new StreamMigration();
+      const jsm = createMock<JetStreamManager>({
+        streams: {
+          info: vi.fn().mockImplementation(async (name: string) => {
+            if (name === backupStreamName) {
+              return createMock<StreamInfo>({
+                config: { name: backupStreamName } as StreamConfig,
+                state: { messages: 5 } as StreamInfo['state'],
+              });
+            }
+
+            return createMock<StreamInfo>({
+              config: {
+                name: testStreamName,
+                sources: [{ name: backupStreamName }],
+              } as unknown as StreamConfig,
+              state: { messages: 5 } as StreamInfo['state'],
+              sources: [{ name: backupStreamName, lag: 0, active: 1_000 }],
+            });
+          }),
+          add: vi.fn(),
+          update: vi.fn().mockResolvedValue(createMock<StreamInfo>()),
+          delete: vi.fn().mockResolvedValue(true),
+        },
+      });
+
+      // When
+      const recovered = await sut.recoverInterrupted(jsm, testStreamName, newConfig);
+
+      // Then: drained, backup removed, source detached — in that order
+      expect(recovered).toBe(true);
+      expect(jsm.streams.delete).toHaveBeenCalledWith(backupStreamName);
+
+      const detachCall = vi.mocked(jsm.streams.update).mock.calls.at(-1)!;
+
+      expect(detachCall[0]).toBe(testStreamName);
+      expect(detachCall[1]).toMatchObject({ sources: [] });
+      expect(vi.mocked(jsm.streams.delete).mock.invocationCallOrder[0]!).toBeLessThan(
+        vi.mocked(jsm.streams.update).mock.invocationCallOrder.at(-1)!,
+      );
+    });
+
     it('should delete a stale empty backup when the stream is healthy', async () => {
       // Given: an empty leftover backup without a freshness stamp
       const sut = new StreamMigration();

--- a/src/server/infrastructure/__tests__/stream.provider.spec.ts
+++ b/src/server/infrastructure/__tests__/stream.provider.spec.ts
@@ -8,6 +8,7 @@ import { ConnectionProvider } from '../../../connection';
 import { StreamKind } from '../../../interfaces';
 import type { JetstreamModuleOptions, StreamConfigOverrides } from '../../../interfaces';
 import {
+  DEFAULT_BROADCAST_STREAM_CONFIG,
   DEFAULT_DLQ_STREAM_CONFIG,
   DEFAULT_EVENT_STREAM_CONFIG,
   internalName,
@@ -178,6 +179,52 @@ describe(StreamProvider, () => {
         expect(subjects).toEqual([`${name}.ordered.>`]);
         expect(subjects.some((s) => s.includes('_sch'))).toBe(false);
       });
+    });
+  });
+
+  describe('shared broadcast stream protection', () => {
+    const sharedBroadcastConfig = (overrides: Record<string, unknown> = {}) => ({
+      ...DEFAULT_BROADCAST_STREAM_CONFIG,
+      name: 'broadcast-stream',
+      subjects: ['broadcast.>'],
+      description: 'JetStream broadcast stream (shared across services)',
+      ...overrides,
+    });
+
+    it('should not strip subjects or rewrite the description set by other services', async () => {
+      // Given: another service enabled broadcast scheduling, so the shared
+      // stream carries an extra subject this service's config does not declare
+      mockJsm.streams.info.mockResolvedValue(
+        createMock<StreamInfo>({
+          config: sharedBroadcastConfig({ subjects: ['broadcast.>', 'broadcast._sch.>'] }),
+        }),
+      );
+      mockJsm.streams.update.mockResolvedValue(createMock<StreamInfo>());
+
+      // When
+      await sut.ensureStreams([StreamKind.Broadcast]);
+
+      // Then: no update — the local config must not clobber the shared stream
+      expect(mockJsm.streams.update).not.toHaveBeenCalled();
+      expect(mockJsm.streams.add).not.toHaveBeenCalled();
+    });
+
+    it('should refuse destructive migration of the shared broadcast stream', async () => {
+      // Given: an immutable diff on the shared stream and the migration flag on
+      options.allowDestructiveMigration = true;
+      sut = new StreamProvider(options, connection);
+
+      mockJsm.streams.info.mockResolvedValue(
+        createMock<StreamInfo>({
+          config: sharedBroadcastConfig({ storage: StorageType.Memory }),
+        }),
+      );
+
+      // When/Then: recreating broadcast-stream would delete every other
+      // service's durable consumers — fail loudly instead
+      await expect(sut.ensureStreams([StreamKind.Broadcast])).rejects.toThrow(
+        /broadcast-stream.*shared|shared.*broadcast-stream/i,
+      );
     });
   });
 

--- a/src/server/infrastructure/__tests__/stream.provider.spec.ts
+++ b/src/server/infrastructure/__tests__/stream.provider.spec.ts
@@ -585,7 +585,7 @@ describe(StreamProvider, () => {
       });
 
       mockJsm.getAccountInfo = getAccountInfo;
-      mockJsm.streams.info.mockResolvedValue({
+      mockStreamInfo({
         config: { ...DEFAULT_EVENT_STREAM_CONFIG, name: sut.getStreamName(StreamKind.Event) },
       } as never);
 

--- a/src/server/infrastructure/__tests__/stream.provider.spec.ts
+++ b/src/server/infrastructure/__tests__/stream.provider.spec.ts
@@ -50,6 +50,22 @@ describe(StreamProvider, () => {
 
   afterEach(vi.resetAllMocks);
 
+  const streamNotFound = (): JetStreamApiError =>
+    new JetStreamApiError({
+      err_code: 10059,
+      code: 404,
+      description: 'stream not found',
+    });
+
+  /** Resolve `info` for real streams; report migration backups as absent. */
+  const mockStreamInfo = (info: StreamInfo): void => {
+    mockJsm.streams.info.mockImplementation(async (name: string) => {
+      if (name.endsWith('__migration_backup')) throw streamNotFound();
+
+      return info;
+    });
+  };
+
   describe('getStreamName', () => {
     describe('when kind is Event', () => {
       it('should return the correct stream name', () => {
@@ -183,7 +199,9 @@ describe(StreamProvider, () => {
   });
 
   describe('shared broadcast stream protection', () => {
-    const sharedBroadcastConfig = (overrides: Record<string, unknown> = {}) => ({
+    const sharedBroadcastConfig = (
+      overrides: Record<string, unknown> = {},
+    ): Record<string, unknown> => ({
       ...DEFAULT_BROADCAST_STREAM_CONFIG,
       name: 'broadcast-stream',
       subjects: ['broadcast.>'],
@@ -194,7 +212,7 @@ describe(StreamProvider, () => {
     it('should not strip subjects or rewrite the description set by other services', async () => {
       // Given: another service enabled broadcast scheduling, so the shared
       // stream carries an extra subject this service's config does not declare
-      mockJsm.streams.info.mockResolvedValue(
+      mockStreamInfo(
         createMock<StreamInfo>({
           config: sharedBroadcastConfig({ subjects: ['broadcast.>', 'broadcast._sch.>'] }),
         }),
@@ -214,7 +232,7 @@ describe(StreamProvider, () => {
       options.allowDestructiveMigration = true;
       sut = new StreamProvider(options, connection);
 
-      mockJsm.streams.info.mockResolvedValue(
+      mockStreamInfo(
         createMock<StreamInfo>({
           config: sharedBroadcastConfig({ storage: StorageType.Memory }),
         }),
@@ -266,7 +284,7 @@ describe(StreamProvider, () => {
           },
         });
 
-        mockJsm.streams.info.mockResolvedValue(existingInfo);
+        mockStreamInfo(existingInfo);
 
         const updated = createMock<StreamInfo>();
 
@@ -291,7 +309,7 @@ describe(StreamProvider, () => {
           max_age: 999,
         };
 
-        mockJsm.streams.info.mockResolvedValue(createMock<StreamInfo>({ config: existingConfig }));
+        mockStreamInfo(createMock<StreamInfo>({ config: existingConfig }));
         mockJsm.streams.update.mockResolvedValue(createMock<StreamInfo>());
 
         // When
@@ -313,7 +331,7 @@ describe(StreamProvider, () => {
           storage: StorageType.Memory,
         };
 
-        mockJsm.streams.info.mockResolvedValue(createMock<StreamInfo>({ config: existingConfig }));
+        mockStreamInfo(createMock<StreamInfo>({ config: existingConfig }));
 
         // When (allowDestructiveMigration is false by default)
         await sut.ensureStreams([StreamKind.Event]);
@@ -335,7 +353,7 @@ describe(StreamProvider, () => {
           max_age: 999,
         };
 
-        mockJsm.streams.info.mockResolvedValue(createMock<StreamInfo>({ config: existingConfig }));
+        mockStreamInfo(createMock<StreamInfo>({ config: existingConfig }));
         mockJsm.streams.update.mockResolvedValue(createMock<StreamInfo>());
 
         // When
@@ -362,7 +380,7 @@ describe(StreamProvider, () => {
           retention: RetentionPolicy.Limits,
         };
 
-        mockJsm.streams.info.mockResolvedValue(createMock<StreamInfo>({ config: existingConfig }));
+        mockStreamInfo(createMock<StreamInfo>({ config: existingConfig }));
 
         // When / Then
         await expect(sut.ensureStreams([StreamKind.Event])).rejects.toThrow(
@@ -466,12 +484,7 @@ describe(StreamProvider, () => {
           options = { ...options, dlq: {} };
           sut = new StreamProvider(options, connection);
 
-          // First call (event stream) returns not-found, second call (DLQ) returns info
-          const notFoundError = new JetStreamApiError({
-            err_code: 10059,
-            code: 404,
-            description: 'stream not found',
-          });
+          // Event stream is absent (gets created); the DLQ stream exists
           const existingDlqInfo = createMock<StreamInfo>({
             config: {
               ...DEFAULT_DLQ_STREAM_CONFIG,
@@ -481,9 +494,11 @@ describe(StreamProvider, () => {
             } as StreamInfo['config'],
           });
 
-          mockJsm.streams.info
-            .mockRejectedValueOnce(notFoundError) // event stream → create
-            .mockResolvedValueOnce(existingDlqInfo); // DLQ stream → exists
+          mockJsm.streams.info.mockImplementation(async (name: string) => {
+            if (name.endsWith('_dlq-stream')) return existingDlqInfo;
+
+            throw streamNotFound();
+          });
 
           mockJsm.streams.add.mockResolvedValue(createMock<StreamInfo>());
 

--- a/src/server/infrastructure/stream-migration.ts
+++ b/src/server/infrastructure/stream-migration.ts
@@ -1,119 +1,130 @@
 import { Logger } from '@nestjs/common';
-import { JetStreamApiError, type JetStreamManager, type StreamConfig } from '@nats-io/jetstream';
+import {
+  JetStreamApiError,
+  type JetStreamManager,
+  type StreamConfig,
+  type StreamInfo,
+} from '@nats-io/jetstream';
 
+import { compareStreamConfig } from './stream-config-diff';
 import { NatsErrorCode } from './nats-error-codes';
 
 export const MIGRATION_BACKUP_SUFFIX = '__migration_backup';
 const DEFAULT_SOURCING_TIMEOUT_MS = 30_000;
 const SOURCING_POLL_INTERVAL_MS = 100;
+/** How long migrate() waits for another instance's in-flight migration to finish. */
+const DEFAULT_PEER_WAIT_MS = 60_000;
+/**
+ * Backups younger than this are treated as another instance's live migration
+ * and never touched. Stale ones (older, or without the metadata stamp) are
+ * leftovers of an interrupted run and get recovered.
+ */
+const ACTIVE_MIGRATION_GRACE_MS = 90_000;
+const MIGRATION_STARTED_AT_KEY = 'nestjs-jetstream-migration-started-at';
+
+/** Desired stream configuration shape accepted by migration entry points. */
+type MigrationStreamConfig = Partial<StreamConfig> & { name: string; subjects: string[] };
 
 /**
  * Orchestrates blue-green stream recreation for immutable property changes.
  *
  * Uses NATS stream sourcing (server-side copy) to preserve messages:
- *   1. Backup: create temp stream sourcing from original
- *   2. Delete original
- *   3. Create original with new config
- *   4. Restore: source from temp into new original
- *   5. Cleanup: remove temp stream
+ *   1. Quiesce: remove the original's subjects so new publishes are rejected
+ *      loudly instead of acked into a stream that is about to be deleted
+ *   2. Backup: create temp stream sourcing from the original; wait for the
+ *      source lag to reach zero (immune to message-count races)
+ *   3. Delete original
+ *   4. Create original with the new config
+ *   5. Restore: source from the backup into the new original, drain, then
+ *      delete the backup BEFORE detaching the source — the surviving order
+ *      guarantees "backup exists with no source attached" can only mean the
+ *      restore never started, which {@link recoverInterrupted} re-runs safely
  *
- * **Rolling update safety:** During Phase 4 (restore), other pods' self-healing
- * may recreate consumers and begin consuming restored messages. For workqueue
- * streams this means acked messages are deleted, which could cause the sourcing
- * count check to stall. In practice, server-side sourcing is much faster than
- * consumer pull (network round-trips for each ack), so this is unlikely for
- * streams under ~100k messages. For very large streams, scale down to 1 replica
- * before migrating, or schedule migration during low-traffic windows.
+ * Publishers see "no stream matches subject" errors from quiesce until
+ * Phase 4 completes. Client-side retry is the caller's responsibility — the
+ * alternative was acknowledged writes that silently vanished.
  *
- * There is also a brief window (milliseconds) between Phase 2 (delete) and
- * Phase 3 (create) where the stream does not exist. Publishers may see
- * temporary "stream not found" errors. Client-side retry is the caller's
- * responsibility.
+ * A process dying mid-migration leaves the backup behind;
+ * {@link recoverInterrupted} finishes the job on the next startup. Backups
+ * created moments ago belong to another instance's live migration (rolling
+ * deploys) and are waited out, never deleted.
  *
  * Ref: https://docs.nats.io/nats-concepts/jetstream/streams#sources
  */
 export class StreamMigration {
   private readonly logger = new Logger('Jetstream:Stream');
 
-  public constructor(private readonly sourcingTimeoutMs = DEFAULT_SOURCING_TIMEOUT_MS) {}
+  public constructor(
+    private readonly sourcingTimeoutMs = DEFAULT_SOURCING_TIMEOUT_MS,
+    private readonly peerWaitMs = DEFAULT_PEER_WAIT_MS,
+  ) {}
 
   public async migrate(
     jsm: JetStreamManager,
     streamName: string,
-    newConfig: Partial<StreamConfig> & { name: string; subjects: string[] },
+    newConfig: MigrationStreamConfig,
   ): Promise<void> {
     const backupName = `${streamName}${MIGRATION_BACKUP_SUFFIX}`;
     const startTime = Date.now();
 
-    // Check original stream FIRST — if it's gone but backup exists,
-    // we must NOT delete the backup (it may be the only copy of the data).
+    const peerFinished = await this.waitOutPeerMigration(jsm, backupName);
     const currentInfo = await jsm.streams.info(streamName);
 
-    await this.cleanupOrphanedBackup(jsm, backupName);
+    if (peerFinished && !compareStreamConfig(currentInfo.config, newConfig).hasImmutableChanges) {
+      this.logger.log(`Stream ${streamName}: migration completed by another instance`);
+      await jsm.streams.update(streamName, newConfig);
 
-    const messageCount = currentInfo.state.messages;
+      return;
+    }
 
     this.logger.log(`Stream ${streamName}: destructive migration started`);
 
-    // Track whether original stream has been deleted — after Phase 2,
-    // backup is the only copy and must NOT be deleted on failure.
     let originalDeleted = false;
+    let drainedCount = 0;
 
     try {
-      if (messageCount > 0) {
-        // Phase 1: Backup via sourcing
-        this.logger.log(`  Phase 1/4: Backing up ${messageCount} messages → ${backupName}`);
+      // Phase 1: Quiesce — without this, a publish acked between the backup
+      // catching up and the delete would be destroyed with the stream.
+      this.logger.log(`  Phase 1/4: Quiescing ${streamName} (publishes rejected during migration)`);
+      await jsm.streams.update(streamName, { ...currentInfo.config, subjects: [] });
+
+      drainedCount = (await jsm.streams.info(streamName)).state.messages;
+
+      if (drainedCount > 0) {
+        // Phase 2: Backup via sourcing
+        this.logger.log(`  Phase 2/4: Backing up ${drainedCount} messages → ${backupName}`);
         await jsm.streams.add({
           ...currentInfo.config,
           name: backupName,
           subjects: [],
           sources: [{ name: streamName }],
+          metadata: { [MIGRATION_STARTED_AT_KEY]: new Date().toISOString() },
         } as StreamConfig);
 
-        await this.waitForSourcing(jsm, backupName, messageCount);
+        await this.waitForSourceDrained(jsm, backupName, streamName, drainedCount);
       }
 
-      // Phase 2: Delete original
-      this.logger.log(`  Phase 2/4: Deleting old stream`);
+      // Phase 3: Delete + recreate
+      this.logger.log(`  Phase 3/4: Recreating ${streamName} with the new config`);
       await jsm.streams.delete(streamName);
       originalDeleted = true;
-
-      // Phase 3: Create with new config
-      this.logger.log(`  Phase 3/4: Creating stream with new config`);
       await jsm.streams.add(newConfig as StreamConfig);
 
-      if (messageCount > 0) {
-        // Phase 4: Restore from backup.
-        // First remove the backup's source pointing to streamName — that reference is stale
-        // (original was deleted in Phase 2) and would cause a cycle when we make the new
-        // stream source from the backup.
-        const backupInfo = await jsm.streams.info(backupName);
-
-        await jsm.streams.update(backupName, { ...backupInfo.config, sources: [] });
-
-        this.logger.log(`  Phase 4/4: Restoring ${messageCount} messages from backup`);
-        await jsm.streams.update(streamName, {
-          ...newConfig,
-          sources: [{ name: backupName }],
-        });
-
-        await this.waitForSourcing(jsm, streamName, messageCount);
-
-        // Remove sources — pass full config without sources
-        await jsm.streams.update(streamName, { ...newConfig, sources: [] });
-        await jsm.streams.delete(backupName);
+      if (drainedCount > 0) {
+        // Phase 4: Restore from backup
+        this.logger.log(`  Phase 4/4: Restoring ${drainedCount} messages from backup`);
+        await this.restoreFromBackup(jsm, streamName, newConfig, backupName);
       }
     } catch (err) {
-      if (originalDeleted && messageCount > 0) {
-        // After Phase 2: backup is the only copy — DO NOT delete it.
-        // Leave it for manual recovery or next startup retry.
+      if (originalDeleted) {
+        // The backup is the only copy now — recoverInterrupted() resumes the
+        // restore on the next startup.
         this.logger.error(
-          `Migration failed after deleting original stream. ` +
-            `Backup ${backupName} preserved for manual recovery.`,
+          `Migration of ${streamName} failed after the original was deleted. ` +
+            `Backup ${backupName} preserved — restoration resumes on the next startup.`,
         );
       } else {
-        // Before Phase 2: original still intact — safe to clean up backup
-        await this.cleanupOrphanedBackup(jsm, backupName);
+        await this.rollbackBeforeDelete(jsm, streamName, currentInfo, backupName);
       }
 
       throw err;
@@ -122,41 +133,215 @@ export class StreamMigration {
     const durationMs = Date.now() - startTime;
 
     this.logger.log(
-      `Stream ${streamName}: migration complete (${messageCount} messages preserved, took ${(durationMs / 1000).toFixed(1)}s)`,
+      `Stream ${streamName}: migration complete (${drainedCount} messages preserved, took ${(durationMs / 1000).toFixed(1)}s)`,
     );
   }
 
-  private async waitForSourcing(
+  /**
+   * Detect and finish a migration that a previous process left unfinished.
+   * Safe against concurrent instances: a backup fresh enough to belong to a
+   * live migration is left alone.
+   *
+   * @returns true when recovery work was performed.
+   */
+  public async recoverInterrupted(
     jsm: JetStreamManager,
     streamName: string,
-    expectedCount: number,
+    desiredConfig: MigrationStreamConfig,
+  ): Promise<boolean> {
+    const backupName = `${streamName}${MIGRATION_BACKUP_SUFFIX}`;
+    const backupInfo = await this.tryInfo(jsm, backupName);
+
+    if (backupInfo === null) return false;
+
+    if (this.isPeerMigrationActive(backupInfo)) return false;
+
+    const streamInfo = await this.tryInfo(jsm, streamName);
+
+    if (streamInfo === null) {
+      // Died between delete and create: the backup holds the only copy.
+      this.logger.warn(`Stream ${streamName}: resuming interrupted migration from ${backupName}`);
+      await jsm.streams.add(desiredConfig as StreamConfig);
+
+      if (backupInfo.state.messages > 0) {
+        await this.restoreFromBackup(jsm, streamName, desiredConfig, backupName);
+      } else {
+        await jsm.streams.delete(backupName);
+      }
+
+      return true;
+    }
+
+    const hasBackupSource = (streamInfo.config.sources ?? []).some((s) => s.name === backupName);
+
+    if (hasBackupSource) {
+      // Died mid-restore: the source keeps its position server-side — let it
+      // finish, then clean up.
+      this.logger.warn(`Stream ${streamName}: finishing interrupted restore from ${backupName}`);
+      await this.waitForSourceDrained(jsm, streamName, backupName, backupInfo.state.messages);
+      await jsm.streams.delete(backupName);
+      await jsm.streams.update(streamName, { ...streamInfo.config, sources: [] });
+
+      return true;
+    }
+
+    if (backupInfo.state.messages === 0) {
+      this.logger.warn(`Removing empty migration backup ${backupName}`);
+      await jsm.streams.delete(backupName);
+
+      return true;
+    }
+
+    // Died after the recreate but before the restore was wired up. Nothing
+    // from the backup has been sourced yet (sources are only detached after a
+    // full drain), so re-running the restore cannot duplicate messages.
+    this.logger.warn(
+      `Stream ${streamName}: restoring ${backupInfo.state.messages} messages from stale ${backupName}`,
+    );
+    await this.restoreFromBackup(
+      jsm,
+      streamName,
+      { ...streamInfo.config, name: streamName, subjects: streamInfo.config.subjects },
+      backupName,
+    );
+
+    return true;
+  }
+
+  /** Attach the backup as a source, drain it fully, then clean up. */
+  private async restoreFromBackup(
+    jsm: JetStreamManager,
+    streamName: string,
+    streamConfig: MigrationStreamConfig,
+    backupName: string,
+  ): Promise<void> {
+    // The backup's own source still points at the (recreated) original —
+    // stale, and a cycle once the original sources from the backup.
+    const backupInfo = await jsm.streams.info(backupName);
+
+    if ((backupInfo.config.sources ?? []).length > 0) {
+      await jsm.streams.update(backupName, { ...backupInfo.config, sources: [] });
+    }
+
+    await jsm.streams.update(streamName, { ...streamConfig, sources: [{ name: backupName }] });
+    await this.waitForSourceDrained(jsm, streamName, backupName, backupInfo.state.messages);
+
+    // Delete the backup before detaching the source — see the class doc for
+    // why this order is what makes recoverInterrupted() safe.
+    await jsm.streams.delete(backupName);
+    await jsm.streams.update(streamName, { ...streamConfig, sources: [] });
+  }
+
+  /**
+   * Wait until `sourceName` is fully drained into `streamName`. Lag-based, so
+   * concurrent live publishes to the target cannot fake completion the way a
+   * bare message-count comparison could. A freshly attached source reports
+   * `lag: 0, active: -1` before its first sync — `active >= 0` filters that
+   * false positive out (verified against NATS 2.12.6).
+   */
+  private async waitForSourceDrained(
+    jsm: JetStreamManager,
+    streamName: string,
+    sourceName: string,
+    minimumMessages: number,
   ): Promise<void> {
     const deadline = Date.now() + this.sourcingTimeoutMs;
 
     while (Date.now() < deadline) {
       const info = await jsm.streams.info(streamName);
+      const source = (info.sources ?? []).find((s) => s.name === sourceName);
 
-      if (info.state.messages >= expectedCount) return;
+      if (
+        source !== undefined &&
+        source.active >= 0 &&
+        source.lag === 0 &&
+        info.state.messages >= minimumMessages
+      ) {
+        return;
+      }
 
       await new Promise((r) => setTimeout(r, SOURCING_POLL_INTERVAL_MS));
     }
 
     throw new Error(
-      `Stream sourcing timeout: ${streamName} has not reached ${expectedCount} messages within ${this.sourcingTimeoutMs / 1000}s`,
+      `Stream sourcing timeout: ${sourceName} has not drained into ${streamName} within ` +
+        `${this.sourcingTimeoutMs / 1000}s. The backup is preserved; restoration resumes on the next startup.`,
     );
   }
 
-  private async cleanupOrphanedBackup(jsm: JetStreamManager, backupName: string): Promise<void> {
+  /**
+   * A backup already present when migrate() begins belongs to another
+   * instance migrating right now (rolling deploy) — wait for it to finish.
+   * Stale leftovers are handled by recoverInterrupted() before migrate() runs,
+   * so a timeout here means something is genuinely stuck.
+   *
+   * @returns true when a peer's backup was observed and cleared.
+   */
+  private async waitOutPeerMigration(jsm: JetStreamManager, backupName: string): Promise<boolean> {
+    if ((await this.tryInfo(jsm, backupName)) === null) return false;
+
+    this.logger.warn(
+      `Migration backup ${backupName} exists — another instance appears to be migrating; waiting`,
+    );
+
+    const deadline = Date.now() + this.peerWaitMs;
+
+    while (Date.now() < deadline) {
+      if ((await this.tryInfo(jsm, backupName)) === null) return true;
+
+      await new Promise((r) => setTimeout(r, SOURCING_POLL_INTERVAL_MS * 5));
+    }
+
+    throw new Error(
+      `Migration backup ${backupName} did not clear within ${this.peerWaitMs / 1000}s. ` +
+        'If no other instance is migrating, recover or remove the backup manually.',
+    );
+  }
+
+  /** Failure before the original was deleted: undo the quiesce, drop our backup. */
+  private async rollbackBeforeDelete(
+    jsm: JetStreamManager,
+    streamName: string,
+    originalInfo: StreamInfo,
+    backupName: string,
+  ): Promise<void> {
     try {
-      await jsm.streams.info(backupName);
-      this.logger.warn(`Found orphaned migration backup stream: ${backupName}, cleaning up`);
-      await jsm.streams.delete(backupName);
+      await jsm.streams.update(streamName, { ...originalInfo.config });
+
+      const backupInfo = await this.tryInfo(jsm, backupName);
+
+      if (backupInfo !== null) {
+        await jsm.streams.delete(backupName);
+      }
+    } catch (rollbackErr) {
+      this.logger.error(
+        `Rollback of ${streamName} after a failed migration also failed — the stream may be left quiesced:`,
+        rollbackErr,
+      );
+    }
+  }
+
+  private isPeerMigrationActive(backupInfo: StreamInfo): boolean {
+    const startedAt = backupInfo.config.metadata?.[MIGRATION_STARTED_AT_KEY];
+
+    if (!startedAt) return false;
+
+    const startedMs = Date.parse(startedAt);
+
+    if (Number.isNaN(startedMs)) return false;
+
+    return Date.now() - startedMs < ACTIVE_MIGRATION_GRACE_MS;
+  }
+
+  private async tryInfo(jsm: JetStreamManager, name: string): Promise<StreamInfo | null> {
+    try {
+      return await jsm.streams.info(name);
     } catch (err) {
       if (
         err instanceof JetStreamApiError &&
         err.apiError().err_code === NatsErrorCode.StreamNotFound
       ) {
-        return; // Backup doesn't exist — expected path
+        return null;
       }
 
       throw err;

--- a/src/server/infrastructure/stream.provider.ts
+++ b/src/server/infrastructure/stream.provider.ts
@@ -160,6 +160,10 @@ export class StreamProvider {
       async () => {
         this.logger.log(`Ensuring stream: ${config.name}`);
 
+        // A leftover migration backup means a previous process died
+        // mid-migration — finish its job before reconciling the config.
+        await this.migration.recoverInterrupted(jsm, config.name, config);
+
         try {
           const currentInfo = await jsm.streams.info(config.name);
 

--- a/src/server/infrastructure/stream.provider.ts
+++ b/src/server/infrastructure/stream.provider.ts
@@ -231,6 +231,14 @@ export class StreamProvider {
     config: Partial<StreamConfig> & { name: string; subjects: string[] },
     ctx: ProvisioningErrorContext,
   ): Promise<StreamInfo> {
+    if (this.isSharedStream(config.name)) {
+      // The broadcast stream is shared by every service in the cluster. Other
+      // services may have added subjects (e.g. broadcast._sch.> for
+      // scheduling) that this service's config does not declare — an update
+      // with the local subject list would strip them.
+      config.subjects = [...new Set([...config.subjects, ...currentInfo.config.subjects])];
+    }
+
     const diff = compareStreamConfig(currentInfo.config, config);
 
     if (!diff.hasChanges) {
@@ -274,6 +282,14 @@ export class StreamProvider {
       }
 
       return currentInfo;
+    }
+
+    if (this.isSharedStream(config.name)) {
+      throw new Error(
+        `Stream ${config.name} is shared across services and cannot be destructively migrated: ` +
+          "recreating it would delete every other service's durable broadcast consumers and " +
+          'replay retained history to them. Coordinate a manual migration instead.',
+      );
     }
 
     // Destructive migration
@@ -380,13 +396,23 @@ export class StreamProvider {
     }
   }
 
+  /** The broadcast stream is global — every service in the cluster shares it. */
+  private isSharedStream(name: string): boolean {
+    return name === this.getStreamName(StreamKind.Broadcast);
+  }
+
   /** Build the full stream config by merging defaults with user overrides. */
   private buildConfig(
     kind: StreamKind,
   ): Partial<StreamConfig> & { name: string; subjects: string[] } {
     const name = this.getStreamName(kind);
     const subjects = this.getSubjects(kind);
-    const description = `JetStream ${kind} stream for ${this.options.name}`;
+    // The shared stream's description must not embed a service name — each
+    // deploy of a different service would rewrite it back and forth.
+    const description =
+      kind === StreamKind.Broadcast
+        ? 'JetStream broadcast stream (shared across services)'
+        : `JetStream ${kind} stream for ${this.options.name}`;
 
     const defaults = this.getDefaults(kind);
     const overrides = this.getOverrides(kind);

--- a/src/server/routing/__tests__/event.router.spec.ts
+++ b/src/server/routing/__tests__/event.router.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock, type Mocked } from 'vitest';
+import { Logger } from '@nestjs/common';
 import { createMock } from '@golevelup/ts-vitest';
 import { faker } from '@faker-js/faker';
 import type { DeliveryInfo, JsMsg } from '@nats-io/jetstream';
@@ -77,6 +78,121 @@ describe(EventRouter, () => {
         expect(events$.observed).toBe(false);
         expect(broadcasts$.observed).toBe(false);
       });
+    });
+  });
+
+  describe('routing resilience', () => {
+    it('should release the slot when a post-settlement hook throws on the sync path', async () => {
+      // Given: concurrency 1; HandlerCompleted reporting is enabled and the
+      // hook throws — the failure escapes settlement and hits the limiter
+      const processingConfig: EventProcessingConfig = { events: { concurrency: 1 } };
+
+      eventBus.hasHook.mockReturnValue(true);
+      eventBus.emit.mockImplementation(() => {
+        throw new Error('hook exploded');
+      });
+
+      sut = new EventRouter(
+        messageProvider,
+        patternRegistry,
+        codec,
+        eventBus,
+        undefined,
+        processingConfig,
+      );
+      sut.start();
+
+      const handler = vi.fn().mockReturnValue(undefined);
+
+      patternRegistry.getHandler.mockReturnValue(handler);
+
+      const first = createMock<JsMsg>({
+        subject: 'first.subject',
+        data: new TextEncoder().encode(JSON.stringify({})),
+      });
+      const second = createMock<JsMsg>({
+        subject: 'second.subject',
+        data: new TextEncoder().encode(JSON.stringify({})),
+      });
+
+      // When
+      events$.next(first);
+      events$.next(second);
+      await new Promise(process.nextTick);
+
+      // Then: both messages were settled despite the throwing hook
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(first.ack).toHaveBeenCalled();
+      expect(second.ack).toHaveBeenCalled();
+    });
+
+    it('should log and not crash when the message stream errors', () => {
+      // Given
+      const errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+
+      sut.start();
+
+      // When: the underlying observable errors
+      events$.error(new Error('stream exploded'));
+
+      // Then
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Stream error'),
+        expect.any(Error),
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should log and survive a failing dead-letter capture for unroutable messages', async () => {
+      // Given: dlq configured, no handler for the subject, and the capture
+      // chain rejects (the DeadLetter hook emit throws)
+      const errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+      const options: JetstreamModuleOptions = {
+        name: 'my-service',
+        servers: ['nats://localhost:4222'],
+        dlq: {},
+      };
+      const dlqConfig: DeadLetterConfig = { maxDeliverByStream: new Map() };
+      const connection = createMock<ConnectionProvider>({
+        getJetStreamClient: vi.fn().mockReturnValue({ publish: vi.fn() }),
+      });
+
+      eventBus.emit.mockImplementation(() => {
+        throw new Error('hook exploded');
+      });
+
+      sut = new EventRouter(
+        messageProvider,
+        patternRegistry,
+        codec,
+        eventBus,
+        dlqConfig,
+        undefined,
+        undefined,
+        connection,
+        options,
+      );
+      sut.start();
+
+      patternRegistry.getHandler.mockReturnValue(null);
+
+      const msg = createMock<JsMsg>({
+        subject: 'orphan.subject',
+        data: new TextEncoder().encode(JSON.stringify({})),
+      });
+
+      // When: the unroutable message arrives
+      events$.next(msg);
+      await new Promise(process.nextTick);
+
+      // Then: the failure is logged, nothing escapes as an unhandled rejection
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Dead-letter capture failed for unroutable'),
+        expect.anything(),
+      );
+
+      errorSpy.mockRestore();
     });
   });
 
@@ -615,6 +731,36 @@ describe(EventRouter, () => {
         expect(msg.ack).not.toHaveBeenCalled();
         expect(msg.nak).not.toHaveBeenCalled();
         expect(msg.term).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when ordered handler throws synchronously', () => {
+      it('should contain the throw and keep processing the stream', async () => {
+        // Given: a handler that throws before returning a promise
+        const handler = vi.fn().mockImplementation(() => {
+          throw new Error('sync failure');
+        });
+
+        patternRegistry.getHandler.mockReturnValue(handler);
+
+        const failing = createMock<JsMsg>({
+          subject: 'first.ordered',
+          data: new TextEncoder().encode(JSON.stringify({})),
+        });
+        const healthy = createMock<JsMsg>({
+          subject: 'second.ordered',
+          data: new TextEncoder().encode(JSON.stringify({})),
+        });
+
+        // When: both ordered messages arrive
+        ordered$.next(failing);
+        ordered$.next(healthy);
+        await new Promise(process.nextTick);
+
+        // Then: no settlement attempted, the stream stays alive
+        expect(handler).toHaveBeenCalledTimes(2);
+        expect(failing.nak).not.toHaveBeenCalled();
+        expect(failing.term).not.toHaveBeenCalled();
       });
     });
 
@@ -1205,6 +1351,45 @@ describe(EventRouter, () => {
       });
 
       describe('when options.dlq is set — publish fails', () => {
+        it('should nak and preserve the message in dlq-only mode (no callback to fall back to)', async () => {
+          // Given: dlq-only configuration and a DLQ publish that never succeeds
+          const options: JetstreamModuleOptions = {
+            name: 'my-service',
+            servers: ['nats://localhost:4222'],
+            dlq: {},
+          };
+          const dlqOnlyConfig: DeadLetterConfig = { maxDeliverByStream };
+
+          mockJs.publish.mockRejectedValue(new Error('NATS down'));
+
+          sut = new EventRouter(
+            messageProvider,
+            patternRegistry,
+            codec,
+            eventBus,
+            dlqOnlyConfig,
+            undefined,
+            undefined,
+            connection,
+            options,
+          );
+          sut.start();
+
+          const handler = vi.fn().mockRejectedValue(new Error('handler error'));
+
+          patternRegistry.getHandler.mockReturnValue(handler);
+
+          const msg = createDeadLetterMsg();
+
+          // When: dead-letter message arrives and every capture attempt fails
+          events$.next(msg);
+          await new Promise(process.nextTick);
+
+          // Then: the message is released but never deleted
+          expect(msg.nak).toHaveBeenCalled();
+          expect(msg.term).not.toHaveBeenCalled();
+        });
+
         it('should retry the DLQ publish before falling back', async () => {
           // Given: DLQ publish fails once, then succeeds
           const options: JetstreamModuleOptions = {

--- a/src/server/routing/__tests__/event.router.spec.ts
+++ b/src/server/routing/__tests__/event.router.spec.ts
@@ -1617,6 +1617,44 @@ describe(EventRouter, () => {
       expect((msg.working as ReturnType<typeof vi.fn>).mock.calls.length).toBe(countAfterDone);
     });
 
+    it('should extend ack for backlogged messages while they wait for a slot', async () => {
+      // Given: concurrency 1 with ackExtension; the first handler hangs and
+      // holds the only slot, so the second message parks in the backlog —
+      // its ack_wait clock is already running on the server
+      sut = new EventRouter(messageProvider, patternRegistry, codec, eventBus, undefined, {
+        events: { concurrency: 1, ackExtension: 30 },
+      });
+      sut.start();
+
+      let resolveHandler!: () => void;
+      const handlerPromise = new Promise<void>((r) => {
+        resolveHandler = r;
+      });
+      const handler = vi.fn().mockReturnValue(handlerPromise);
+
+      patternRegistry.getHandler.mockReturnValue(handler);
+
+      const inFlight = createMock<JsMsg>({
+        subject: 'first.subject',
+        data: new TextEncoder().encode(JSON.stringify({})),
+      });
+      const queued = createMock<JsMsg>({
+        subject: 'second.subject',
+        data: new TextEncoder().encode(JSON.stringify({})),
+      });
+
+      // When: the second message waits in the backlog
+      events$.next(inFlight);
+      events$.next(queued);
+      await new Promise((r) => setTimeout(r, 120));
+
+      // Then: the queued message kept its ack alive while waiting
+      expect(queued.working).toHaveBeenCalled();
+
+      resolveHandler();
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
     it('should not call working() when ackExtension is disabled', async () => {
       // Given: default sut (no processingConfig)
       sut.start();

--- a/src/server/routing/__tests__/event.router.spec.ts
+++ b/src/server/routing/__tests__/event.router.spec.ts
@@ -80,6 +80,83 @@ describe(EventRouter, () => {
     });
   });
 
+  describe('settlement resilience', () => {
+    const createSettleMsg = (subject: string, ackImpl?: () => void): JsMsg =>
+      createMock<JsMsg>({
+        subject,
+        data: new TextEncoder().encode(JSON.stringify({})),
+        ...(ackImpl ? { ack: vi.fn(ackImpl) } : {}),
+      });
+
+    it('should keep routing after ack throws on the sync path with bounded concurrency', async () => {
+      // Given: concurrency 1 and a sync handler; the first message's ack
+      // throws (settlement is a publish — it fails when the connection drops)
+      const processingConfig: EventProcessingConfig = { events: { concurrency: 1 } };
+
+      sut = new EventRouter(
+        messageProvider,
+        patternRegistry,
+        codec,
+        eventBus,
+        undefined,
+        processingConfig,
+      );
+      sut.start();
+
+      const handler = vi.fn().mockReturnValue(undefined);
+
+      patternRegistry.getHandler.mockReturnValue(handler);
+
+      const failing = createSettleMsg('first.subject', () => {
+        throw new Error('connection closed');
+      });
+      const healthy = createSettleMsg('second.subject');
+
+      // When: both messages arrive
+      events$.next(failing);
+      events$.next(healthy);
+      await new Promise(process.nextTick);
+
+      // Then: the slot was released and the second message processed normally
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(healthy.ack).toHaveBeenCalled();
+    });
+
+    it('should free the concurrency slot when settlement fails on the async path', async () => {
+      // Given: concurrency 1 and an async handler; the first message's ack throws
+      const processingConfig: EventProcessingConfig = { events: { concurrency: 1 } };
+
+      sut = new EventRouter(
+        messageProvider,
+        patternRegistry,
+        codec,
+        eventBus,
+        undefined,
+        processingConfig,
+      );
+      sut.start();
+
+      const handler = vi.fn().mockResolvedValue(undefined);
+
+      patternRegistry.getHandler.mockReturnValue(handler);
+
+      const failing = createSettleMsg('first.subject', () => {
+        throw new Error('connection closed');
+      });
+      const healthy = createSettleMsg('second.subject');
+
+      // When: both messages arrive
+      events$.next(failing);
+      events$.next(healthy);
+      await new Promise(process.nextTick);
+      await new Promise(process.nextTick);
+
+      // Then: no unhandled rejection escapes and the second message is processed
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(healthy.ack).toHaveBeenCalled();
+    });
+  });
+
   describe('message handling', () => {
     beforeEach(() => {
       sut.start();

--- a/src/server/routing/__tests__/event.router.spec.ts
+++ b/src/server/routing/__tests__/event.router.spec.ts
@@ -1069,6 +1069,47 @@ describe(EventRouter, () => {
       });
 
       describe('when options.dlq is set — publish fails', () => {
+        it('should retry the DLQ publish before falling back', async () => {
+          // Given: DLQ publish fails once, then succeeds
+          const options: JetstreamModuleOptions = {
+            name: 'my-service',
+            servers: ['nats://localhost:4222'],
+            dlq: {},
+          };
+
+          mockJs.publish
+            .mockRejectedValueOnce(new Error('transient NATS hiccup'))
+            .mockResolvedValue(undefined);
+
+          sut = new EventRouter(
+            messageProvider,
+            patternRegistry,
+            codec,
+            eventBus,
+            deadLetterConfig,
+            undefined,
+            undefined,
+            connection,
+            options,
+          );
+          sut.start();
+
+          const handler = vi.fn().mockRejectedValue(new Error('handler error'));
+
+          patternRegistry.getHandler.mockReturnValue(handler);
+
+          const msg = createDeadLetterMsg();
+
+          // When: dead-letter message arrives
+          events$.next(msg);
+          await new Promise(process.nextTick);
+
+          // Then: second attempt landed the message in the DLQ — no fallback path
+          expect(mockJs.publish).toHaveBeenCalledTimes(2);
+          expect(msg.term).toHaveBeenCalledWith('Moved to DLQ stream');
+          expect(msg.nak).not.toHaveBeenCalled();
+        });
+
         it('should fall back to onDeadLetter callback and nak when DLQ publish throws', async () => {
           // Given: DLQ publish fails
           const options: JetstreamModuleOptions = {

--- a/src/server/routing/__tests__/event.router.spec.ts
+++ b/src/server/routing/__tests__/event.router.spec.ts
@@ -930,6 +930,65 @@ describe(EventRouter, () => {
           expect(msg.term).toHaveBeenCalledWith('Moved to DLQ stream');
         });
 
+        it('should strip NATS control headers from the DLQ republish', async () => {
+          // Given: a message that carries server control headers from the
+          // original publish (per-message TTL, dedup id)
+          const options: JetstreamModuleOptions = {
+            name: 'my-service',
+            servers: ['nats://localhost:4222'],
+            dlq: {},
+          };
+
+          sut = new EventRouter(
+            messageProvider,
+            patternRegistry,
+            codec,
+            eventBus,
+            deadLetterConfig,
+            undefined,
+            undefined,
+            connection,
+            options,
+          );
+          sut.start();
+
+          const handler = vi.fn().mockRejectedValue(new Error('handler error'));
+
+          patternRegistry.getHandler.mockReturnValue(handler);
+
+          const mockHeaders = new Map([
+            ['Nats-TTL', ['30s']],
+            ['Nats-Msg-Id', ['original-id']],
+            ['X-Trace-Id', ['abc123']],
+          ]);
+          const msg = createMock<JsMsg>({
+            subject: 'test.subject',
+            data: new TextEncoder().encode(JSON.stringify({ key: 'value' })),
+            headers: mockHeaders as unknown as JsMsg['headers'],
+            info: {
+              deliveryCount: 3,
+              stream: streamName,
+              streamSequence: 42,
+              redelivered: true,
+              timestampNanos: Date.now() * 1_000_000,
+            } as DeliveryInfo,
+          });
+
+          // When: dead-letter message arrives
+          events$.next(msg);
+          await new Promise(process.nextTick);
+
+          // Then: control headers are gone (a copied Nats-TTL would expire the
+          // DLQ entry or get the publish rejected), diagnostics are preserved
+          const publishCall = mockJs.publish.mock.calls[0]!;
+          const dlqHeaders = publishCall[2].headers;
+
+          expect(dlqHeaders.get('Nats-TTL')).toBe('');
+          expect(dlqHeaders.get('Nats-Msg-Id')).toBe('');
+          expect(dlqHeaders.get('X-Trace-Id')).toBe('abc123');
+          expect(msg.term).toHaveBeenCalledWith('Moved to DLQ stream');
+        });
+
         it('should use error.message as reason for Error instances', async () => {
           // Given: handler throws a proper Error
           const options: JetstreamModuleOptions = {

--- a/src/server/routing/__tests__/rpc.router.spec.ts
+++ b/src/server/routing/__tests__/rpc.router.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock, type Mocked } from 'vitest';
 import { createMock } from '@golevelup/ts-vitest';
 import { faker } from '@faker-js/faker';
 import type { MsgHdrs, NatsConnection } from '@nats-io/transport-node';
@@ -423,6 +423,76 @@ describe(RpcRouter, () => {
 
         sut.destroy();
         vi.useRealTimers();
+      });
+    });
+
+    describe('when term throws inside the timeout timer', () => {
+      it('should contain the failure instead of crashing the process', async () => {
+        vi.useFakeTimers();
+
+        // Given: a hanging handler and a term that throws (degraded connection)
+        sut = new RpcRouter(messageProvider, patternRegistry, connection, codec, eventBus, {
+          timeout: 100,
+        });
+        await sut.start();
+
+        const handler = vi.fn().mockReturnValue(new Promise(() => {}));
+
+        patternRegistry.getHandler.mockReturnValue(handler);
+
+        const correlationId = faker.string.uuid();
+        const msg = createRpcMsg('slow.cmd', {}, faker.string.uuid(), correlationId);
+
+        (msg.term as Mock).mockImplementation(() => {
+          throw new Error('connection closed');
+        });
+
+        commands$.next(msg);
+
+        // Then: the timer callback must not surface the throw as an uncaught
+        // exception, and the timeout signal still fires
+        expect(() => vi.advanceTimersByTime(100)).not.toThrow();
+        expect(eventBus.emit).toHaveBeenCalledWith(
+          TransportEvent.RpcTimeout,
+          msg.subject,
+          correlationId,
+        );
+
+        sut.destroy();
+        vi.useRealTimers();
+      });
+    });
+
+    describe('when ack throws on the sync path with bounded concurrency', () => {
+      it('should release the slot and keep processing', async () => {
+        // Given: concurrency 1, sync handler, first message's ack throws
+        sut = new RpcRouter(messageProvider, patternRegistry, connection, codec, eventBus, {
+          concurrency: 1,
+        });
+        await sut.start();
+
+        const handler = vi.fn().mockReturnValue({ ok: true });
+
+        patternRegistry.getHandler.mockReturnValue(handler);
+
+        const failing = createRpcMsg('cmd.one', {}, faker.string.uuid(), faker.string.uuid());
+
+        (failing.ack as Mock).mockImplementation(() => {
+          throw new Error('connection closed');
+        });
+
+        const healthy = createRpcMsg('cmd.two', {}, faker.string.uuid(), faker.string.uuid());
+
+        // When: both commands arrive
+        commands$.next(failing);
+        commands$.next(healthy);
+        await new Promise(process.nextTick);
+
+        // Then: the second command is still handled
+        expect(handler).toHaveBeenCalledTimes(2);
+        expect(healthy.ack).toHaveBeenCalled();
+
+        sut.destroy();
       });
     });
 

--- a/src/server/routing/__tests__/rpc.router.spec.ts
+++ b/src/server/routing/__tests__/rpc.router.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock, type Mocked } from 'vitest';
+import { Logger } from '@nestjs/common';
 import { createMock } from '@golevelup/ts-vitest';
 import { faker } from '@faker-js/faker';
 import type { MsgHdrs, NatsConnection } from '@nats-io/transport-node';
@@ -496,6 +497,85 @@ describe(RpcRouter, () => {
       });
     });
 
+    describe('when the handler throws synchronously', () => {
+      it('should reply with the error and term the command', async () => {
+        // Given: a handler that throws before returning a promise
+        await sut.start();
+
+        const handler = vi.fn().mockImplementation(() => {
+          throw new Error('sync failure');
+        });
+
+        patternRegistry.getHandler.mockReturnValue(handler);
+
+        const replyTo = faker.string.uuid();
+        const correlationId = faker.string.uuid();
+        const msg = createRpcMsg('cmd.sync-fail', {}, replyTo, correlationId);
+
+        // When: the command arrives
+        commands$.next(msg);
+        await new Promise(process.nextTick);
+
+        // Then: caller gets an error reply, the command is terminated, no ack
+        expect(mockNc.publish).toHaveBeenCalledWith(
+          replyTo,
+          expect.any(Uint8Array),
+          expect.anything(),
+        );
+        expect(msg.term).toHaveBeenCalledWith('Handler error: cmd.sync-fail');
+        expect(msg.ack).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the commands stream errors', () => {
+      it('should log and not crash', async () => {
+        // Given
+        const errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+
+        await sut.start();
+
+        // When: the underlying observable errors
+        commands$.error(new Error('stream exploded'));
+
+        // Then
+        expect(errorSpy).toHaveBeenCalledWith('Stream error in RPC router', expect.any(Error));
+
+        errorSpy.mockRestore();
+      });
+    });
+
+    describe('when the routing promise itself rejects', () => {
+      it('should log the failure and release the concurrency slot', async () => {
+        // Given: concurrency 1; the handler rejects AND the error-reporting
+        // hook throws, so the rejection escapes the settlement path entirely
+        sut = new RpcRouter(messageProvider, patternRegistry, connection, codec, eventBus, {
+          concurrency: 1,
+        });
+        await sut.start();
+
+        eventBus.emit.mockImplementation(() => {
+          throw new Error('hook exploded');
+        });
+
+        const handler = vi.fn().mockRejectedValue(new Error('handler failed'));
+
+        patternRegistry.getHandler.mockReturnValue(handler);
+
+        const failing = createRpcMsg('cmd.one', {}, faker.string.uuid(), faker.string.uuid());
+        const healthy = createRpcMsg('cmd.two', {}, faker.string.uuid(), faker.string.uuid());
+
+        // When: both commands arrive
+        commands$.next(failing);
+        commands$.next(healthy);
+        await new Promise((r) => setTimeout(r, 20));
+
+        // Then: no unhandled rejection escaped and the slot was released
+        expect(handler).toHaveBeenCalledTimes(2);
+
+        sut.destroy();
+      });
+    });
+
     describe('when handle() throws an unexpected error', () => {
       it('should catch via catchError and keep the subscription alive', async () => {
         await sut.start();
@@ -675,6 +755,77 @@ describe(RpcRouter, () => {
       await new Promise((r) => setTimeout(r, 100));
 
       expect((msg.working as ReturnType<typeof vi.fn>).mock.calls.length).toBe(countAfterDone);
+    });
+
+    it('should extend ack for backlogged commands while they wait for a slot', async () => {
+      // Given: concurrency 1 with ackExtension; the first handler hangs and
+      // holds the only slot, so the second command parks in the backlog
+      sut = new RpcRouter(messageProvider, patternRegistry, connection, codec, eventBus, {
+        concurrency: 1,
+        ackExtension: 30,
+      });
+      await sut.start();
+
+      let resolveHandler!: () => void;
+      const handlerPromise = new Promise<void>((r) => {
+        resolveHandler = r;
+      });
+      const handler = vi.fn().mockReturnValue(handlerPromise);
+
+      patternRegistry.getHandler.mockReturnValue(handler);
+
+      const inFlight = createRpcMsg('cmd.one', {}, faker.string.uuid(), faker.string.uuid());
+      const queued = createRpcMsg('cmd.two', {}, faker.string.uuid(), faker.string.uuid());
+
+      // When: the second command waits in the backlog
+      commands$.next(inFlight);
+      commands$.next(queued);
+      await new Promise((r) => setTimeout(r, 120));
+
+      // Then: the queued command kept its ack alive while waiting
+      expect(queued.working).toHaveBeenCalled();
+
+      resolveHandler();
+      await new Promise((r) => setTimeout(r, 10));
+      sut.destroy();
+    });
+
+    it('should stop parked extension timers when the router is destroyed', async () => {
+      // Given: a command parked in the backlog with its waiting-phase timer
+      sut = new RpcRouter(messageProvider, patternRegistry, connection, codec, eventBus, {
+        concurrency: 1,
+        ackExtension: 30,
+      });
+      await sut.start();
+
+      let resolveHandler!: () => void;
+      const handlerPromise = new Promise<void>((r) => {
+        resolveHandler = r;
+      });
+      const handler = vi.fn().mockReturnValue(handlerPromise);
+
+      patternRegistry.getHandler.mockReturnValue(handler);
+
+      const inFlight = createRpcMsg('cmd.one', {}, faker.string.uuid(), faker.string.uuid());
+      const queued = createRpcMsg('cmd.two', {}, faker.string.uuid(), faker.string.uuid());
+
+      commands$.next(inFlight);
+      commands$.next(queued);
+      await new Promise((r) => setTimeout(r, 70));
+
+      // When: the router shuts down
+      sut.destroy();
+
+      const countAtDestroy = (queued.working as ReturnType<typeof vi.fn>).mock.calls.length;
+
+      // Then: nothing keeps ticking for the parked command
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect((queued.working as ReturnType<typeof vi.fn>).mock.calls.length).toBe(countAtDestroy);
+
+      // Settle the in-flight handler so its processing-phase timer stops too
+      resolveHandler();
+      await new Promise((r) => setTimeout(r, 10));
     });
 
     it('should clear working() interval on timeout', async () => {

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -507,15 +507,21 @@ export class EventRouter {
    * failed and we still have to surface the message somewhere observable.
    */
   private async fallbackToOnDeadLetterCallback(info: DeadLetterInfo, msg: JsMsg): Promise<void> {
-    // Safety net: deadLetterConfig is guaranteed by isDeadLetter() guard,
-    // but if somehow null, term the message to prevent infinite redelivery.
-    if (!this.deadLetterConfig) {
-      msg.term('Dead letter config unavailable');
+    const onDeadLetter = this.deadLetterConfig?.onDeadLetter;
+
+    if (!onDeadLetter) {
+      // dlq-only mode and the DLQ publish failed: there is no callback to fall
+      // back to. Keep the message in the stream rather than deleting it.
+      this.logger.error(
+        `Dead letter for ${msg.subject} could not be captured (DLQ publish failed, no onDeadLetter callback) — leaving the message in the stream`,
+      );
+      msg.nak();
+
       return;
     }
 
     try {
-      await this.deadLetterConfig.onDeadLetter(info);
+      await onDeadLetter(info);
       msg.term('Dead letter processed via fallback callback');
     } catch (hookErr) {
       this.logger.error(

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -7,7 +7,7 @@ import { RpcContext } from '../../context';
 import { EventBus } from '../../hooks';
 import { MessageKind, StreamKind, TransportEvent } from '../../interfaces';
 import { ConnectionProvider } from '../../connection';
-import { headers as natsHeaders } from '@nats-io/transport-node';
+import { headers as natsHeaders, type MsgHdrs } from '@nats-io/transport-node';
 
 import type {
   Codec,
@@ -39,6 +39,9 @@ import {
 
 /** Narrow consume-kind tag emitted by the event router (no `Rpc` here). */
 type EventConsumeKind = Exclude<ConsumeKind, ConsumeKind.Rpc>;
+
+/** How many times a dead letter is published to the DLQ stream before falling back. */
+const DLQ_PUBLISH_ATTEMPTS = 3;
 
 /**
  * Resolved routing shape for one incoming event/broadcast/ordered message —
@@ -542,9 +545,10 @@ export class EventRouter {
 
   /**
    * Last-resort path for a dead letter: invoke `onDeadLetter`, then `term` on
-   * success or `nak` on hook failure so NATS retries on the next delivery
-   * cycle. Used when DLQ stream isn't configured, or when publishing to it
-   * failed and we still have to surface the message somewhere observable.
+   * success. On failure the message is nak'd to release it, but the server
+   * never redelivers past `max_deliver` — it stays in the stream for manual
+   * recovery. Used when the DLQ stream isn't configured, or when publishing
+   * to it failed and we still have to surface the message somewhere.
    */
   private async fallbackToOnDeadLetterCallback(info: DeadLetterInfo, msg: JsMsg): Promise<void> {
     const onDeadLetter = this.deadLetterConfig?.onDeadLetter;
@@ -565,11 +569,46 @@ export class EventRouter {
       msg.term('Dead letter processed via fallback callback');
     } catch (hookErr) {
       this.logger.error(
-        `Fallback onDeadLetter callback failed for ${msg.subject}, nak for retry:`,
+        `Fallback onDeadLetter callback failed for ${msg.subject} — the message stays in the stream and will not be redelivered (max_deliver exhausted); recover it manually:`,
         hookErr,
       );
       msg.nak();
     }
+  }
+
+  /**
+   * Attempt the DLQ publish up to {@link DLQ_PUBLISH_ATTEMPTS} times.
+   *
+   * Past `max_deliver` the server never redelivers, so an in-process retry is
+   * the only second chance a dead letter gets. There is no artificial delay
+   * between attempts: when the broker is unreachable each publish already
+   * spends its own request timeout, which spaces the attempts naturally.
+   */
+  private async publishToDlqWithRetry(
+    connection: ConnectionProvider,
+    subject: string,
+    data: Uint8Array,
+    headers: MsgHdrs,
+  ): Promise<void> {
+    let lastErr: unknown;
+
+    for (let attempt = 1; attempt <= DLQ_PUBLISH_ATTEMPTS; attempt += 1) {
+      try {
+        await connection.getJetStreamClient().publish(subject, data, { headers });
+
+        return;
+      } catch (err) {
+        lastErr = err;
+
+        if (attempt < DLQ_PUBLISH_ATTEMPTS) {
+          this.logger.warn(
+            `DLQ publish attempt ${attempt}/${DLQ_PUBLISH_ATTEMPTS} failed for ${subject}, retrying`,
+          );
+        }
+      }
+    }
+
+    throw lastErr;
   }
 
   /**
@@ -617,9 +656,7 @@ export class EventRouter {
     hdrs.set(JetstreamDlqHeader.DeliveryCount, msg.info.deliveryCount.toString());
 
     try {
-      const js = this.connection.getJetStreamClient();
-
-      await js.publish(destinationSubject, msg.data, { headers: hdrs });
+      await this.publishToDlqWithRetry(this.connection, destinationSubject, msg.data, hdrs);
       this.logger.log(`Message sent to DLQ: ${msg.subject}`);
 
       if (this.deadLetterConfig?.onDeadLetter) {

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -59,6 +59,15 @@ interface ResolvedEvent {
   readonly data: unknown;
 }
 
+/**
+ * A delivered message parked in the concurrency backlog, together with the
+ * ack-extension timer that keeps it alive while it waits for a slot.
+ */
+interface QueuedMessage {
+  readonly msg: JsMsg;
+  readonly stopAckExtension: (() => void) | null;
+}
+
 const eventConsumeKindFor = (kind: StreamKind): EventConsumeKind => {
   if (kind === StreamKind.Broadcast) return ConsumeKind.Broadcast;
   if (kind === StreamKind.Ordered) return ConsumeKind.Ordered;
@@ -534,7 +543,7 @@ export class EventRouter {
     const backlogWarnThreshold = 1_000;
     let active = 0;
     let backlogWarned = false;
-    const backlog: JsMsg[] = [];
+    const backlog: QueuedMessage[] = [];
 
     const onAsyncDone = (): void => {
       active--;
@@ -567,11 +576,14 @@ export class EventRouter {
         const next = backlog.shift();
 
         if (next === undefined) return;
+        // The processing-phase timer is started inside route(); the waiting
+        // phase is over.
+        next.stopAckExtension?.();
         active++;
-        const result = routeSafely(next);
+        const result = routeSafely(next.msg);
 
         if (result !== undefined) {
-          trackAsync(result, next);
+          trackAsync(result, next.msg);
         } else {
           active--;
         }
@@ -583,7 +595,15 @@ export class EventRouter {
     const subscription = stream$.subscribe({
       next: (msg: JsMsg): void => {
         if (active >= maxActive) {
-          backlog.push(msg);
+          // A parked message was already delivered — its ack_wait clock is
+          // running on the server. Without extension a long wait ends in
+          // redelivery and double processing.
+          backlog.push({
+            msg,
+            stopAckExtension: hasAckExtension
+              ? startAckExtensionTimer(msg, ackExtensionInterval)
+              : null,
+          });
           if (!backlogWarned && backlog.length >= backlogWarnThreshold) {
             backlogWarned = true;
             logger.warn(
@@ -607,6 +627,16 @@ export class EventRouter {
       error: (err: unknown): void => {
         logger.error(`Stream error in ${kind} router`, err);
       },
+    });
+
+    // Backlogged messages keep extension timers alive — stop them when the
+    // router unsubscribes so a destroyed router leaves nothing ticking.
+    subscription.add(() => {
+      for (const queued of backlog) {
+        queued.stopAckExtension?.();
+      }
+
+      backlog.length = 0;
     });
 
     this.subscriptions.push(subscription);

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -177,10 +177,37 @@ export class EventRouter {
           this.handleDeadLetter(msg, data, err)
       : null;
 
-    const settleSuccess = (msg: JsMsg, ctx: RpcContext): void => {
-      if (ctx.shouldTerminate) msg.term(ctx.terminateReason);
-      else if (ctx.shouldRetry) msg.nak(ctx.retryDelay);
-      else msg.ack();
+    /**
+     * Settle a message whose handler completed without throwing.
+     *
+     * Returns a Promise only when a `retry()` on the final permitted delivery
+     * escalates to dead-letter handling — a nak at that point would strand the
+     * message, since the server never redelivers past `max_deliver`.
+     */
+    const settleSuccess = (msg: JsMsg, ctx: RpcContext, data: unknown): Promise<void> | undefined => {
+      if (ctx.shouldTerminate) {
+        msg.term(ctx.terminateReason);
+
+        return undefined;
+      }
+
+      if (ctx.shouldRetry) {
+        if (handleDeadLetter !== null && isDeadLetter(msg)) {
+          return handleDeadLetter(
+            msg,
+            data,
+            new Error('Retry requested on the final delivery attempt'),
+          );
+        }
+
+        msg.nak(ctx.retryDelay);
+
+        return undefined;
+      }
+
+      msg.ack();
+
+      return undefined;
     };
 
     const settleFailure = async (msg: JsMsg, data: unknown, err: unknown): Promise<void> => {
@@ -309,18 +336,31 @@ export class EventRouter {
       }
 
       if (!isPromiseLike(pending)) {
-        settleSuccess(msg, ctx);
-        reportHandlerCompleted(msg, startedAt, statusForContext(ctx));
-        if (stopAckExtension !== null) stopAckExtension();
+        const settled = settleSuccess(msg, ctx, data);
 
-        return undefined;
+        reportHandlerCompleted(msg, startedAt, statusForContext(ctx));
+
+        if (settled === undefined) {
+          if (stopAckExtension !== null) stopAckExtension();
+
+          return undefined;
+        }
+
+        // Same ack-extension reasoning as the failure path: the dead-letter
+        // publish may outlast ack_wait.
+        return settled.finally(() => {
+          if (stopAckExtension !== null) stopAckExtension();
+        });
       }
 
       return (pending as Promise<unknown>).then(
-        () => {
-          settleSuccess(msg, ctx);
-          reportHandlerCompleted(msg, startedAt, statusForContext(ctx));
-          if (stopAckExtension !== null) stopAckExtension();
+        async () => {
+          try {
+            await settleSuccess(msg, ctx, data);
+            reportHandlerCompleted(msg, startedAt, statusForContext(ctx));
+          } finally {
+            if (stopAckExtension !== null) stopAckExtension();
+          }
         },
         async (err: unknown) => {
           eventBus.emit(

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -20,6 +20,7 @@ import type {
 import {
   isPromiseLike,
   resolveAckExtensionInterval,
+  settleQuietly,
   startAckExtensionTimer,
   unwrapResult,
 } from '../../utils';
@@ -197,7 +198,9 @@ export class EventRouter {
       data: unknown,
     ): Promise<void> | undefined => {
       if (ctx.shouldTerminate) {
-        msg.term(ctx.terminateReason);
+        settleQuietly(logger, `Failed to term ${msg.subject}:`, () => {
+          msg.term(ctx.terminateReason);
+        });
 
         return undefined;
       }
@@ -211,12 +214,16 @@ export class EventRouter {
           );
         }
 
-        msg.nak(ctx.retryDelay);
+        settleQuietly(logger, `Failed to nak ${msg.subject}:`, () => {
+          msg.nak(ctx.retryDelay);
+        });
 
         return undefined;
       }
 
-      msg.ack();
+      settleQuietly(logger, `Failed to ack ${msg.subject}:`, () => {
+        msg.ack();
+      });
 
       return undefined;
     };
@@ -228,7 +235,9 @@ export class EventRouter {
         return;
       }
 
-      msg.nak();
+      settleQuietly(logger, `Failed to nak ${msg.subject}:`, () => {
+        msg.nak();
+      });
     };
 
     /**
@@ -532,16 +541,37 @@ export class EventRouter {
       drainBacklog();
     };
 
+    // route() is not expected to throw — every settlement inside it is
+    // guarded — but a failure here must never leak the concurrency slot or
+    // escape into the RxJS observer and kill the subscription.
+    const routeSafely = (msg: JsMsg): Promise<void> | undefined => {
+      try {
+        return route(msg);
+      } catch (err) {
+        logger.error(`Unexpected routing failure for ${msg.subject}:`, err);
+
+        return undefined;
+      }
+    };
+
+    const trackAsync = (result: Promise<void>, msg: JsMsg): void => {
+      void result
+        .catch((err: unknown) => {
+          logger.error(`Unexpected routing failure for ${msg.subject}:`, err);
+        })
+        .finally(onAsyncDone);
+    };
+
     const drainBacklog = (): void => {
       while (active < maxActive) {
         const next = backlog.shift();
 
         if (next === undefined) return;
         active++;
-        const result = route(next);
+        const result = routeSafely(next);
 
         if (result !== undefined) {
-          void result.finally(onAsyncDone);
+          trackAsync(result, next);
         } else {
           active--;
         }
@@ -565,10 +595,10 @@ export class EventRouter {
         }
 
         active++;
-        const result = route(msg);
+        const result = routeSafely(msg);
 
         if (result !== undefined) {
-          void result.finally(onAsyncDone);
+          trackAsync(result, msg);
         } else {
           active--;
           if (backlog.length > 0) drainBacklog();
@@ -610,20 +640,26 @@ export class EventRouter {
       this.logger.error(
         `Dead letter for ${msg.subject} could not be captured (DLQ publish failed, no onDeadLetter callback) — leaving the message in the stream`,
       );
-      msg.nak();
+      settleQuietly(this.logger, `Failed to nak ${msg.subject}:`, () => {
+        msg.nak();
+      });
 
       return;
     }
 
     try {
       await onDeadLetter(info);
-      msg.term('Dead letter processed via fallback callback');
+      settleQuietly(this.logger, `Failed to term ${msg.subject}:`, () => {
+        msg.term('Dead letter processed via fallback callback');
+      });
     } catch (hookErr) {
       this.logger.error(
         `Fallback onDeadLetter callback failed for ${msg.subject} — the message stays in the stream and will not be redelivered (max_deliver exhausted); recover it manually:`,
         hookErr,
       );
-      msg.nak();
+      settleQuietly(this.logger, `Failed to nak ${msg.subject}:`, () => {
+        msg.nak();
+      });
     }
   }
 
@@ -735,7 +771,9 @@ export class EventRouter {
         }
       }
 
-      msg.term('Moved to DLQ stream');
+      settleQuietly(this.logger, `Failed to term ${msg.subject}:`, () => {
+        msg.term('Moved to DLQ stream');
+      });
     } catch (publishErr) {
       this.logger.error(`Failed to publish to DLQ for ${msg.subject}:`, publishErr);
       await this.fallbackToOnDeadLetterCallback(info, msg);

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -187,7 +187,11 @@ export class EventRouter {
      * escalates to dead-letter handling — a nak at that point would strand the
      * message, since the server never redelivers past `max_deliver`.
      */
-    const settleSuccess = (msg: JsMsg, ctx: RpcContext, data: unknown): Promise<void> | undefined => {
+    const settleSuccess = (
+      msg: JsMsg,
+      ctx: RpcContext,
+      data: unknown,
+    ): Promise<void> | undefined => {
       if (ctx.shouldTerminate) {
         msg.term(ctx.terminateReason);
 
@@ -224,21 +228,54 @@ export class EventRouter {
     };
 
     /**
+     * Capture a message that can never be routed (no handler, undecodable
+     * payload). Redelivery cannot fix these, so they go straight to
+     * dead-letter handling regardless of delivery count. On a workqueue
+     * stream a plain term() would delete the payload permanently.
+     */
+    const captureUnroutable = (
+      capture: NonNullable<typeof handleDeadLetter>,
+      msg: JsMsg,
+      err: Error,
+    ): Promise<void> => {
+      let data: unknown;
+
+      try {
+        data = codec.decode(msg.data);
+      } catch {
+        data = undefined;
+      }
+
+      return capture(msg, data, err).catch((captureErr: unknown) => {
+        logger.error(`Dead-letter capture failed for unroutable ${msg.subject}:`, captureErr);
+      });
+    };
+
+    /**
      * Resolve the handler and decode payload for one event.
      *
-     * Returns `null` when the message cannot be routed (no handler, decode
-     * error, or unexpected pre-dispatch failure) — those branches settle the
-     * message synchronously inside the helper and produce nothing to dispatch.
+     * Returns `null` when the message cannot be routed and was settled
+     * synchronously, a Promise when an unroutable message is being captured
+     * by dead-letter handling, and a {@link ResolvedEvent} otherwise.
      */
-    const resolveEvent = (msg: JsMsg): ResolvedEvent | null => {
+    const resolveEvent = (msg: JsMsg): ResolvedEvent | Promise<void> | null => {
       const subject = msg.subject;
 
       try {
         const handler = patternRegistry.getHandler(subject);
 
         if (!handler) {
-          msg.term(`No handler for event: ${subject}`);
           logger.error(`No handler for subject: ${subject}`);
+
+          if (handleDeadLetter !== null) {
+            return captureUnroutable(
+              handleDeadLetter,
+              msg,
+              new Error(`No handler for event: ${subject}`),
+            );
+          }
+
+          msg.term(`No handler for event: ${subject}`);
 
           return null;
         }
@@ -248,8 +285,17 @@ export class EventRouter {
         try {
           data = codec.decode(msg.data);
         } catch (err) {
-          msg.term('Decode error');
           logger.error(`Decode error for ${subject}:`, err);
+
+          if (handleDeadLetter !== null) {
+            return captureUnroutable(
+              handleDeadLetter,
+              msg,
+              new Error(`Decode error: ${err instanceof Error ? err.message : String(err)}`),
+            );
+          }
+
+          msg.term('Decode error');
 
           return null;
         }
@@ -293,6 +339,7 @@ export class EventRouter {
       const resolved = resolveEvent(msg);
 
       if (resolved === null) return undefined;
+      if (isPromiseLike(resolved)) return resolved as Promise<void>;
 
       const { handler, data } = resolved;
       const ctx = new RpcContext([msg]);

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -26,7 +26,11 @@ import {
 
 import { MessageProvider } from '../infrastructure';
 import { PatternRegistry } from './pattern-registry';
-import { dlqStreamName, JetstreamDlqHeader } from '../../jetstream.constants';
+import {
+  dlqStreamName,
+  JetstreamDlqHeader,
+  NATS_CONTROL_HEADER_PREFIX,
+} from '../../jetstream.constants';
 import {
   ConsumeKind,
   deriveOtelAttrs,
@@ -624,6 +628,28 @@ export class EventRouter {
   }
 
   /**
+   * Copy the original message headers for the DLQ republish, dropping NATS
+   * server control headers: a copied Nats-TTL expires the DLQ entry (or gets
+   * the publish rejected when the DLQ stream has no allow_msg_ttl), a copied
+   * Nats-Msg-Id collides with the DLQ dedup window.
+   */
+  private buildDlqHeaders(msg: JsMsg): MsgHdrs {
+    const hdrs = natsHeaders();
+
+    if (!msg.headers) return hdrs;
+
+    for (const [k, v] of msg.headers) {
+      if (k.toLowerCase().startsWith(NATS_CONTROL_HEADER_PREFIX)) continue;
+
+      for (const val of v) {
+        hdrs.append(k, val);
+      }
+    }
+
+    return hdrs;
+  }
+
+  /**
    * Attempt the DLQ publish up to {@link DLQ_PUBLISH_ATTEMPTS} times.
    *
    * Past `max_deliver` the server never redelivers, so an in-process retry is
@@ -678,15 +704,7 @@ export class EventRouter {
     }
 
     const destinationSubject = dlqStreamName(serviceName);
-    const hdrs = natsHeaders();
-
-    if (msg.headers) {
-      for (const [k, v] of msg.headers) {
-        for (const val of v) {
-          hdrs.append(k, val);
-        }
-      }
-    }
+    const hdrs = this.buildDlqHeaders(msg);
 
     let reason = String(error);
 

--- a/src/server/routing/rpc.router.ts
+++ b/src/server/routing/rpc.router.ts
@@ -49,6 +49,15 @@ interface ResolvedCommand {
 }
 
 /**
+ * A delivered command parked in the concurrency backlog, together with the
+ * ack-extension timer that keeps it alive while it waits for a slot.
+ */
+interface QueuedCommand {
+  readonly msg: JsMsg;
+  readonly stopAckExtension: (() => void) | null;
+}
+
+/**
  * Routes RPC command messages in JetStream mode.
  *
  * Delivery semantics:
@@ -355,7 +364,7 @@ export class RpcRouter {
     const backlogWarnThreshold = 1_000;
     let active = 0;
     let backlogWarned = false;
-    const backlog: JsMsg[] = [];
+    const backlog: QueuedCommand[] = [];
 
     const onAsyncDone = (): void => {
       active--;
@@ -388,11 +397,14 @@ export class RpcRouter {
         const next = backlog.shift();
 
         if (next === undefined) return;
+        // The processing-phase timer is started inside handleSafe(); the
+        // waiting phase is over.
+        next.stopAckExtension?.();
         active++;
-        const result = routeSafely(next);
+        const result = routeSafely(next.msg);
 
         if (result !== undefined) {
-          trackAsync(result, next);
+          trackAsync(result, next.msg);
         } else {
           active--;
         }
@@ -404,7 +416,15 @@ export class RpcRouter {
     this.subscription = this.messageProvider.commands$.subscribe({
       next: (msg: JsMsg): void => {
         if (active >= maxActive) {
-          backlog.push(msg);
+          // A parked command was already delivered — its ack_wait clock is
+          // running on the server. Without extension a long wait ends in
+          // redelivery and a duplicate execution.
+          backlog.push({
+            msg,
+            stopAckExtension: hasAckExtension
+              ? startAckExtensionTimer(msg, ackExtensionInterval)
+              : null,
+          });
           if (!backlogWarned && backlog.length >= backlogWarnThreshold) {
             backlogWarned = true;
             logger.warn(
@@ -428,6 +448,16 @@ export class RpcRouter {
       error: (err: unknown): void => {
         logger.error('Stream error in RPC router', err);
       },
+    });
+
+    // Backlogged commands keep extension timers alive — stop them when the
+    // router unsubscribes so a destroyed router leaves nothing ticking.
+    this.subscription.add(() => {
+      for (const queued of backlog) {
+        queued.stopAckExtension?.();
+      }
+
+      backlog.length = 0;
     });
   }
 

--- a/src/server/routing/rpc.router.ts
+++ b/src/server/routing/rpc.router.ts
@@ -27,6 +27,7 @@ import {
   isPromiseLike,
   resolveAckExtensionInterval,
   serializeError,
+  settleQuietly,
   startAckExtensionTimer,
   unwrapResult,
 } from '../../utils';
@@ -259,7 +260,9 @@ export class RpcRouter {
           `rpc-handler:${subject}`,
         );
         publishErrorReply(replyTo, correlationId, subject, err);
-        msg.term(`Handler error: ${subject}`);
+        settleQuietly(logger, `Failed to term ${subject}:`, () => {
+          msg.term(`Handler error: ${subject}`);
+        });
       };
 
       // Abort wire that the handler-deadline timer uses to close the
@@ -294,7 +297,9 @@ export class RpcRouter {
 
       if (!isPromiseLike(pending)) {
         if (stopAckExtension !== null) stopAckExtension();
-        msg.ack();
+        settleQuietly(logger, `Failed to ack ${subject}:`, () => {
+          msg.ack();
+        });
         publishReply(replyTo, correlationId, pending);
         reportHandlerCompleted(msg, startedAt, 'success');
 
@@ -311,7 +316,11 @@ export class RpcRouter {
         abortController.abort();
         // RpcTimeout hook is the canonical signal here — no separate log.
         emitRpcTimeout(subject, correlationId);
-        msg.term('Handler timeout');
+        // This runs inside a bare timer callback — an unguarded term throw
+        // on a degraded connection would surface as an uncaught exception.
+        settleQuietly(logger, `Failed to term ${subject}:`, () => {
+          msg.term('Handler timeout');
+        });
         // Transport outcome is terminated — the handler's eventual resolution
         // is irrelevant once we've replied with timeout.
         reportHandlerCompleted(msg, startedAt, 'terminated');
@@ -323,7 +332,9 @@ export class RpcRouter {
           settled = true;
           clearTimeout(timeoutId);
           if (stopAckExtension !== null) stopAckExtension();
-          msg.ack();
+          settleQuietly(logger, `Failed to ack ${subject}:`, () => {
+            msg.ack();
+          });
           publishReply(replyTo, correlationId, result);
           reportHandlerCompleted(msg, startedAt, 'success');
         },
@@ -351,16 +362,37 @@ export class RpcRouter {
       drainBacklog();
     };
 
+    // handleSafe() is not expected to throw — settlement inside it is guarded
+    // — but a failure here must never leak the concurrency slot or escape
+    // into the RxJS observer and kill the subscription.
+    const routeSafely = (msg: JsMsg): Promise<void> | undefined => {
+      try {
+        return handleSafe(msg);
+      } catch (err) {
+        logger.error(`Unexpected routing failure for ${msg.subject}:`, err);
+
+        return undefined;
+      }
+    };
+
+    const trackAsync = (result: Promise<void>, msg: JsMsg): void => {
+      void result
+        .catch((err: unknown) => {
+          logger.error(`Unexpected routing failure for ${msg.subject}:`, err);
+        })
+        .finally(onAsyncDone);
+    };
+
     const drainBacklog = (): void => {
       while (active < maxActive) {
         const next = backlog.shift();
 
         if (next === undefined) return;
         active++;
-        const result = handleSafe(next);
+        const result = routeSafely(next);
 
         if (result !== undefined) {
-          void result.finally(onAsyncDone);
+          trackAsync(result, next);
         } else {
           active--;
         }
@@ -384,10 +416,10 @@ export class RpcRouter {
         }
 
         active++;
-        const result = handleSafe(msg);
+        const result = routeSafely(msg);
 
         if (result !== undefined) {
-          void result.finally(onAsyncDone);
+          trackAsync(result, msg);
         } else {
           active--;
           if (backlog.length > 0) drainBacklog();

--- a/src/server/strategy.ts
+++ b/src/server/strategy.ts
@@ -158,51 +158,34 @@ export class JetstreamStrategy extends Server implements CustomTransportStrategy
       await this.streamProvider.ensureStreams(streamKinds);
 
       // 4. Ensure durable consumers exist (ordered consumers are ephemeral — skip)
+      let consumers: Map<StreamKind, ConsumerInfo> | null = null;
+
       if (durableKinds.length > 0) {
-        const consumers = await this.consumerProvider.ensureConsumers(durableKinds);
+        consumers = await this.consumerProvider.ensureConsumers(durableKinds);
 
         // 5. Populate shared ack_wait map from actual NATS consumer configs
         this.populateAckWaitMap(consumers);
 
         // 6. Update DLQ thresholds from actual NATS consumer configs
         this.eventRouter.updateMaxDeliverMap(this.buildMaxDeliverMap(consumers));
-
-        // 7. Start durable message consumption
-        this.messageProvider.start(consumers);
       }
 
-      // 8. Start ordered consumer if handlers are registered
-      if (this.patternRegistry.hasOrderedHandlers()) {
-        const orderedStreamName = this.streamProvider.getStreamName(StreamKind.Ordered);
+      // 7. Subscribe routers BEFORE consumption starts. Consumers flush any
+      // pending backlog the moment they go live, and a message pushed into a
+      // subject with no observers is dropped unsettled — for commands
+      // (max_deliver: 1) that loss is permanent.
+      await this.startRouters();
 
-        await this.messageProvider.startOrdered(
-          orderedStreamName,
-          this.patternRegistry.getOrderedSubjects(),
-          this.options.ordered,
-        );
-      }
-
-      // 9. Start event router if any event-type handlers exist
-      if (
-        this.patternRegistry.hasEventHandlers() ||
-        this.patternRegistry.hasBroadcastHandlers() ||
-        this.patternRegistry.hasOrderedHandlers()
-      ) {
-        this.eventRouter.start();
-      }
-
-      // 10. Start RPC router if JetStream mode
-      if (isJetStreamRpcMode(this.options.rpc) && this.patternRegistry.hasRpcHandlers()) {
-        await this.rpcRouter.start();
-      }
+      // 8. Start durable and ordered message consumption
+      await this.startConsumption(consumers);
     }
 
-    // 11. Start Core RPC server if core mode
+    // 9. Start Core RPC server if core mode
     if (isCoreRpcMode(this.options.rpc) && this.patternRegistry.hasRpcHandlers()) {
       await this.coreRpcServer.start();
     }
 
-    // 12. Publish handler metadata to KV (non-critical — errors logged, not thrown)
+    // 10. Publish handler metadata to KV (non-critical — errors logged, not thrown)
     if (this.metadataProvider && this.patternRegistry.hasMetadata()) {
       await this.metadataProvider.publish(this.patternRegistry.getMetadataEntries());
     }
@@ -238,7 +221,38 @@ export class JetstreamStrategy extends Server implements CustomTransportStrategy
     return { streams, durableConsumers };
   }
 
-  /** Populate the shared ack_wait map from actual NATS consumer configs. */
+  /** Subscribe the event and RPC routers to the message subjects. */
+  private async startRouters(): Promise<void> {
+    if (
+      this.patternRegistry.hasEventHandlers() ||
+      this.patternRegistry.hasBroadcastHandlers() ||
+      this.patternRegistry.hasOrderedHandlers()
+    ) {
+      this.eventRouter.start();
+    }
+
+    if (isJetStreamRpcMode(this.options.rpc) && this.patternRegistry.hasRpcHandlers()) {
+      await this.rpcRouter.start();
+    }
+  }
+
+  /** Begin durable and ordered consumption; routers must already be subscribed. */
+  private async startConsumption(consumers: Map<StreamKind, ConsumerInfo> | null): Promise<void> {
+    if (consumers !== null) {
+      this.messageProvider.start(consumers);
+    }
+
+    if (this.patternRegistry.hasOrderedHandlers()) {
+      const orderedStreamName = this.streamProvider.getStreamName(StreamKind.Ordered);
+
+      await this.messageProvider.startOrdered(
+        orderedStreamName,
+        this.patternRegistry.getOrderedSubjects(),
+        this.options.ordered,
+      );
+    }
+  }
+
   private populateAckWaitMap(consumers: Map<StreamKind, ConsumerInfo>): void {
     for (const [kind, info] of consumers) {
       if (info.config.ack_wait) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,4 +2,6 @@ export { resolveAckExtensionInterval, startAckExtensionTimer } from './ack-exten
 
 export { serializeError } from './serialize-error';
 
+export { settleQuietly, type SettleLogger } from './settle-quietly';
+
 export { unwrapResult, isPromiseLike } from './unwrap-result';

--- a/src/utils/settle-quietly.ts
+++ b/src/utils/settle-quietly.ts
@@ -1,0 +1,19 @@
+/** Minimal logger surface needed by {@link settleQuietly} — matches NestJS Logger. */
+export interface SettleLogger {
+  error(message: string, error?: unknown): void;
+}
+
+/**
+ * Run a message-settlement call (`ack`/`nak`/`term`) that may throw when the
+ * connection is degraded — settlement is a publish under the hood. The error
+ * is logged instead of propagated so a dying connection cannot take a routing
+ * subscription or the process down with it; the unsettled message redelivers
+ * via `ack_wait` once the connection recovers.
+ */
+export const settleQuietly = (logger: SettleLogger, label: string, action: () => void): void => {
+  try {
+    action();
+  } catch (err) {
+    logger.error(label, err);
+  }
+};

--- a/test/integration/core-rpc.spec.ts
+++ b/test/integration/core-rpc.spec.ts
@@ -23,6 +23,11 @@ class RpcController {
     throw new RpcException('User not found');
   }
 
+  @MessagePattern('user.touch')
+  touchUser(@Payload() _data: { id: number }): void {
+    // command-style handler with no return value
+  }
+
   @MessagePattern('user.get-with-ctx')
   getUserWithCtx(
     @Payload() data: { id: number },
@@ -75,6 +80,15 @@ describe('Core RPC Round-Trip', () => {
     const result = await firstValueFrom(client.send('user.get', { id: 42 }));
 
     expect(result).toEqual({ id: 42, name: 'Test User' });
+  });
+
+  it('should complete cleanly when the handler returns nothing', async () => {
+    // Given/When: calling a void handler. NestJS skips next() for undefined
+    // responses, so the observable completes empty — the call must not
+    // surface a decode error.
+    await expect(
+      firstValueFrom(client.send('user.touch', { id: 42 }), { defaultValue: undefined }),
+    ).resolves.toBeUndefined();
   });
 
   it('should receive RpcException error from handler', async () => {

--- a/test/integration/dead-letter.spec.ts
+++ b/test/integration/dead-letter.spec.ts
@@ -1,12 +1,12 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { Controller, INestApplication } from '@nestjs/common';
-import { ClientProxy, EventPattern, Payload } from '@nestjs/microservices';
+import { ClientProxy, Ctx, EventPattern, Payload } from '@nestjs/microservices';
 import { TestingModule } from '@nestjs/testing';
 import type { NatsConnection } from '@nats-io/transport-node';
 import { firstValueFrom } from 'rxjs';
 import type { StartedTestContainer } from 'testcontainers';
 
-import type { DeadLetterInfo } from '../../src';
+import type { DeadLetterInfo, RpcContext } from '../../src';
 import { getClientToken, toNanos, dlqStreamName, JetstreamDlqHeader } from '../../src';
 import { jetstreamManager } from '@nats-io/jetstream';
 
@@ -27,6 +27,17 @@ class AlwaysFailingController {
   handleOrder(@Payload() _data: unknown): never {
     this.attempts++;
     throw new Error('Permanent failure');
+  }
+}
+
+@Controller()
+class AlwaysRetryingController {
+  public attempts = 0;
+
+  @EventPattern('order.postponed')
+  handleOrder(@Payload() _data: unknown, @Ctx() ctx: RpcContext): void {
+    this.attempts++;
+    ctx.retry();
   }
 }
 
@@ -159,6 +170,64 @@ describe('Dead Letter Queue Hook', () => {
       expect(controller.attempts).toBe(2);
     });
   });
+  describe('ctx.retry() exhausting deliveries', () => {
+    let app: INestApplication;
+    let module: TestingModule;
+    let client: ClientProxy;
+    let serviceName: string;
+    let controller: AlwaysRetryingController;
+
+    const deadLetters: DeadLetterInfo[] = [];
+
+    beforeEach(async () => {
+      serviceName = uniqueServiceName();
+      deadLetters.length = 0;
+
+      ({ app, module } = await createTestApp(
+        {
+          name: serviceName,
+          port,
+          events: {
+            consumer: {
+              max_deliver: 2,
+              ack_wait: toNanos(2, 'seconds'),
+            },
+          },
+          onDeadLetter: async (info) => {
+            deadLetters.push(info);
+          },
+        },
+        [AlwaysRetryingController],
+        [serviceName],
+      ));
+
+      client = module.get<ClientProxy>(getClientToken(serviceName));
+      controller = module.get(AlwaysRetryingController);
+    });
+
+    afterEach(async () => {
+      await app.close();
+      await cleanupStreams(nc, serviceName);
+    });
+
+    it('should treat retry() on the final delivery as a dead letter', async () => {
+      // Given: a handler that requests a business retry on every delivery
+      await firstValueFrom(client.emit('order.postponed', { orderId: 'retry-1' }));
+
+      // When: all delivery attempts are exhausted via ctx.retry()
+      await waitForCondition(() => deadLetters.length > 0, 10_000);
+
+      // Then: the dead letter is captured instead of stranding the message
+      expect(deadLetters).toHaveLength(1);
+      expect(deadLetters[0]).toMatchObject({
+        subject: expect.stringContaining('order.postponed'),
+        data: { orderId: 'retry-1' },
+        deliveryCount: 2,
+      });
+      expect(controller.attempts).toBe(2);
+    });
+  });
+
   describe('with native DLQ configured and no onDeadLetter callback', () => {
     let app: INestApplication;
     let module: TestingModule;

--- a/test/integration/dead-letter.spec.ts
+++ b/test/integration/dead-letter.spec.ts
@@ -159,6 +159,66 @@ describe('Dead Letter Queue Hook', () => {
       expect(controller.attempts).toBe(2);
     });
   });
+  describe('with native DLQ configured and no onDeadLetter callback', () => {
+    let app: INestApplication;
+    let module: TestingModule;
+    let client: ClientProxy;
+    let serviceName: string;
+    let controller: AlwaysFailingController;
+
+    beforeEach(async () => {
+      serviceName = uniqueServiceName();
+
+      ({ app, module } = await createTestApp(
+        {
+          name: serviceName,
+          port,
+          dlq: {},
+          events: {
+            consumer: {
+              max_deliver: 2,
+              ack_wait: toNanos(2, 'seconds'),
+            },
+          },
+        },
+        [AlwaysFailingController],
+        [serviceName],
+      ));
+
+      client = module.get<ClientProxy>(getClientToken(serviceName));
+      controller = module.get(AlwaysFailingController);
+    });
+
+    afterEach(async () => {
+      await app.close();
+      await cleanupStreams(nc, serviceName);
+    });
+
+    it('should republish exhausted messages to the DLQ stream in dlq-only mode', async () => {
+      // Given: emit an event that will always fail
+      await firstValueFrom(client.emit('order.doomed', { orderId: 'dlq-only-1' }));
+
+      // When: all delivery attempts are exhausted
+      await waitForCondition(() => controller.attempts >= 2, 10_000);
+
+      // Then: the dead letter lands in the DLQ stream without any callback configured
+      const jsm = await jetstreamManager(nc);
+      const dlqName = dlqStreamName(serviceName);
+
+      await waitForCondition(async () => {
+        const info = await jsm.streams.info(dlqName);
+
+        return info.state.messages === 1;
+      }, 10_000);
+
+      const msg = await jsm.streams.getMessage(dlqName, { seq: 1 });
+      const decoded = JSON.parse(new TextDecoder().decode(msg!.data));
+
+      expect(decoded.orderId).toBe('dlq-only-1');
+      expect(msg!.header.get(JetstreamDlqHeader.DeliveryCount)).toBe('2');
+    });
+  });
+
   describe('with native DLQ configured', () => {
     let app: INestApplication;
     let module: TestingModule;

--- a/test/integration/dead-letter.spec.ts
+++ b/test/integration/dead-letter.spec.ts
@@ -7,8 +7,14 @@ import { firstValueFrom } from 'rxjs';
 import type { StartedTestContainer } from 'testcontainers';
 
 import type { DeadLetterInfo, RpcContext } from '../../src';
-import { getClientToken, toNanos, dlqStreamName, JetstreamDlqHeader } from '../../src';
-import { jetstreamManager } from '@nats-io/jetstream';
+import {
+  getClientToken,
+  internalName,
+  toNanos,
+  dlqStreamName,
+  JetstreamDlqHeader,
+} from '../../src';
+import { jetstream, jetstreamManager } from '@nats-io/jetstream';
 
 import {
   cleanupStreams,
@@ -285,6 +291,76 @@ describe('Dead Letter Queue Hook', () => {
 
       expect(decoded.orderId).toBe('dlq-only-1');
       expect(msg!.header.get(JetstreamDlqHeader.DeliveryCount)).toBe('2');
+    });
+  });
+
+  describe('unroutable messages with DLQ configured', () => {
+    let app: INestApplication;
+    let module: TestingModule;
+    let client: ClientProxy;
+    let serviceName: string;
+
+    beforeEach(async () => {
+      serviceName = uniqueServiceName();
+
+      ({ app, module } = await createTestApp(
+        {
+          name: serviceName,
+          port,
+          dlq: {},
+        },
+        [AlwaysFailingController],
+        [serviceName],
+      ));
+
+      client = module.get<ClientProxy>(getClientToken(serviceName));
+    });
+
+    afterEach(async () => {
+      await app.close();
+      await cleanupStreams(nc, serviceName);
+    });
+
+    const dlqMessageCount = async (): Promise<number> => {
+      const jsm = await jetstreamManager(nc);
+      const info = await jsm.streams.info(dlqStreamName(serviceName));
+
+      return info.state.messages;
+    };
+
+    it('should capture events without a registered handler in the DLQ', async () => {
+      // Given: an event pattern no controller handles
+      await firstValueFrom(client.emit('order.unknown', { orderId: 'orphan-1' }));
+
+      // Then: the message lands in the DLQ instead of being deleted
+      await waitForCondition(async () => (await dlqMessageCount()) === 1, 10_000);
+
+      const jsm = await jetstreamManager(nc);
+      const msg = await jsm.streams.getMessage(dlqStreamName(serviceName), { seq: 1 });
+
+      expect(msg!.header.get(JetstreamDlqHeader.DeadLetterReason)).toContain('No handler');
+
+      const decoded = JSON.parse(new TextDecoder().decode(msg!.data));
+
+      expect(decoded.orderId).toBe('orphan-1');
+    });
+
+    it('should capture undecodable payloads in the DLQ', async () => {
+      // Given: raw bytes that are not valid JSON, published to a handled subject
+      const js = jetstream(nc);
+      const subject = `${internalName(serviceName)}.ev.order.doomed`;
+      const garbage = new Uint8Array([0xff, 0xfe, 0x00, 0x7b]);
+
+      await js.publish(subject, garbage);
+
+      // Then: the message lands in the DLQ with the original bytes intact
+      await waitForCondition(async () => (await dlqMessageCount()) === 1, 10_000);
+
+      const jsm = await jetstreamManager(nc);
+      const msg = await jsm.streams.getMessage(dlqStreamName(serviceName), { seq: 1 });
+
+      expect(msg!.header.get(JetstreamDlqHeader.DeadLetterReason)).toContain('Decode error');
+      expect(new Uint8Array(msg!.data)).toEqual(garbage);
     });
   });
 

--- a/test/integration/jetstream-rpc.spec.ts
+++ b/test/integration/jetstream-rpc.spec.ts
@@ -24,6 +24,11 @@ class JsRpcController {
     throw new RpcException('Not found');
   }
 
+  @MessagePattern('user.touch')
+  touchUser(@Payload() _data: { id: number }): void {
+    // command-style handler with no return value
+  }
+
   @MessagePattern('user.ctx')
   getUserWithCtx(
     @Payload() data: { id: number },
@@ -76,6 +81,15 @@ describe('JetStream RPC Round-Trip', () => {
     const result = await firstValueFrom(client.send('user.get', { id: 7 }));
 
     expect(result).toEqual({ id: 7, name: 'JS User' });
+  });
+
+  it('should complete cleanly when the handler returns nothing', async () => {
+    // Given/When: calling a void handler. NestJS skips next() for undefined
+    // responses, so the observable completes empty — the call must not
+    // surface a decode error.
+    await expect(
+      firstValueFrom(client.send('user.touch', { id: 7 }), { defaultValue: undefined }),
+    ).resolves.toBeUndefined();
   });
 
   it('should receive RpcException error via inbox', async () => {

--- a/test/integration/scheduling.spec.ts
+++ b/test/integration/scheduling.spec.ts
@@ -14,6 +14,7 @@ import {
   RpcContext,
   StreamKind,
   streamName,
+  toNanos,
 } from '../../src';
 
 import {
@@ -407,6 +408,57 @@ describe('Message Scheduling (Delayed Jobs)', () => {
       await waitForCondition(async () => (await countScheduleMessages()) === 0, 10_000);
 
       expect(await countScheduleMessages()).toBe(0);
+    });
+  });
+
+  describe('scheduling combined with per-message TTL', () => {
+    let app: INestApplication;
+    let module: TestingModule;
+    let client: ClientProxy;
+    let serviceName: string;
+    let controller: ScheduledEventController;
+
+    beforeEach(async () => {
+      serviceName = uniqueServiceName();
+
+      ({ app, module } = await createTestApp(
+        {
+          name: serviceName,
+          port,
+          events: {
+            stream: { allow_msg_schedules: true, allow_msg_ttl: true },
+          },
+        },
+        [ScheduledEventController],
+        [serviceName],
+      ));
+
+      client = module.get<ClientProxy>(getClientToken(serviceName));
+      controller = module.get(ScheduledEventController);
+    });
+
+    afterEach(async () => {
+      await app.close();
+      await cleanupStreams(nc, serviceName);
+    });
+
+    it('should deliver a scheduled message whose ttl is shorter than the schedule delay', async () => {
+      // Given: ttl 1s, delivery scheduled 3s out — the ttl belongs to the
+      // delivered message, so it must not expire the pending schedule
+      const payload = { orderId: 7, reminder: true };
+
+      const record = new JetstreamRecordBuilder(payload)
+        .scheduleAt(new Date(Date.now() + 3_000))
+        .ttl(toNanos(1, 'seconds'))
+        .build();
+
+      // When: emit and wait past the ttl and up to the schedule
+      await firstValueFrom(client.emit('order.reminder', record));
+
+      // Then: the message still fires at the scheduled time
+      await waitForCondition(() => controller.received.length > 0, 10_000);
+
+      expect(controller.received[0]).toEqual(payload);
     });
   });
 

--- a/test/integration/stream-migration.spec.ts
+++ b/test/integration/stream-migration.spec.ts
@@ -475,6 +475,179 @@ describe('Stream sourcing behavior (NATS verification)', () => {
       });
     });
 
+    describe('messages published during migration', () => {
+      it('should preserve every acked publish across the migration', async () => {
+        const serviceName = uniqueServiceName();
+
+        // Given: a File-backed stream with seed traffic
+        const { app: app1 } = await createTestApp(
+          { name: serviceName, port, events: { stream: { storage: StorageType.File } } },
+          [MigrationTestController],
+          [serviceName],
+        );
+
+        await app1.close();
+
+        const subject = buildSubject(serviceName, StreamKind.Event, 'migration.test');
+        const encoder = new TextEncoder();
+
+        for (let i = 0; i < 20; i++) {
+          await js.publish(subject, encoder.encode(JSON.stringify({ seed: i })));
+        }
+
+        // A producer keeps publishing while the migration runs. Only acked
+        // publishes count — a rejected publish never happened for a producer
+        // with retry logic, but an acked one is a delivery promise.
+        let acked = 20;
+        let stop = false;
+        const publisher = (async (): Promise<void> => {
+          let i = 0;
+
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- mutated outside the closure
+          while (!stop) {
+            try {
+              await js.publish(subject, encoder.encode(JSON.stringify({ live: i++ })));
+              acked++;
+            } catch {
+              await new Promise((r) => setTimeout(r, 20));
+            }
+          }
+        })();
+
+        // When: storage migration runs under live traffic
+        const { app: app2, module: module2 } = await createTestApp(
+          {
+            name: serviceName,
+            port,
+            allowDestructiveMigration: true,
+            events: {
+              stream: { storage: StorageType.Memory, max_bytes: MEMORY_STREAM_MAX_BYTES },
+            },
+          },
+          [MigrationTestController],
+          [serviceName],
+        );
+
+        stop = true;
+        await publisher;
+
+        // Then: every acked message is delivered exactly once
+        const controller = module2.get(MigrationTestController);
+
+        await waitForCondition(() => controller.received.length >= acked, 20_000);
+        await new Promise((r) => setTimeout(r, 1_000));
+
+        expect(controller.received).toHaveLength(acked);
+
+        await app2.close();
+        await cleanupStreams(nc, serviceName);
+      });
+    });
+
+    describe('interrupted migration recovery', () => {
+      it('should restore the stream from a stranded backup on startup', async () => {
+        const serviceName = uniqueServiceName();
+        const evStreamName = streamName(serviceName, StreamKind.Event);
+        const backupName = `${evStreamName}__migration_backup`;
+        const subject = buildSubject(serviceName, StreamKind.Event, 'migration.test');
+        const encoder = new TextEncoder();
+
+        // Given: a crash between delete and create left only the backup —
+        // the sole copy of the data (no metadata, like a stale leftover)
+        await jsm.streams.add({
+          name: backupName,
+          subjects: [subject],
+          retention: RetentionPolicy.Workqueue,
+          storage: StorageType.File,
+          num_replicas: 1,
+        });
+
+        for (let i = 0; i < 5; i++) {
+          await js.publish(subject, encoder.encode(JSON.stringify({ i })));
+        }
+
+        // The real backup holds no subjects — clear them so the recreated
+        // event stream does not overlap
+        const backupInfo = await jsm.streams.info(backupName);
+
+        await jsm.streams.update(backupName, { ...backupInfo.config, subjects: [] });
+
+        // When: the service boots normally
+        const { app, module } = await createTestApp(
+          { name: serviceName, port },
+          [MigrationTestController],
+          [serviceName],
+        );
+
+        // Then: the data is restored and delivered; the backup is cleaned up
+        const controller = module.get(MigrationTestController);
+
+        await waitForCondition(() => controller.received.length >= 5, 20_000);
+
+        expect(controller.received).toHaveLength(5);
+
+        await expect(jsm.streams.info(backupName)).rejects.toThrow();
+
+        await app.close();
+        await cleanupStreams(nc, serviceName);
+      });
+
+      it('should finish the restore when the previous run died after recreating the stream', async () => {
+        const serviceName = uniqueServiceName();
+        const evStreamName = streamName(serviceName, StreamKind.Event);
+        const backupName = `${evStreamName}__migration_backup`;
+        const subject = buildSubject(serviceName, StreamKind.Event, 'migration.test');
+        const encoder = new TextEncoder();
+
+        // Given: a backup holding the data (created first so its temporary
+        // subject does not overlap the recreated stream)
+        await jsm.streams.add({
+          name: backupName,
+          subjects: [subject],
+          retention: RetentionPolicy.Workqueue,
+          storage: StorageType.File,
+          num_replicas: 1,
+        });
+
+        for (let i = 0; i < 5; i++) {
+          await js.publish(subject, encoder.encode(JSON.stringify({ i })));
+        }
+
+        const backupInfo = await jsm.streams.info(backupName);
+
+        await jsm.streams.update(backupName, { ...backupInfo.config, subjects: [] });
+
+        // ...and the recreated-but-empty stream, as left behind by a process
+        // that died right after Phase 3
+        await jsm.streams.add({
+          name: evStreamName,
+          subjects: [`${serviceName}__microservice.ev.>`],
+          retention: RetentionPolicy.Workqueue,
+          storage: StorageType.File,
+          num_replicas: 1,
+        });
+
+        // When: the service boots again
+        const { app, module } = await createTestApp(
+          { name: serviceName, port },
+          [MigrationTestController],
+          [serviceName],
+        );
+
+        // Then: backup contents are restored into the live stream
+        const controller = module.get(MigrationTestController);
+
+        await waitForCondition(() => controller.received.length >= 5, 20_000);
+
+        expect(controller.received).toHaveLength(5);
+
+        await expect(jsm.streams.info(backupName)).rejects.toThrow();
+
+        await app.close();
+        await cleanupStreams(nc, serviceName);
+      });
+    });
+
     describe('orphaned backup cleanup', () => {
       it('should clean up orphaned backup stream before migration', async () => {
         const serviceName = uniqueServiceName();

--- a/website/docs/guides/dead-letter-queue.md
+++ b/website/docs/guides/dead-letter-queue.md
@@ -8,7 +8,7 @@ schema:
   headline: "How to configure a Dead Letter Queue"
   description: "Capture NestJS NATS JetStream messages that exhaust all delivery attempts via a DLQ stream or onDeadLetter callback."
   datePublished: "2026-03-21"
-  dateModified: "2026-05-27"
+  dateModified: "2026-06-10"
 ---
 
 import Since from '@site/src/components/Since';
@@ -26,9 +26,14 @@ Start with either. For maximum durability, use them together — the full fallba
 
 ## What is a dead letter?
 
-In NATS JetStream, each consumer has a `max_deliver` setting (default: **3**). Every time a handler throws an exception, the message is `nak`'d and redelivered. Once the delivery count reaches `max_deliver`, the message has nowhere to go — it's "dead."
+In NATS JetStream, each consumer has a `max_deliver` setting (default: **3**). Every time a handler throws an exception — or requests a business retry via [`ctx.retry()`](/docs/guides/handler-context) — the message is `nak`'d and redelivered. Once the delivery count reaches `max_deliver`, the message has nowhere to go — it's "dead."
 
 Without a DLQ strategy, the transport would simply `term()` the message after the final failed attempt. With the DLQ stream or callback, you get a chance to save it before it's gone.
+
+Two more cases are captured as dead letters immediately, regardless of delivery count, because redelivery can never fix them:
+
+- **No registered handler** for the subject (e.g. a handler was renamed mid-rolling-deploy while producers still publish the old pattern).
+- **Undecodable payload** (codec mismatch between producer and consumer). The original bytes are preserved in the DLQ entry.
 
 ```mermaid
 sequenceDiagram

--- a/website/docs/guides/dead-letter-queue.md
+++ b/website/docs/guides/dead-letter-queue.md
@@ -115,10 +115,10 @@ The `JetstreamDlqHeader` enum is exported from the package — use it for type-s
 The transport uses a strict, **no-silent-loss** chain when handling a dead letter:
 
 1. **Emit `TransportEvent.DeadLetter`** — fires for every dead letter, regardless of configuration (for observability). Happens unconditionally.
-2. **Try DLQ stream publish** — if `dlq` is configured, publish the payload and tracking headers to the DLQ stream.
+2. **Try DLQ stream publish (up to 3 attempts)** — if `dlq` is configured, publish the payload and tracking headers to the DLQ stream. A transient broker hiccup is retried in-process before giving up; this matters because the server never redelivers a message past `max_deliver`, so these attempts are the only second chance a dead letter gets.
 3. **On successful publish — notify `onDeadLetter`** — if a callback is also registered, it is invoked as a **notification hook** (logging, metrics, alerting). Any error thrown by the callback at this stage is logged and swallowed; the original message still terminates successfully.
-4. **On failed publish — fall back to `onDeadLetter`** — if the DLQ publish itself throws (broker rejection, connectivity issue, disk full), the transport falls back to the callback so the payload still has a chance to land somewhere. On success, the message is terminated; on failure, it is `nak`'d.
-5. **`nak()` as last resort** — if no callback is configured and the DLQ publish fails, or if the fallback callback also throws, the message is `nak`'d rather than silently terminated. It will be redelivered, which gives you a chance to recover the broker or fix the callback. The delivery count stays at `max_deliver`, so it will be treated as a dead letter again on the next attempt.
+4. **On failed publish — fall back to `onDeadLetter`** — if every DLQ publish attempt throws (broker rejection, connectivity issue, disk full), the transport falls back to the callback so the payload still has a chance to land somewhere. On success, the message is terminated; on failure, it is `nak`'d.
+5. **`nak()` as last resort** — if no callback is configured and the DLQ publish fails, or if the fallback callback also throws, the message is `nak`'d rather than silently terminated. Because the delivery count has reached `max_deliver`, NATS will **not** redeliver it — the message stays in the stream, visible to operators, until it is recovered manually or expires via `max_age`. An error log records every such case.
 
 This chain guarantees that no message is terminated without passing through at least one recovery path.
 
@@ -188,10 +188,10 @@ When `dlq` is not configured and only the callback is registered, the flow is:
 3. The `TransportEvent.DeadLetter` hook fires (for observability).
 4. `onDeadLetter(info)` is called and awaited.
 5. On success: the message is `term()`'d (terminated — removed from the stream permanently).
-6. On failure: the message is `nak()`'d, giving the callback another chance on the next delivery cycle.
+6. On failure: the message is `nak()`'d and stays in the stream — see the warning below.
 
-:::warning Callback failures trigger retry
-If your `onDeadLetter` callback throws (e.g., the database is down), the message is **not** terminated. Instead, it is `nak`'d so that NATS redelivers it. This means your callback will be retried — but be aware that the delivery count has already reached `max_deliver`, so the message will be treated as a dead letter again on the next attempt. If you combine the callback with `dlq: { stream }`, the same nak safety applies at the end of the fallback chain described above.
+:::warning Callback failures keep the message in the stream
+If your `onDeadLetter` callback throws (e.g., the database is down), the message is **not** terminated — it is `nak`'d so the data is preserved. But the delivery count has already reached `max_deliver`, so NATS will **not** deliver it again: the message remains in the stream until you recover it manually (e.g. with `nats stream get` / a replay tool) or it expires via `max_age`. Each occurrence is recorded with an error log. If you combine the callback with `dlq: { stream }`, the DLQ publish (with its in-process retries) runs first, and the callback is only a fallback.
 :::
 
 ## DI integration with forRootAsync

--- a/website/docs/guides/handler-context.md
+++ b/website/docs/guides/handler-context.md
@@ -8,7 +8,7 @@ schema:
   headline: "RpcContext — Handler Context & Message Settlement"
   description: "Access JetStream metadata and control ack, retry, and terminate actions in NestJS message handlers via RpcContext."
   datePublished: "2026-03-21"
-  dateModified: "2026-04-11"
+  dateModified: "2026-06-10"
 ---
 
 import Since from '@site/src/components/Since';
@@ -97,7 +97,7 @@ class RpcContext {
 
 Control how the transport acknowledges the message — without throwing errors.
 
-**`ctx.retry({ delayMs? })`** → `msg.nak(delayMs)`, redelivering the message. Use for business-level retries (external service unavailable, resource locked).
+**`ctx.retry({ delayMs? })`** → `msg.nak(delayMs)`, redelivering the message. Use for business-level retries (external service unavailable, resource locked). Each retry consumes a delivery attempt; a `retry()` on the final permitted delivery is routed through [dead-letter handling](/docs/guides/dead-letter-queue) just like a throwing handler, so the message is captured instead of stranded.
 
 **`ctx.terminate(reason?)`** → `msg.term(reason)`, permanently rejecting. Use when the message is no longer relevant (order cancelled, entity deleted).
 

--- a/website/docs/guides/scheduling.md
+++ b/website/docs/guides/scheduling.md
@@ -111,11 +111,12 @@ Setting `max_age: 0` disables automatic cleanup for **all** messages in the even
 ## Limitations
 
 - **One-shot only.** No cron or interval scheduling. NATS supports these ([ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md)), but the library currently exposes only `scheduleAt()` for one-shot delivery.
-- **Events only.** `scheduleAt()` is ignored for RPC ([`client.send()`](/docs/patterns/rpc)); a warning is logged.
+- **Workqueue events and broadcasts only.** `scheduleAt()` is ignored for RPC ([`client.send()`](/docs/patterns/rpc)) with a logged warning, and **throws** for [`ordered:` patterns](/docs/patterns/ordered-events) — the schedule holder cannot live in the same stream as an ordered target, which the server requires.
 - **Future dates only.** `scheduleAt()` throws if the date is not in the future.
 - **NATS >= 2.12.** `allow_msg_schedules` is not supported by older server versions.
-- **`max_age` constraint.** Schedule delay must not exceed the stream's `max_age`.
+- **`max_age` constraint.** Schedule delay must not exceed the stream's `max_age` — the pending schedule is an ordinary stored message and expires with the stream's retention. Note the **broadcast stream default is 1 hour**: scheduling a broadcast further out requires raising its `max_age`.
 - **Per-stream opt-in.** Broadcast scheduling requires `allow_msg_schedules: true` on the [broadcast stream](/docs/patterns/broadcast) config separately.
+- **`ttl()` applies to the delivered message.** Combining `.ttl()` with `.scheduleAt()` sets `Nats-Schedule-TTL`: the countdown starts when the scheduled message fires, not when it is published.
 
 ## See also
 

--- a/website/docs/guides/stream-migration.md
+++ b/website/docs/guides/stream-migration.md
@@ -8,7 +8,7 @@ schema:
   headline: "How to migrate immutable stream properties"
   description: "Safely change immutable stream properties without losing messages via blue-green sourcing."
   datePublished: "2026-04-02"
-  dateModified: "2026-05-27"
+  dateModified: "2026-06-10"
 ---
 
 import Since from '@site/src/components/Since';
@@ -54,18 +54,22 @@ Without `allowDestructiveMigration`, the transport logs a warning and continues 
 The transport uses **blue-green recreation** via [NATS stream sourcing](https://docs.nats.io/nats-concepts/jetstream/streams#sources) — a server-side message copy mechanism that preserves all messages:
 
 ```text
-Phase 1/4  Create backup stream ← sourcing ← original
-           (server-side copy, no application-level consumption)
+Phase 1/4  Quiesce: remove the original's subjects
+           (new publishes are rejected loudly instead of being acked
+            into a stream that is about to be deleted)
 
-Phase 2/4  Delete original stream
+Phase 2/4  Create backup stream ← sourcing ← original
+           (server-side copy; completion is tracked via source lag)
 
-Phase 3/4  Create original stream with new config (e.g., Memory storage)
+Phase 3/4  Delete original, create it again with the new config
 
 Phase 4/4  Original ← sourcing ← backup
-           → restore all messages → remove sources → delete backup
+           → drain → delete backup → detach source
 ```
 
 The stream keeps its original name. Consumers are recreated automatically after migration by each pod's startup sequence or self-healing.
+
+Every acknowledged publish is preserved: a producer either gets a successful ack (the message survives the migration) or a loud rejection it can retry — never an ack for a message that later disappears.
 
 ### Backup stream as a distributed lock
 
@@ -78,12 +82,12 @@ During migration, the backup stream (`{stream}__migration_backup`) serves a dual
 
 ### To publishers
 
-There is a **brief window** between Phase 2 (delete) and Phase 3 (create) where the stream does not exist — in practice this is one round-trip to the NATS server, but the window is real. Publishers will receive "stream not found" errors during it.
+From the quiesce (Phase 1) until the restore completes, publishes to the migrating stream are **rejected** — the subject has no stream behind it, so producers receive "no stream matches subject" / no-responders errors.
 
-- **`client.emit()`** (fire-and-forget) — the event is lost. If you need guaranteed delivery during migration, implement retry logic in the caller.
+- **`client.emit()`** (fire-and-forget) — the publish rejects with an error. Implement retry logic in the caller if you need delivery during migration.
 - **`client.send()`** (RPC) — the caller receives an error and can retry.
 
-For most services, this window is too short to matter. If you need zero-loss guarantees during migration, schedule it during a maintenance window with publishers paused.
+The rejection window lasts as long as the message copy does — milliseconds for small streams. This is deliberate: a rejected publish is retryable, while an acknowledged write into a stream that is about to be deleted would be silent data loss. If you need a zero-rejection migration, schedule it during a maintenance window with publishers paused.
 
 ### To consumers on other pods (rolling updates)
 
@@ -109,17 +113,18 @@ Expect migration time to scale roughly linearly with message count. For small st
 
 ## Error handling
 
-- **Backup creation fails.** The original stream is untouched; an error is thrown.
-- **Phase 2/3 fails (delete or create).** The backup is cleaned up; an error is thrown.
-- **Sourcing timeout during Phase 4 (30s default).** The stream exists with the new config but holds incomplete messages. The backup is cleaned up and an error is thrown — manual intervention may be needed, check the stream message count.
-- **Process killed mid-migration.** The orphaned backup is detected on the next application startup, cleaned up, and the migration is retried from scratch.
-- **NATS connection lost.** The transport reconnects and the migration resumes from the beginning.
+- **Failure before the original is deleted.** The quiesce is rolled back (subjects restored), the backup is removed, and an error is thrown — the original stream is intact and serving traffic.
+- **Failure after the original is deleted.** The backup is the only copy of the data and is always preserved. Restoration resumes automatically on the next application startup.
+- **Sourcing timeout (30s default).** Same as above: the backup is preserved and the restore resumes on the next startup. Nothing is lost.
+- **Process killed mid-migration.** Detected on the next startup: a stranded backup is restored into the stream (recreating it first if the crash happened between delete and create), then cleaned up.
+- **Two instances migrating concurrently (rolling deploy).** Backups carry a freshness stamp. An instance that finds another instance's live backup waits for that migration to finish instead of interfering; only stale leftovers are recovered.
 
 ## Limitations
 
 - **`retention` is not migratable.** It is controlled by the transport (`Workqueue` for events/commands, `Limits` for broadcast/ordered). A mismatch always throws an error on startup.
 - **The publisher gap is inherent.** NATS does not support atomic stream rename or swap. The millisecond window between delete and create cannot be eliminated.
-- **`allowDestructiveMigration` applies to all streams.** It's a single flag at the module level. You cannot enable migration for the event stream but not the broadcast stream — if any stream has an immutable conflict, it will be migrated.
+- **`allowDestructiveMigration` applies to all service-owned streams.** It's a single flag at the module level — if any of them has an immutable conflict, it will be migrated.
+- **The shared broadcast stream is never destructively migrated.** `broadcast-stream` is shared by every service in the cluster; recreating it would delete other services' durable consumers and replay retained history to them. An immutable conflict on it throws an error instead — coordinate that change manually.
 
 ## Example: switching to in-memory streams
 

--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -84,7 +84,7 @@ export default function Root({ children }) {
   "headline": "How to configure a Dead Letter Queue",
   "description": "Capture NestJS NATS JetStream messages that exhaust all delivery attempts via a DLQ stream or onDeadLetter callback.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-05-27"
+  "dateModified": "2026-06-10"
 },
       
     '/docs/guides/graceful-shutdown/': {
@@ -100,7 +100,7 @@ export default function Root({ children }) {
   "headline": "RpcContext — Handler Context & Message Settlement",
   "description": "Access JetStream metadata and control ack, retry, and terminate actions in NestJS message handlers via RpcContext.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-04-11"
+  "dateModified": "2026-06-10"
 },
       
     '/docs/guides/health-checks/': {
@@ -172,7 +172,7 @@ export default function Root({ children }) {
   "headline": "How to migrate immutable stream properties",
   "description": "Safely change immutable stream properties without losing messages via blue-green sourcing.",
   "datePublished": "2026-04-02",
-  "dateModified": "2026-05-27"
+  "dateModified": "2026-06-10"
 },
       
     '/docs/guides/troubleshooting/': {


### PR DESCRIPTION
## Summary

A full-codebase reliability audit surfaced a set of bugs sharing one trait: the library's assumptions diverged from actual NATS server semantics, and the result was silent — lost messages, stranded streams, or hung callers, with no error anywhere. This PR fixes all of them, each with a failing test written first.

## Dead-letter pipeline

- **`dlq` without `onDeadLetter` never armed dead-letter detection.** The DLQ stream was created but never published to; failing messages exhausted `max_deliver` and sat in the workqueue stream forever. This matches a real production incident (165 stranded messages, empty DLQ). Detection now arms for either capture mechanism.
- **`ctx.retry()` on the final delivery stranded the message** — it nak'd unconditionally, but the server never redelivers past `max_deliver`. Now escalates to dead-letter handling like a throwing handler.
- **The fallback chain promised retries that cannot happen.** It nak'd "for the next delivery cycle" at exactly the point where no further delivery exists. The DLQ publish now gets bounded in-process retries (the only second chance a dead letter has), and the terminal case is logged honestly.
- **Unroutable messages (no handler after a rename, undecodable payload) were term'd** — permanent deletion on a workqueue stream. They are now captured in the DLQ immediately; redelivery can't fix them anyway.
- **The DLQ republish copied NATS control headers verbatim** — a `Nats-TTL` from the original publish either got the DLQ entry rejected or silently expired it.

## Scheduling

- **`.ttl()` + `.scheduleAt()` cancelled the schedule**: the ttl landed as `Nats-TTL` on the schedule holder, removing it before it fired — publish acked, nothing delivered. It now maps to `Nats-Schedule-TTL` (the delivered message's ttl).
- **`scheduleAt()` on `ordered:` patterns could never deliver** (the holder and the target live in different streams; the server requires the same stream). Now rejected at the client with an actionable error.

## RPC and codec

- **A void `@MessagePattern` handler produced a decode error at the caller** (`JSON.parse('')`), turning successful commands into errors — and inviting duplicate-execution retries. Empty payloads now decode as `undefined` in both codecs.
- **A deduplicated command publish hung the caller for the full RPC timeout** (the PubAck's `duplicate` flag was ignored; the reply belongs to the original request). Now fails fast.

## Routing and lifecycle

- **Settlement calls (`ack`/`nak`/`term`) were unguarded** — on a degraded connection they became unhandled rejections, uncaught exceptions from the RPC timeout timer, or killed the router subscription; a sync-path throw also leaked a concurrency slot permanently.
- **Backlogged messages got no ack extension** while waiting for a concurrency slot, so sustained load meant ack_wait redeliveries and double processing.
- **Consumers started delivering before the routers subscribed** — with ordered handlers present, pending backlog flushed into subjects with zero observers and was dropped; commands (`max_deliver: 1`) were lost permanently.

## Streams

- **Every service rewrote the shared `broadcast-stream` config with its own** (subjects, description), and `allowDestructiveMigration` could recreate the shared stream — deleting every other service's durable consumers mid-traffic. Subjects are now unioned, the description is service-neutral, and destructive migration of the shared stream is refused.
- **Destructive migration had four data-loss windows**: live publishes counted as restored messages (premature backup deletion), acked publishes vanished in the backup→delete gap, a crash between delete and create stranded all data in the backup forever (and wedged consumer self-healing), and concurrent pods deleted each other's backups. The migration now quiesces the original (publishers get loud, retryable rejections instead of doomed acks), tracks completion via source lag with an activity guard, stamps backups with a freshness marker so live peer migrations are waited out, and finishes any interrupted migration on the next startup.

## Testing

Every fix follows red-green: the failing test reproducing the bug landed before the code change. New integration coverage includes dlq-only mode, retry exhaustion, unroutable capture, ttl+schedule survival, live publishing during migration, and interrupted-migration recovery (both crash points). Full suite: 859 tests across 69 files, green.

Guides updated to match: dead-letter chain semantics, scheduling limitations, handler-context retry exhaustion, and the reworked migration behavior.

BEGIN_COMMIT_OVERRIDE
fix(dlq): engage dead-letter handling when dlq is configured without onDeadLetter

fix(events): escalate ctx.retry() on the final delivery to dead-letter handling

fix(dlq): retry the DLQ publish in-process and stop promising redelivery

fix(events): capture unroutable messages in the DLQ instead of terminating them

fix(client): apply ttl to the delivered message instead of the schedule holder

fix(client): reject scheduleAt for ordered patterns

fix(headers): block user-set NATS control headers and drop them from DLQ republish

fix(codec): decode empty payloads as undefined

fix(client): fail fast when a JetStream RPC publish is deduplicated

fix(routing): contain settlement failures on degraded connections

fix(routing): keep ack extension running for backlogged messages

fix(server): subscribe routers before consumers start delivering

fix(streams): stop services from clobbering the shared broadcast stream

fix(migration): close the data-loss windows in destructive stream migration
END_COMMIT_OVERRIDE