### PR TITLE
fix(streams): drop the self-overlapping broadcast schedule subject

### DIFF
--- a/src/server/infrastructure/__tests__/stream.provider.spec.ts
+++ b/src/server/infrastructure/__tests__/stream.provider.spec.ts
@@ -144,8 +144,7 @@ describe(StreamProvider, () => {
     });
 
     describe('when kind is Broadcast with allow_msg_schedules: true', () => {
-      it('should include broadcast._sch.>', () => {
-        // Given: scheduling enabled for broadcast
+      it('should NOT add a schedule subject — broadcast.> already covers it', () => {
         options.broadcast = { stream: { allow_msg_schedules: true } };
         sut = new StreamProvider(options, connection);
 
@@ -153,7 +152,7 @@ describe(StreamProvider, () => {
         const subjects = sut.getSubjects(StreamKind.Broadcast);
 
         // Then
-        expect(subjects).toEqual(['broadcast.>', 'broadcast._sch.>']);
+        expect(subjects).toEqual(['broadcast.>']);
       });
     });
 
@@ -210,11 +209,10 @@ describe(StreamProvider, () => {
     });
 
     it('should not strip subjects or rewrite the description set by other services', async () => {
-      // Given: another service enabled broadcast scheduling, so the shared
-      // stream carries an extra subject this service's config does not declare
+      // Given: the live stream has an extra subject broadcast.> does not cover
       mockStreamInfo(
         createMock<StreamInfo>({
-          config: sharedBroadcastConfig({ subjects: ['broadcast.>', 'broadcast._sch.>'] }),
+          config: sharedBroadcastConfig({ subjects: ['broadcast.>', 'announcements.>'] }),
         }),
       );
       mockJsm.streams.update.mockResolvedValue(createMock<StreamInfo>());
@@ -225,6 +223,26 @@ describe(StreamProvider, () => {
       // Then: no update — the local config must not clobber the shared stream
       expect(mockJsm.streams.update).not.toHaveBeenCalled();
       expect(mockJsm.streams.add).not.toHaveBeenCalled();
+    });
+
+    it('should collapse subjects covered by a broader one out of the shared-stream union', async () => {
+      // Given: the live stream still carries a legacy broadcast._sch.>
+      mockStreamInfo(
+        createMock<StreamInfo>({
+          config: sharedBroadcastConfig({ subjects: ['broadcast.>', 'broadcast._sch.>'] }),
+        }),
+      );
+      mockJsm.streams.update.mockResolvedValue(createMock<StreamInfo>());
+
+      // When
+      await sut.ensureStreams([StreamKind.Broadcast]);
+
+      // Then: the redundant subject is healed away
+      expect(mockJsm.streams.update).toHaveBeenCalledOnce();
+
+      const updateArg = mockJsm.streams.update.mock.calls[0]![1] as { subjects: string[] };
+
+      expect(updateArg.subjects).toEqual(['broadcast.>']);
     });
 
     it('should refuse destructive migration of the shared broadcast stream', async () => {

--- a/src/server/infrastructure/__tests__/stream.provider.spec.ts
+++ b/src/server/infrastructure/__tests__/stream.provider.spec.ts
@@ -225,6 +225,22 @@ describe(StreamProvider, () => {
       expect(mockJsm.streams.add).not.toHaveBeenCalled();
     });
 
+    it('should keep a literal subject that the catch-all does not match', async () => {
+      // Given: NATS '>' matches one-or-more tokens, so broadcast.> does not cover 'broadcast'
+      mockStreamInfo(
+        createMock<StreamInfo>({
+          config: sharedBroadcastConfig({ subjects: ['broadcast.>', 'broadcast'] }),
+        }),
+      );
+      mockJsm.streams.update.mockResolvedValue(createMock<StreamInfo>());
+
+      // When
+      await sut.ensureStreams([StreamKind.Broadcast]);
+
+      // Then
+      expect(mockJsm.streams.update).not.toHaveBeenCalled();
+    });
+
     it('should collapse subjects covered by a broader one out of the shared-stream union', async () => {
       // Given: the live stream still carries a legacy broadcast._sch.>
       mockStreamInfo(

--- a/src/server/infrastructure/stream.provider.ts
+++ b/src/server/infrastructure/stream.provider.ts
@@ -136,7 +136,6 @@ export class StreamProvider {
       case StreamKind.Command:
         return [`${name}.${StreamKind.Command}.>`];
       case StreamKind.Broadcast:
-        // No _sch entry: broadcast.> already covers it, a sibling would self-overlap (err 10052).
         return ['broadcast.>'];
 
       case StreamKind.Ordered:
@@ -245,7 +244,6 @@ export class StreamProvider {
     ctx: ProvisioningErrorContext,
   ): Promise<StreamInfo> {
     if (this.isSharedStream(config.name)) {
-      // Keep other services' subjects, but drop entries covered by a broader one (err 10052).
       const merged = [...new Set([...config.subjects, ...currentInfo.config.subjects])];
 
       config.subjects = merged.filter((s) => !merged.some((other) => subjectCovers(other, s)));

--- a/src/server/infrastructure/stream.provider.ts
+++ b/src/server/infrastructure/stream.provider.ts
@@ -37,6 +37,22 @@ import { StreamMigration } from './stream-migration';
 /** A `StreamKind` or the `'dlq'` label, used for reservation/error provenance. */
 type ReservationKind = StreamKind | 'dlq';
 
+/** True when `broad` matches everything `narrow` matches. Identical entries return false. */
+const subjectCovers = (broad: string, narrow: string): boolean => {
+  if (broad === narrow) return false;
+
+  const broadTokens = broad.split('.');
+  const narrowTokens = narrow.split('.');
+
+  for (let i = 0; i < broadTokens.length; i += 1) {
+    if (broadTokens[i] === '>') return true;
+    if (i >= narrowTokens.length || narrowTokens[i] === '>') return false;
+    if (broadTokens[i] !== '*' && broadTokens[i] !== narrowTokens[i]) return false;
+  }
+
+  return broadTokens.length === narrowTokens.length;
+};
+
 /**
  * Manages JetStream stream lifecycle: creation, updates, and idempotent ensures.
  *
@@ -119,15 +135,9 @@ export class StreamProvider {
 
       case StreamKind.Command:
         return [`${name}.${StreamKind.Command}.>`];
-      case StreamKind.Broadcast: {
-        const subjects = ['broadcast.>'];
-
-        if (this.isSchedulingEnabled(kind)) {
-          subjects.push('broadcast._sch.>');
-        }
-
-        return subjects;
-      }
+      case StreamKind.Broadcast:
+        // No _sch entry: broadcast.> already covers it, a sibling would self-overlap (err 10052).
+        return ['broadcast.>'];
 
       case StreamKind.Ordered:
         return [`${name}.${StreamKind.Ordered}.>`];
@@ -235,9 +245,10 @@ export class StreamProvider {
     ctx: ProvisioningErrorContext,
   ): Promise<StreamInfo> {
     if (this.isSharedStream(config.name)) {
-      // Other services may have added subjects (e.g. broadcast._sch.>) that
-      // the local config does not declare — don't strip them.
-      config.subjects = [...new Set([...config.subjects, ...currentInfo.config.subjects])];
+      // Keep other services' subjects, but drop entries covered by a broader one (err 10052).
+      const merged = [...new Set([...config.subjects, ...currentInfo.config.subjects])];
+
+      config.subjects = merged.filter((s) => !merged.some((other) => subjectCovers(other, s)));
     }
 
     const diff = compareStreamConfig(currentInfo.config, config);

--- a/src/server/infrastructure/stream.provider.ts
+++ b/src/server/infrastructure/stream.provider.ts
@@ -45,7 +45,7 @@ const subjectCovers = (broad: string, narrow: string): boolean => {
   const narrowTokens = narrow.split('.');
 
   for (let i = 0; i < broadTokens.length; i += 1) {
-    if (broadTokens[i] === '>') return true;
+    if (broadTokens[i] === '>') return i < narrowTokens.length;
     if (i >= narrowTokens.length || narrowTokens[i] === '>') return false;
     if (broadTokens[i] !== '*' && broadTokens[i] !== narrowTokens[i]) return false;
   }

--- a/test/integration/scheduling.spec.ts
+++ b/test/integration/scheduling.spec.ts
@@ -430,7 +430,6 @@ describe('Message Scheduling (Delayed Jobs)', () => {
     beforeEach(async () => {
       serviceName = uniqueServiceName();
 
-      // Boot is part of the assertion — self-overlapping subjects fail here
       ({ app, module } = await createTestApp(
         {
           name: serviceName,
@@ -453,7 +452,7 @@ describe('Message Scheduling (Delayed Jobs)', () => {
     });
 
     it('should boot with broadcast scheduling enabled and deliver a scheduled broadcast', async () => {
-      // Given: a scheduled broadcast — its holder rides broadcast.> itself
+      // Given: a broadcast scheduled 1.5s out
       const payload = { promo: 'summer' };
 
       const record = new JetstreamRecordBuilder(payload)

--- a/test/integration/scheduling.spec.ts
+++ b/test/integration/scheduling.spec.ts
@@ -69,6 +69,16 @@ class HeaderCapturingController {
   }
 }
 
+@Controller()
+class BroadcastScheduledController {
+  public readonly received: unknown[] = [];
+
+  @EventPattern('promo.start', { broadcast: true })
+  handlePromo(@Payload() data: unknown): void {
+    this.received.push(data);
+  }
+}
+
 describe('Message Scheduling (Delayed Jobs)', () => {
   let nc: NatsConnection;
   let container: StartedTestContainer;
@@ -407,6 +417,56 @@ describe('Message Scheduling (Delayed Jobs)', () => {
       await waitForCondition(async () => (await countScheduleMessages()) === 0, 10_000);
 
       expect(await countScheduleMessages()).toBe(0);
+    });
+  });
+
+  describe('broadcast scheduling', () => {
+    let app: INestApplication;
+    let module: TestingModule;
+    let client: ClientProxy;
+    let serviceName: string;
+    let controller: BroadcastScheduledController;
+
+    beforeEach(async () => {
+      serviceName = uniqueServiceName();
+
+      // Boot is part of the assertion — self-overlapping subjects fail here
+      ({ app, module } = await createTestApp(
+        {
+          name: serviceName,
+          port,
+          broadcast: {
+            stream: { allow_msg_schedules: true },
+          },
+        },
+        [BroadcastScheduledController],
+        [serviceName],
+      ));
+
+      client = module.get<ClientProxy>(getClientToken(serviceName));
+      controller = module.get(BroadcastScheduledController);
+    });
+
+    afterEach(async () => {
+      await app.close();
+      await cleanupStreams(nc, serviceName);
+    });
+
+    it('should boot with broadcast scheduling enabled and deliver a scheduled broadcast', async () => {
+      // Given: a scheduled broadcast — its holder rides broadcast.> itself
+      const payload = { promo: 'summer' };
+
+      const record = new JetstreamRecordBuilder(payload)
+        .scheduleAt(new Date(Date.now() + 1_500))
+        .build();
+
+      // When
+      await firstValueFrom(client.emit('broadcast:promo.start', record));
+
+      // Then
+      await waitForCondition(() => controller.received.length > 0, 10_000);
+
+      expect(controller.received[0]).toEqual(payload);
     });
   });
 


### PR DESCRIPTION
Fixes the boot crash reported for `broadcast: { stream: { allow_msg_schedules: true } }`.

## Root cause

`getSubjects(Broadcast)` appended `broadcast._sch.>` next to the `broadcast.>` catch-all. NATS validates that a stream's own subjects must not overlap each other (err 10052), so provisioning was rejected and every service with the flag crash-looped. The entry was also redundant: scheduled broadcast holders publish to `broadcast._sch.<pattern>.<nuid>`, which the catch-all already routes into the stream. The events stream is unaffected — its `.ev.>` and `._sch.>` subjects are non-overlapping siblings.

## Fix

- Broadcast subjects are always `['broadcast.>']`; the dedicated `_sch` entry stays only where it is needed (events).
- The shared-stream subject union now collapses entries covered by a broader subject, so a legacy `broadcast._sch.>` that an older server accepted is healed away instead of wedging updates fleet-wide (the secondary issue from the report).

## Tests (TDD)

- New e2e: boot with broadcast scheduling enabled + scheduled broadcast round-trip — reproduced the exact err-10052 boot failure before the fix.
- Unit: broadcast subjects with scheduling are exactly `['broadcast.>']`; the union collapse heals `['broadcast.>', 'broadcast._sch.>']` back to `['broadcast.>']`; uncovered foreign subjects still survive the union; events keep both subjects.
- Full suite: 875/875 green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added broadcast scheduling integration testing with configurable delays.

* **Tests**
  * Expanded test coverage for JetStream broadcast subject handling and stream consolidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->