### PR TITLE
docs(code): condense inline comments

### DIFF
--- a/src/client/jetstream.client.ts
+++ b/src/client/jetstream.client.ts
@@ -234,10 +234,7 @@ export class JetstreamClient extends ClientProxy {
     const publishKind = detectEventKind(packet.pattern);
 
     if (schedule && publishKind === PublishKind.Ordered) {
-      // The schedule holder lives in the event stream's _sch namespace, but the
-      // target subject belongs to the ordered stream — the server requires the
-      // schedule target to be a subject of the same stream, so this can never
-      // be delivered. Fail loudly instead of dropping the message.
+      // ADR-51: the schedule target must live in the same stream as the holder — impossible for ordered patterns.
       throw new Error(
         `scheduleAt() is not supported for ordered events (pattern: ${packet.pattern}). ` +
           'Scheduled delivery is available for workqueue events and broadcasts.',
@@ -287,9 +284,7 @@ export class JetstreamClient extends ClientProxy {
           };
 
           if (schedule) {
-            // ttl belongs to the delivered message (Nats-Schedule-TTL). As a
-            // top-level option it would become Nats-TTL on the schedule holder
-            // and cancel the schedule once it elapses.
+            // As a top-level option ttl would expire the schedule holder itself; it belongs to the delivered message.
             const ack = await this.connection
               .getJetStreamClient()
               .publish(publishSubject, encoded, {
@@ -574,10 +569,7 @@ export class JetstreamClient extends ClientProxy {
       );
 
       if (ack.duplicate) {
-        // The stream dropped this publish as a duplicate (messageId reused
-        // within the dedup window). The original command owns the reply — this
-        // correlation id will never receive one, so fail now instead of
-        // burning the full RPC timeout.
+        // The reply belongs to the original (deduped) request — fail fast instead of waiting out the timeout.
         throw new Error(
           `Duplicate RPC publish for ${subject}: the messageId was already used within the ` +
             'stream dedup window, so the reply belongs to the original request',

--- a/src/codec/json.codec.ts
+++ b/src/codec/json.codec.ts
@@ -18,14 +18,12 @@ const decoder = new TextDecoder();
  */
 export class JsonCodec implements Codec {
   public encode(data: unknown): Uint8Array {
-    // JSON.stringify(undefined) returns undefined, which TextEncoder turns
-    // into an empty payload — the symmetric decode() guard restores it.
+    // JSON.stringify(undefined) yields an empty payload; decode() restores it.
     return encoder.encode(JSON.stringify(data));
   }
 
   public decode(data: Uint8Array): unknown {
-    // Empty payloads come from void handler replies, payload-less emits, and
-    // foreign publishers. JSON.parse('') would throw on all of them.
+    // Void replies and payload-less emits arrive empty; JSON.parse('') would throw.
     if (data.length === 0) return undefined;
 
     return JSON.parse(decoder.decode(data));

--- a/src/codec/msgpack.codec.ts
+++ b/src/codec/msgpack.codec.ts
@@ -48,8 +48,7 @@ export class MsgpackCodec implements Codec {
   }
 
   public decode(data: Uint8Array): unknown {
-    // Mirror JsonCodec: empty payloads (payload-less emits from foreign
-    // publishers) decode to undefined instead of throwing.
+    // Mirror JsonCodec: empty payloads decode to undefined.
     if (data.length === 0) return undefined;
 
     return this.packr.unpack(data);

--- a/src/server/infrastructure/__tests__/stream-migration.spec.ts
+++ b/src/server/infrastructure/__tests__/stream-migration.spec.ts
@@ -153,9 +153,8 @@ describe(StreamMigration.name, () => {
     });
 
     it('should delete the backup before detaching the restore source', async () => {
-      // The surviving order is what makes interrupted-restore recovery safe:
-      // "backup present with no source attached" can only mean the restore
-      // never started.
+      // The order recovery relies on: "backup without an attached source"
+      // can only mean the restore never started.
       const sut = new StreamMigration();
       const jsm = buildMockJsm(100);
 

--- a/src/server/infrastructure/stream-migration.ts
+++ b/src/server/infrastructure/stream-migration.ts
@@ -14,11 +14,7 @@ const DEFAULT_SOURCING_TIMEOUT_MS = 30_000;
 const SOURCING_POLL_INTERVAL_MS = 100;
 /** How long migrate() waits for another instance's in-flight migration to finish. */
 const DEFAULT_PEER_WAIT_MS = 60_000;
-/**
- * Backups younger than this are treated as another instance's live migration
- * and never touched. Stale ones (older, or without the metadata stamp) are
- * leftovers of an interrupted run and get recovered.
- */
+/** Younger backups belong to a live peer migration; older ones get recovered. */
 const ACTIVE_MIGRATION_GRACE_MS = 90_000;
 const MIGRATION_STARTED_AT_KEY = 'nestjs-jetstream-migration-started-at';
 
@@ -29,25 +25,17 @@ type MigrationStreamConfig = Partial<StreamConfig> & { name: string; subjects: s
  * Orchestrates blue-green stream recreation for immutable property changes.
  *
  * Uses NATS stream sourcing (server-side copy) to preserve messages:
- *   1. Quiesce: remove the original's subjects so new publishes are rejected
- *      loudly instead of acked into a stream that is about to be deleted
- *   2. Backup: create temp stream sourcing from the original; wait for the
- *      source lag to reach zero (immune to message-count races)
- *   3. Delete original
- *   4. Create original with the new config
- *   5. Restore: source from the backup into the new original, drain, then
- *      delete the backup BEFORE detaching the source — the surviving order
- *      guarantees "backup exists with no source attached" can only mean the
- *      restore never started, which {@link recoverInterrupted} re-runs safely
+ *   1. Quiesce: drop the original's subjects — publishes reject loudly instead
+ *      of being acked into a stream that is about to be deleted
+ *   2. Backup: temp stream sources the original; drain tracked via source lag
+ *   3. Delete the original, recreate it with the new config
+ *   4. Restore: source the backup back, drain, delete the backup BEFORE
+ *      detaching the source — so "backup without an attached source" can only
+ *      mean the restore never started, which makes recovery re-runnable
  *
- * Publishers see "no stream matches subject" errors from quiesce until
- * Phase 4 completes. Client-side retry is the caller's responsibility — the
- * alternative was acknowledged writes that silently vanished.
- *
- * A process dying mid-migration leaves the backup behind;
- * {@link recoverInterrupted} finishes the job on the next startup. Backups
- * created moments ago belong to another instance's live migration (rolling
- * deploys) and are waited out, never deleted.
+ * A process dying mid-migration leaves the backup behind and
+ * {@link recoverInterrupted} finishes the job on the next startup; a fresh
+ * backup means a live peer migration and is waited out, never deleted.
  *
  * Ref: https://docs.nats.io/nats-concepts/jetstream/streams#sources
  */
@@ -83,8 +71,7 @@ export class StreamMigration {
     let drainedCount = 0;
 
     try {
-      // Phase 1: Quiesce — without this, a publish acked between the backup
-      // catching up and the delete would be destroyed with the stream.
+      // Phase 1: Quiesce — an acked publish after this point cannot be lost.
       this.logger.log(`  Phase 1/4: Quiescing ${streamName} (publishes rejected during migration)`);
       await jsm.streams.update(streamName, { ...currentInfo.config, subjects: [] });
 
@@ -117,8 +104,7 @@ export class StreamMigration {
       }
     } catch (err) {
       if (originalDeleted) {
-        // The backup is the only copy now — recoverInterrupted() resumes the
-        // restore on the next startup.
+        // The backup is the only copy now; recovery resumes on the next startup.
         this.logger.error(
           `Migration of ${streamName} failed after the original was deleted. ` +
             `Backup ${backupName} preserved — restoration resumes on the next startup.`,
@@ -138,11 +124,8 @@ export class StreamMigration {
   }
 
   /**
-   * Detect and finish a migration that a previous process left unfinished.
-   * Safe against concurrent instances: a backup fresh enough to belong to a
-   * live migration is left alone.
-   *
-   * @returns true when recovery work was performed.
+   * Finish a migration a previous process left unfinished; a backup fresh
+   * enough to belong to a live peer migration is left alone.
    */
   public async recoverInterrupted(
     jsm: JetStreamManager,
@@ -175,8 +158,7 @@ export class StreamMigration {
     const hasBackupSource = (streamInfo.config.sources ?? []).some((s) => s.name === backupName);
 
     if (hasBackupSource) {
-      // Died mid-restore: the source keeps its position server-side — let it
-      // finish, then clean up.
+      // Died mid-restore: the source keeps its position — let it finish.
       this.logger.warn(`Stream ${streamName}: finishing interrupted restore from ${backupName}`);
       await this.waitForSourceDrained(jsm, streamName, backupName, backupInfo.state.messages);
       await jsm.streams.delete(backupName);
@@ -192,9 +174,8 @@ export class StreamMigration {
       return true;
     }
 
-    // Died after the recreate but before the restore was wired up. Nothing
-    // from the backup has been sourced yet (sources are only detached after a
-    // full drain), so re-running the restore cannot duplicate messages.
+    // Died before the restore was wired up — nothing sourced yet, so
+    // re-running it cannot duplicate messages.
     this.logger.warn(
       `Stream ${streamName}: restoring ${backupInfo.state.messages} messages from stale ${backupName}`,
     );
@@ -215,8 +196,7 @@ export class StreamMigration {
     streamConfig: MigrationStreamConfig,
     backupName: string,
   ): Promise<void> {
-    // The backup's own source still points at the (recreated) original —
-    // stale, and a cycle once the original sources from the backup.
+    // Clear the backup's stale source ref — it would form a sourcing cycle.
     const backupInfo = await jsm.streams.info(backupName);
 
     if ((backupInfo.config.sources ?? []).length > 0) {
@@ -226,18 +206,15 @@ export class StreamMigration {
     await jsm.streams.update(streamName, { ...streamConfig, sources: [{ name: backupName }] });
     await this.waitForSourceDrained(jsm, streamName, backupName, backupInfo.state.messages);
 
-    // Delete the backup before detaching the source — see the class doc for
-    // why this order is what makes recoverInterrupted() safe.
+    // Backup deleted before the source detaches — the order recovery relies on.
     await jsm.streams.delete(backupName);
     await jsm.streams.update(streamName, { ...streamConfig, sources: [] });
   }
 
   /**
-   * Wait until `sourceName` is fully drained into `streamName`. Lag-based, so
-   * concurrent live publishes to the target cannot fake completion the way a
-   * bare message-count comparison could. A freshly attached source reports
-   * `lag: 0, active: -1` before its first sync — `active >= 0` filters that
-   * false positive out (verified against NATS 2.12.6).
+   * Lag-based drain check — live publishes cannot fake completion. A fresh
+   * source reports lag 0 / active -1 before its first sync (NATS 2.12.6),
+   * hence the active guard.
    */
   private async waitForSourceDrained(
     jsm: JetStreamManager,
@@ -270,12 +247,8 @@ export class StreamMigration {
   }
 
   /**
-   * A backup already present when migrate() begins belongs to another
-   * instance migrating right now (rolling deploy) — wait for it to finish.
-   * Stale leftovers are handled by recoverInterrupted() before migrate() runs,
-   * so a timeout here means something is genuinely stuck.
-   *
-   * @returns true when a peer's backup was observed and cleared.
+   * A backup present at migrate() start is a live peer migration — wait it
+   * out. Stale leftovers were already handled by recoverInterrupted().
    */
   private async waitOutPeerMigration(jsm: JetStreamManager, backupName: string): Promise<boolean> {
     if ((await this.tryInfo(jsm, backupName)) === null) return false;

--- a/src/server/infrastructure/stream.provider.ts
+++ b/src/server/infrastructure/stream.provider.ts
@@ -160,8 +160,7 @@ export class StreamProvider {
       async () => {
         this.logger.log(`Ensuring stream: ${config.name}`);
 
-        // A leftover migration backup means a previous process died
-        // mid-migration — finish its job before reconciling the config.
+        // Finish any migration a previous process left unfinished.
         await this.migration.recoverInterrupted(jsm, config.name, config);
 
         try {
@@ -236,10 +235,8 @@ export class StreamProvider {
     ctx: ProvisioningErrorContext,
   ): Promise<StreamInfo> {
     if (this.isSharedStream(config.name)) {
-      // The broadcast stream is shared by every service in the cluster. Other
-      // services may have added subjects (e.g. broadcast._sch.> for
-      // scheduling) that this service's config does not declare — an update
-      // with the local subject list would strip them.
+      // Other services may have added subjects (e.g. broadcast._sch.>) that
+      // the local config does not declare — don't strip them.
       config.subjects = [...new Set([...config.subjects, ...currentInfo.config.subjects])];
     }
 
@@ -411,8 +408,7 @@ export class StreamProvider {
   ): Partial<StreamConfig> & { name: string; subjects: string[] } {
     const name = this.getStreamName(kind);
     const subjects = this.getSubjects(kind);
-    // The shared stream's description must not embed a service name — each
-    // deploy of a different service would rewrite it back and forth.
+    // A service-specific description on the shared stream would flip-flop on every deploy.
     const description =
       kind === StreamKind.Broadcast
         ? 'JetStream broadcast stream (shared across services)'

--- a/src/server/routing/__tests__/event.router.spec.ts
+++ b/src/server/routing/__tests__/event.router.spec.ts
@@ -1803,9 +1803,8 @@ describe(EventRouter, () => {
     });
 
     it('should extend ack for backlogged messages while they wait for a slot', async () => {
-      // Given: concurrency 1 with ackExtension; the first handler hangs and
-      // holds the only slot, so the second message parks in the backlog —
-      // its ack_wait clock is already running on the server
+      // Given: concurrency 1, the first handler hangs — the second message
+      // parks in the backlog with its ack_wait clock running
       sut = new EventRouter(messageProvider, patternRegistry, codec, eventBus, undefined, {
         events: { concurrency: 1, ackExtension: 30 },
       });

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -59,10 +59,7 @@ interface ResolvedEvent {
   readonly data: unknown;
 }
 
-/**
- * A delivered message parked in the concurrency backlog, together with the
- * ack-extension timer that keeps it alive while it waits for a slot.
- */
+/** A message parked in the concurrency backlog with its ack-extension timer. */
 interface QueuedMessage {
   readonly msg: JsMsg;
   readonly stopAckExtension: (() => void) | null;
@@ -194,13 +191,8 @@ export class EventRouter {
           this.handleDeadLetter(msg, data, err)
       : null;
 
-    /**
-     * Settle a message whose handler completed without throwing.
-     *
-     * Returns a Promise only when a `retry()` on the final permitted delivery
-     * escalates to dead-letter handling — a nak at that point would strand the
-     * message, since the server never redelivers past `max_deliver`.
-     */
+    // Returns a Promise only when retry() on the final delivery escalates to
+    // dead-letter handling — a nak there would strand the message.
     const settleSuccess = (
       msg: JsMsg,
       ctx: RpcContext,
@@ -249,12 +241,8 @@ export class EventRouter {
       });
     };
 
-    /**
-     * Capture a message that can never be routed (no handler, undecodable
-     * payload). Redelivery cannot fix these, so they go straight to
-     * dead-letter handling regardless of delivery count. On a workqueue
-     * stream a plain term() would delete the payload permanently.
-     */
+    // Unroutable messages can't be fixed by redelivery — capture them
+    // immediately; term() on a workqueue stream would delete the payload.
     const captureUnroutable = (
       capture: NonNullable<typeof handleDeadLetter>,
       msg: JsMsg,
@@ -273,13 +261,8 @@ export class EventRouter {
       });
     };
 
-    /**
-     * Resolve the handler and decode payload for one event.
-     *
-     * Returns `null` when the message cannot be routed and was settled
-     * synchronously, a Promise when an unroutable message is being captured
-     * by dead-letter handling, and a {@link ResolvedEvent} otherwise.
-     */
+    // Returns null when the message was settled synchronously (unroutable, no
+    // dead-letter config) and a Promise while an unroutable one is captured.
     const resolveEvent = (msg: JsMsg): ResolvedEvent | Promise<void> | null => {
       const subject = msg.subject;
 
@@ -418,8 +401,7 @@ export class EventRouter {
           return undefined;
         }
 
-        // Same ack-extension reasoning as the failure path: the dead-letter
-        // publish may outlast ack_wait.
+        // The dead-letter publish may outlast ack_wait — keep the extension alive.
         return settled.finally(() => {
           if (stopAckExtension !== null) stopAckExtension();
         });
@@ -550,9 +532,7 @@ export class EventRouter {
       drainBacklog();
     };
 
-    // route() is not expected to throw — every settlement inside it is
-    // guarded — but a failure here must never leak the concurrency slot or
-    // escape into the RxJS observer and kill the subscription.
+    // A throw here must not leak the concurrency slot or kill the subscription.
     const routeSafely = (msg: JsMsg): Promise<void> | undefined => {
       try {
         return route(msg);
@@ -576,8 +556,6 @@ export class EventRouter {
         const next = backlog.shift();
 
         if (next === undefined) return;
-        // The processing-phase timer is started inside route(); the waiting
-        // phase is over.
         next.stopAckExtension?.();
         active++;
         const result = routeSafely(next.msg);
@@ -595,9 +573,7 @@ export class EventRouter {
     const subscription = stream$.subscribe({
       next: (msg: JsMsg): void => {
         if (active >= maxActive) {
-          // A parked message was already delivered — its ack_wait clock is
-          // running on the server. Without extension a long wait ends in
-          // redelivery and double processing.
+          // A parked message's ack_wait clock is already running on the server.
           backlog.push({
             msg,
             stopAckExtension: hasAckExtension
@@ -629,8 +605,7 @@ export class EventRouter {
       },
     });
 
-    // Backlogged messages keep extension timers alive — stop them when the
-    // router unsubscribes so a destroyed router leaves nothing ticking.
+    // Stop the parked timers on unsubscribe.
     subscription.add(() => {
       for (const queued of backlog) {
         queued.stopAckExtension?.();
@@ -655,18 +630,14 @@ export class EventRouter {
   }
 
   /**
-   * Last-resort path for a dead letter: invoke `onDeadLetter`, then `term` on
-   * success. On failure the message is nak'd to release it, but the server
-   * never redelivers past `max_deliver` — it stays in the stream for manual
-   * recovery. Used when the DLQ stream isn't configured, or when publishing
-   * to it failed and we still have to surface the message somewhere.
+   * Last resort: invoke onDeadLetter, then term on success. On failure the
+   * message is nak'd — never redelivered past max_deliver, but preserved.
    */
   private async fallbackToOnDeadLetterCallback(info: DeadLetterInfo, msg: JsMsg): Promise<void> {
     const onDeadLetter = this.deadLetterConfig?.onDeadLetter;
 
     if (!onDeadLetter) {
-      // dlq-only mode and the DLQ publish failed: there is no callback to fall
-      // back to. Keep the message in the stream rather than deleting it.
+      // dlq-only mode with a failed DLQ publish — keep the message in the stream.
       this.logger.error(
         `Dead letter for ${msg.subject} could not be captured (DLQ publish failed, no onDeadLetter callback) — leaving the message in the stream`,
       );
@@ -694,10 +665,8 @@ export class EventRouter {
   }
 
   /**
-   * Copy the original message headers for the DLQ republish, dropping NATS
-   * server control headers: a copied Nats-TTL expires the DLQ entry (or gets
-   * the publish rejected when the DLQ stream has no allow_msg_ttl), a copied
-   * Nats-Msg-Id collides with the DLQ dedup window.
+   * Copy headers for the DLQ republish, dropping NATS control headers — a
+   * copied Nats-TTL would expire the DLQ entry, Nats-Msg-Id trips dedup.
    */
   private buildDlqHeaders(msg: JsMsg): MsgHdrs {
     const hdrs = natsHeaders();
@@ -716,12 +685,9 @@ export class EventRouter {
   }
 
   /**
-   * Attempt the DLQ publish up to {@link DLQ_PUBLISH_ATTEMPTS} times.
-   *
-   * Past `max_deliver` the server never redelivers, so an in-process retry is
-   * the only second chance a dead letter gets. There is no artificial delay
-   * between attempts: when the broker is unreachable each publish already
-   * spends its own request timeout, which spaces the attempts naturally.
+   * Past max_deliver the server never redelivers, so these in-process attempts
+   * are the only second chance a dead letter gets. No artificial delay — an
+   * unreachable broker already spaces attempts via its own request timeout.
    */
   private async publishToDlqWithRetry(
     connection: ConnectionProvider,

--- a/src/server/routing/rpc.router.ts
+++ b/src/server/routing/rpc.router.ts
@@ -48,10 +48,7 @@ interface ResolvedCommand {
   readonly correlationId: string;
 }
 
-/**
- * A delivered command parked in the concurrency backlog, together with the
- * ack-extension timer that keeps it alive while it waits for a slot.
- */
+/** A command parked in the concurrency backlog with its ack-extension timer. */
 interface QueuedCommand {
   readonly msg: JsMsg;
   readonly stopAckExtension: (() => void) | null;
@@ -325,8 +322,7 @@ export class RpcRouter {
         abortController.abort();
         // RpcTimeout hook is the canonical signal here — no separate log.
         emitRpcTimeout(subject, correlationId);
-        // This runs inside a bare timer callback — an unguarded term throw
-        // on a degraded connection would surface as an uncaught exception.
+        // Bare timer callback — an unguarded term throw would be an uncaught exception.
         settleQuietly(logger, `Failed to term ${subject}:`, () => {
           msg.term('Handler timeout');
         });
@@ -371,9 +367,7 @@ export class RpcRouter {
       drainBacklog();
     };
 
-    // handleSafe() is not expected to throw — settlement inside it is guarded
-    // — but a failure here must never leak the concurrency slot or escape
-    // into the RxJS observer and kill the subscription.
+    // A throw here must not leak the concurrency slot or kill the subscription.
     const routeSafely = (msg: JsMsg): Promise<void> | undefined => {
       try {
         return handleSafe(msg);
@@ -397,8 +391,6 @@ export class RpcRouter {
         const next = backlog.shift();
 
         if (next === undefined) return;
-        // The processing-phase timer is started inside handleSafe(); the
-        // waiting phase is over.
         next.stopAckExtension?.();
         active++;
         const result = routeSafely(next.msg);
@@ -416,9 +408,7 @@ export class RpcRouter {
     this.subscription = this.messageProvider.commands$.subscribe({
       next: (msg: JsMsg): void => {
         if (active >= maxActive) {
-          // A parked command was already delivered — its ack_wait clock is
-          // running on the server. Without extension a long wait ends in
-          // redelivery and a duplicate execution.
+          // A parked command's ack_wait clock is already running on the server.
           backlog.push({
             msg,
             stopAckExtension: hasAckExtension
@@ -450,8 +440,7 @@ export class RpcRouter {
       },
     });
 
-    // Backlogged commands keep extension timers alive — stop them when the
-    // router unsubscribes so a destroyed router leaves nothing ticking.
+    // Stop the parked timers on unsubscribe.
     this.subscription.add(() => {
       for (const queued of backlog) {
         queued.stopAckExtension?.();

--- a/src/server/strategy.ts
+++ b/src/server/strategy.ts
@@ -170,10 +170,8 @@ export class JetstreamStrategy extends Server implements CustomTransportStrategy
         this.eventRouter.updateMaxDeliverMap(this.buildMaxDeliverMap(consumers));
       }
 
-      // 7. Subscribe routers BEFORE consumption starts. Consumers flush any
-      // pending backlog the moment they go live, and a message pushed into a
-      // subject with no observers is dropped unsettled — for commands
-      // (max_deliver: 1) that loss is permanent.
+      // 7. Subscribe routers BEFORE consumption starts — consumers flush their
+      // backlog immediately, and a subject with no observers drops messages.
       await this.startRouters();
 
       // 8. Start durable and ordered message consumption

--- a/src/utils/settle-quietly.ts
+++ b/src/utils/settle-quietly.ts
@@ -4,11 +4,8 @@ export interface SettleLogger {
 }
 
 /**
- * Run a message-settlement call (`ack`/`nak`/`term`) that may throw when the
- * connection is degraded — settlement is a publish under the hood. The error
- * is logged instead of propagated so a dying connection cannot take a routing
- * subscription or the process down with it; the unsettled message redelivers
- * via `ack_wait` once the connection recovers.
+ * Settlement calls (ack/nak/term) are publishes and throw on a degraded
+ * connection — log instead of letting that kill routing or the process.
  */
 export const settleQuietly = (logger: SettleLogger, label: string, action: () => void): void => {
   try {

--- a/test/integration/core-rpc.spec.ts
+++ b/test/integration/core-rpc.spec.ts
@@ -83,9 +83,8 @@ describe('Core RPC Round-Trip', () => {
   });
 
   it('should complete cleanly when the handler returns nothing', async () => {
-    // Given/When: calling a void handler. NestJS skips next() for undefined
-    // responses, so the observable completes empty — the call must not
-    // surface a decode error.
+    // NestJS skips next() for undefined replies — the observable completes
+    // empty, but must not surface a decode error.
     await expect(
       firstValueFrom(client.send('user.touch', { id: 42 }), { defaultValue: undefined }),
     ).resolves.toBeUndefined();

--- a/test/integration/jetstream-rpc.spec.ts
+++ b/test/integration/jetstream-rpc.spec.ts
@@ -84,9 +84,8 @@ describe('JetStream RPC Round-Trip', () => {
   });
 
   it('should complete cleanly when the handler returns nothing', async () => {
-    // Given/When: calling a void handler. NestJS skips next() for undefined
-    // responses, so the observable completes empty — the call must not
-    // surface a decode error.
+    // NestJS skips next() for undefined replies — the observable completes
+    // empty, but must not surface a decode error.
     await expect(
       firstValueFrom(client.send('user.touch', { id: 7 }), { defaultValue: undefined }),
     ).resolves.toBeUndefined();

--- a/test/integration/scheduling.spec.ts
+++ b/test/integration/scheduling.spec.ts
@@ -356,9 +356,8 @@ describe('Message Scheduling (Delayed Jobs)', () => {
     });
 
     it('should deliver every pending schedule of the same pattern instead of replacing it', async () => {
-      // Given: three messages scheduled on the SAME pattern while earlier ones are pending.
-      // ADR-51 rollup semantics allow one active schedule per subject, so the schedule
-      // subject must be unique per message — otherwise only the last schedule survives.
+      // Given: three schedules on the SAME pattern — per ADR-51 a shared
+      // schedule subject would keep only the last one.
       const now = Date.now();
 
       const records = [1, 2, 3].map((orderId) =>

--- a/test/integration/stream-migration.spec.ts
+++ b/test/integration/stream-migration.spec.ts
@@ -495,9 +495,7 @@ describe('Stream sourcing behavior (NATS verification)', () => {
           await js.publish(subject, encoder.encode(JSON.stringify({ seed: i })));
         }
 
-        // A producer keeps publishing while the migration runs. Only acked
-        // publishes count — a rejected publish never happened for a producer
-        // with retry logic, but an acked one is a delivery promise.
+        // Only acked publishes count: a rejection is retryable, an ack is a delivery promise.
         let acked = 20;
         let stop = false;
         const publisher = (async (): Promise<void> => {


### PR DESCRIPTION
Comment-only follow-up to #180: the inline comments added with the reliability fixes were too wordy — several ran three to six lines for a single statement. This trims them to the constraint they document and keeps the load-bearing ones (ADR-51 rollup semantics, the backup-before-detach ordering that recovery relies on, the source lag/active false positive verified against NATS 2.12.6).

No code changes: 74 insertions / 173 deletions, all comment lines. Type check, lint, and the unit suite pass.