### PR TITLE
feat: select WebSocket transport from server URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.13.0-trebik.1]
+
+### Features
+
+* **connection:** add a custom `connectionFactory` for compatible transports such as NATS WebSocket while preserving the full JetStream lifecycle
+
 ## [2.13.0](https://github.com/HorizonRepublic/nestjs-jetstream/compare/v2.12.1...v2.13.0) (2026-06-15)
 
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ NestJS' [built-in NATS transport](https://docs.nestjs.com/microservices/nats) lo
 - **Scheduled messages, per-message TTL, health checks, graceful shutdown** — all the production levers.
 - **OpenTelemetry-compatible** — W3C `traceparent` propagated through every hop.
 
+## Connection transports
+
+The library always speaks the NATS protocol and automatically chooses the physical connection from the server URL:
+
+| URL | Connection |
+|---|---|
+| `nats://` | NATS over TCP |
+| `tls://` | NATS over TLS |
+| `ws://` | NATS over WebSocket |
+| `wss://` | NATS over secure WebSocket |
+
+No `connectionFactory` is needed for WebSocket. RPC is a separate message-level choice: both Core RPC and JetStream RPC work over TCP/TLS or WebSocket, as do durable events, broadcast, and ordered delivery. See [Connection Transports](website/docs/getting-started/connection-transports.md) for examples and the compatibility matrix.
+
 ## Install
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@horizon-republic/nestjs-jetstream",
-  "version": "2.13.0",
+  "version": "2.13.0-trebik.1",
   "description": "A NestJS transport for NATS with JetStream events, broadcast fan-out, and Core/JetStream RPC.",
   "repository": {
     "type": "git",
@@ -104,6 +104,7 @@
     "@nestjs/microservices": "^11.1.26",
     "@nestjs/platform-express": "^11.1.26",
     "@nestjs/testing": "^11.1.26",
+    "@nats-io/nats-core": "^3.4.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/context-async-hooks": "^2.7.1",
     "@opentelemetry/core": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@horizon-republic/nestjs-jetstream",
-  "version": "2.13.0-trebik.1",
+  "version": "2.13.0-trebik.2",
   "description": "A NestJS transport for NATS with JetStream events, broadcast fan-out, and Core/JetStream RPC.",
   "repository": {
     "type": "git",
@@ -104,7 +104,6 @@
     "@nestjs/microservices": "^11.1.26",
     "@nestjs/platform-express": "^11.1.26",
     "@nestjs/testing": "^11.1.26",
-    "@nats-io/nats-core": "^3.4.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/context-async-hooks": "^2.7.1",
     "@opentelemetry/core": "^2.7.1",
@@ -133,6 +132,7 @@
   "dependencies": {
     "@nats-io/jetstream": "^3.4.0",
     "@nats-io/kv": "^3.4.0",
+    "@nats-io/nats-core": "^3.4.0",
     "@nats-io/nuid": "^3.0.0",
     "@nats-io/transport-node": "^3.4.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@nats-io/kv':
         specifier: ^3.4.0
         version: 3.4.0
+      '@nats-io/nats-core':
+        specifier: ^3.4.0
+        version: 3.4.0
       '@nats-io/nuid':
         specifier: ^3.0.0
         version: 3.0.0
@@ -39,9 +42,6 @@ importers:
       '@golevelup/ts-vitest':
         specifier: ^4.0.0
         version: 4.0.0
-      '@nats-io/nats-core':
-        specifier: ^3.4.0
-        version: 3.4.0
       '@nestjs/common':
         specifier: ^11.1.26
         version: 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@golevelup/ts-vitest':
         specifier: ^4.0.0
         version: 4.0.0
+      '@nats-io/nats-core':
+        specifier: ^3.4.0
+        version: 3.4.0
       '@nestjs/common':
         specifier: ^11.1.26
         version: 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -8212,15 +8215,15 @@ snapshots:
 
   '@babel/core@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -8385,8 +8388,8 @@ snapshots:
 
   '@babel/helpers@7.29.2':
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.2':
     dependencies:
@@ -9981,7 +9984,7 @@ snapshots:
       '@docusaurus/utils': 3.10.1(esbuild@0.27.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-common': 3.10.1(esbuild@0.27.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/history': 4.7.11
-      '@types/react': 19.2.15
+      '@types/react': 19.2.17
       '@types/react-router-config': 5.0.11
       clsx: 2.1.1
       parse-numeric-range: 1.3.0
@@ -14148,7 +14151,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -15846,7 +15849,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
       long: 5.3.2
 
   proxy-addr@2.0.7:

--- a/src/connection/__tests__/connection.provider.spec.ts
+++ b/src/connection/__tests__/connection.provider.spec.ts
@@ -27,6 +27,11 @@ vi.mock('@nats-io/transport-node', async () => ({
   connect: vi.fn(),
 }));
 
+vi.mock('@nats-io/nats-core', async () => ({
+  ...(await vi.importActual('@nats-io/nats-core')),
+  wsconnect: vi.fn(),
+}));
+
 vi.mock('@nats-io/jetstream', async () => ({
   ...(await vi.importActual('@nats-io/jetstream')),
   jetstream: vi.fn(),
@@ -34,6 +39,7 @@ vi.mock('@nats-io/jetstream', async () => ({
 }));
 
 const mockConnect = connect as MockedFunction<typeof connect>;
+const mockWsConnect = wsconnect as MockedFunction<typeof wsconnect>;
 
 describe(ConnectionProvider, () => {
   let sut: ConnectionProvider;
@@ -67,6 +73,7 @@ describe(ConnectionProvider, () => {
     eventBus = createMock<EventBus>();
     mockNc = createNc();
     mockConnect.mockResolvedValue(mockNc);
+    mockWsConnect.mockResolvedValue(mockNc);
     mockJetstream.mockReturnValue(createMock<JetStreamClient>());
 
     sut = new ConnectionProvider(options, eventBus);
@@ -120,6 +127,7 @@ describe(ConnectionProvider, () => {
         // Given: a custom transport factory such as wsconnect
         const connectionFactory = vi.fn<NatsConnectionFactory>().mockResolvedValue(mockNc);
 
+        options.servers = ['wss://nats.example.com'];
         options.connectionOptions = {
           name: 'custom-connection-name',
           reconnectTimeWait: 2_000,
@@ -140,16 +148,43 @@ describe(ConnectionProvider, () => {
           servers: options.servers,
         });
         expect(mockConnect).not.toHaveBeenCalled();
+        expect(mockWsConnect).not.toHaveBeenCalled();
       });
 
-      it('should accept the WebSocket connection factory', () => {
-        const connectionFactory: NatsConnectionFactory = wsconnect;
+      it.each(['ws://nats.example.com', 'wss://nats.example.com'])(
+        'should automatically use the WebSocket transport for %s',
+        async (server) => {
+          // Given: every configured server uses WebSocket
+          options.servers = [server];
+          sut = new ConnectionProvider(options, eventBus);
 
-        expect(connectionFactory).toBe(wsconnect);
-      });
+          // When: connection requested
+          const nc = await sut.getConnection();
+
+          // Then: WebSocket transport receives the resolved options
+          expect(nc).toBe(mockNc);
+          expect(mockWsConnect).toHaveBeenCalledWith(
+            expect.objectContaining({ servers: [server] }),
+          );
+          expect(mockConnect).not.toHaveBeenCalled();
+        },
+      );
     });
 
     describe('error paths', () => {
+      it('should reject mixed WebSocket and TCP server URLs', async () => {
+        // Given: no single physical transport can serve both URL families
+        options.servers = ['wss://nats.example.com', 'nats://nats.internal:4222'];
+        sut = new ConnectionProvider(options, eventBus);
+
+        // When/Then: configuration fails before attempting a connection
+        await expect(sut.getConnection()).rejects.toThrow(
+          'NATS servers cannot mix WebSocket and TCP/TLS URLs',
+        );
+        expect(mockWsConnect).not.toHaveBeenCalled();
+        expect(mockConnect).not.toHaveBeenCalled();
+      });
+
       it('should throw RuntimeException on CONNECTION_REFUSED', async () => {
         // Given: connection refused
         mockConnect.mockRejectedValue(new Error('CONNECTION_REFUSED'));

--- a/src/connection/__tests__/connection.provider.spec.ts
+++ b/src/connection/__tests__/connection.provider.spec.ts
@@ -14,9 +14,10 @@ import type { NatsConnection, Status } from '@nats-io/transport-node';
 import { connect } from '@nats-io/transport-node';
 import type { JetStreamClient, JetStreamManager } from '@nats-io/jetstream';
 import { jetstream, jetstreamManager } from '@nats-io/jetstream';
+import { wsconnect } from '@nats-io/nats-core';
 
 import { EventBus } from '../../hooks';
-import type { JetstreamModuleOptions } from '../../interfaces';
+import type { JetstreamModuleOptions, NatsConnectionFactory } from '../../interfaces';
 import { TransportEvent } from '../../interfaces';
 
 import { ConnectionProvider } from '../connection.provider';
@@ -113,6 +114,38 @@ describe(ConnectionProvider, () => {
         // Then: same connection, single connect call
         expect(nc1).toBe(nc2);
         expect(mockConnect).toHaveBeenCalledTimes(1);
+      });
+
+      it('should use a custom connection factory with merged options', async () => {
+        // Given: a custom transport factory such as wsconnect
+        const connectionFactory = vi.fn<NatsConnectionFactory>().mockResolvedValue(mockNc);
+
+        options.connectionOptions = {
+          name: 'custom-connection-name',
+          reconnectTimeWait: 2_000,
+        };
+        options.connectionFactory = connectionFactory;
+        sut = new ConnectionProvider(options, eventBus);
+
+        // When: connection requested
+        const nc = await sut.getConnection();
+
+        // Then: the custom factory receives the fully resolved configuration
+        expect(nc).toBe(mockNc);
+        expect(connectionFactory).toHaveBeenCalledTimes(1);
+        expect(connectionFactory).toHaveBeenCalledWith({
+          maxReconnectAttempts: -1,
+          reconnectTimeWait: 2_000,
+          name: 'custom-connection-name',
+          servers: options.servers,
+        });
+        expect(mockConnect).not.toHaveBeenCalled();
+      });
+
+      it('should accept the WebSocket connection factory', () => {
+        const connectionFactory: NatsConnectionFactory = wsconnect;
+
+        expect(connectionFactory).toBe(wsconnect);
       });
     });
 

--- a/src/connection/connection.provider.ts
+++ b/src/connection/connection.provider.ts
@@ -203,7 +203,7 @@ export class ConnectionProvider {
   /** Internal: establish the physical connection with reconnect monitoring. */
   private async establish(): Promise<NatsConnection> {
     try {
-      const nc = await connect({
+      const connectionOptions: ConnectionOptions = {
         ...DEFAULT_OPTIONS,
         // Default the NATS connection name to the OTel-derived service name so
         // `nats server info` lines up with span attributes, but let user-supplied
@@ -211,7 +211,10 @@ export class ConnectionProvider {
         name: this.otelServiceName,
         ...this.options.connectionOptions,
         servers: this.options.servers,
-      } as ConnectionOptions);
+      };
+      const nc = this.options.connectionFactory
+        ? await this.options.connectionFactory(connectionOptions)
+        : await connect(connectionOptions);
 
       this.connection = nc;
       this.logger.log(`NATS connection established: ${nc.getServer()}`);

--- a/src/connection/connection.provider.ts
+++ b/src/connection/connection.provider.ts
@@ -5,6 +5,7 @@ import {
   type NatsConnection,
   type Status,
 } from '@nats-io/transport-node';
+import { hasWsProtocol, wsconnect } from '@nats-io/nats-core';
 import {
   jetstream,
   jetstreamManager,
@@ -15,7 +16,7 @@ import { defer, from, Observable, share, shareReplay, switchMap } from 'rxjs';
 
 import { EventBus } from '../hooks';
 import { TransportEvent } from '../interfaces';
-import type { JetstreamModuleOptions } from '../interfaces';
+import type { JetstreamModuleOptions, NatsConnectionFactory } from '../interfaces';
 import {
   ATTR_NATS_CONNECTION_SERVER,
   beginConnectionLifecycleSpan,
@@ -31,6 +32,19 @@ import {
 const DEFAULT_OPTIONS: Partial<ConnectionOptions> = {
   maxReconnectAttempts: -1,
   reconnectTimeWait: 1_000,
+};
+
+const resolveDefaultConnectionFactory = (options: ConnectionOptions): NatsConnectionFactory => {
+  const servers = typeof options.servers === 'string' ? [options.servers] : (options.servers ?? []);
+  const websocketServerCount = servers.filter((server) =>
+    hasWsProtocol({ servers: [server] }),
+  ).length;
+
+  if (websocketServerCount > 0 && websocketServerCount < servers.length) {
+    throw new Error('NATS servers cannot mix WebSocket and TCP/TLS URLs');
+  }
+
+  return websocketServerCount > 0 ? wsconnect : connect;
 };
 
 /**
@@ -212,9 +226,9 @@ export class ConnectionProvider {
         ...this.options.connectionOptions,
         servers: this.options.servers,
       };
-      const nc = this.options.connectionFactory
-        ? await this.options.connectionFactory(connectionOptions)
-        : await connect(connectionOptions);
+      const connectionFactory =
+        this.options.connectionFactory ?? resolveDefaultConnectionFactory(connectionOptions);
+      const nc = await connectionFactory(connectionOptions);
 
       this.connection = nc;
       this.logger.log(`NATS connection established: ${nc.getServer()}`);

--- a/src/connection/connection.provider.ts
+++ b/src/connection/connection.provider.ts
@@ -34,8 +34,7 @@ const DEFAULT_OPTIONS: Partial<ConnectionOptions> = {
   reconnectTimeWait: 1_000,
 };
 
-const resolveDefaultConnectionFactory = (options: ConnectionOptions): NatsConnectionFactory => {
-  const servers = typeof options.servers === 'string' ? [options.servers] : (options.servers ?? []);
+const resolveDefaultConnectionFactory = (servers: readonly string[]): NatsConnectionFactory => {
   const websocketServerCount = servers.filter((server) =>
     hasWsProtocol({ servers: [server] }),
   ).length;
@@ -227,7 +226,7 @@ export class ConnectionProvider {
         servers: this.options.servers,
       };
       const connectionFactory =
-        this.options.connectionFactory ?? resolveDefaultConnectionFactory(connectionOptions);
+        this.options.connectionFactory ?? resolveDefaultConnectionFactory(this.options.servers);
       const nc = await connectionFactory(connectionOptions);
 
       this.connection = nc;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export type {
   JetstreamModuleAsyncOptions,
   JetstreamModuleOptions,
   MetadataRegistryOptions,
+  NatsConnectionFactory,
   OrderedEventOverrides,
   ProvisioningOptions,
   RpcConfig,

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -23,6 +23,7 @@ export type {
   JetstreamModuleOptions,
   JetStreamRpcConfig,
   MetadataRegistryOptions,
+  NatsConnectionFactory,
   OrderedEventOverrides,
   ProvisioningOptions,
   RpcConfig,

--- a/src/interfaces/options.interface.ts
+++ b/src/interfaces/options.interface.ts
@@ -374,12 +374,13 @@ export interface JetstreamModuleOptions {
   /**
    * Custom NATS connection factory.
    *
-   * Use this when the application needs a transport other than the default
-   * Node TCP/TLS client, for example `wsconnect` from `@nats-io/nats-core`.
+   * WebSocket transport is selected automatically when every server uses
+   * `ws://` or `wss://`. Use this factory only to override the scheme-based
+   * selection or provide another compatible transport.
    * The factory receives the same merged options that would be passed to the
-   * default `connect()` implementation.
+   * selected connection implementation.
    *
-   * @default connect from @nats-io/transport-node
+   * @default wsconnect for WebSocket URLs; connect for TCP/TLS URLs
    */
   connectionFactory?: NatsConnectionFactory;
 

--- a/src/interfaces/options.interface.ts
+++ b/src/interfaces/options.interface.ts
@@ -1,5 +1,5 @@
 import { FactoryProvider, ModuleMetadata, Type } from '@nestjs/common';
-import type { ConnectionOptions } from '@nats-io/transport-node';
+import type { ConnectionOptions, NatsConnection } from '@nats-io/transport-node';
 import { DeliverPolicy, ReplayPolicy } from '@nats-io/jetstream';
 import type { ConsumerConfig, ConsumeOptions, StreamConfig } from '@nats-io/jetstream';
 
@@ -221,6 +221,9 @@ export interface ProvisioningOptions {
   management?: ManagementMode;
 }
 
+/** Creates the NATS connection used by the transport. */
+export type NatsConnectionFactory = (options: ConnectionOptions) => Promise<NatsConnection>;
+
 /**
  * Root module configuration for `JetstreamModule.forRoot()`.
  *
@@ -367,6 +370,18 @@ export interface JetstreamModuleOptions {
    * Merged with `name` and `servers`; those take precedence.
    */
   connectionOptions?: Partial<ConnectionOptions>;
+
+  /**
+   * Custom NATS connection factory.
+   *
+   * Use this when the application needs a transport other than the default
+   * Node TCP/TLS client, for example `wsconnect` from `@nats-io/nats-core`.
+   * The factory receives the same merged options that would be passed to the
+   * default `connect()` implementation.
+   *
+   * @default connect from @nats-io/transport-node
+   */
+  connectionFactory?: NatsConnectionFactory;
 
   /**
    * Built-in Prometheus metrics.

--- a/website/docs/getting-started/connection-transports.md
+++ b/website/docs/getting-started/connection-transports.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 3
+sidebar_label: "Connection Transports"
+title: "NATS TCP, TLS, and WebSocket Connections"
+description: "Connect NestJS services to NATS over TCP, TLS, WebSocket, or secure WebSocket, independently of the message pattern or RPC mode."
+schema:
+  type: Article
+  headline: "NATS TCP, TLS, and WebSocket Connections"
+  description: "Choose a NATS connection transport by URL while keeping events and RPC configuration independent."
+  datePublished: "2026-07-20"
+  dateModified: "2026-07-20"
+---
+
+# Connection Transports
+
+The library always speaks the **NATS protocol**. The `servers` URL decides how that protocol reaches the NATS server: directly over TCP/TLS or through WebSocket. The transport is selected automatically; ordinary applications do not need a `connectionFactory`.
+
+| Server URL | Physical connection | Selected implementation |
+|---|---|---|
+| `nats://nats:4222` | NATS over TCP | Node `connect` |
+| `tls://nats.example.com:4222` | NATS over TLS | Node `connect` |
+| `ws://nats.example.com/nats` | NATS over WebSocket | `wsconnect` |
+| `wss://nats.example.com/nats` | NATS over secure WebSocket | `wsconnect` |
+
+```typescript title="TCP connection"
+JetstreamModule.forRoot({
+  name: 'orders',
+  servers: ['nats://nats:4222'],
+})
+```
+
+```typescript title="Secure WebSocket connection"
+JetstreamModule.forRoot({
+  name: 'orders',
+  servers: ['wss://nats.example.com/nats'],
+})
+```
+
+Every URL in one `servers` list must belong to the same physical transport family. Multiple TCP/TLS URLs can be used together, and multiple WebSocket URLs can be used together, but WebSocket and TCP/TLS URLs cannot be mixed in one list.
+
+For WebSocket encryption, use `wss://`. Do not pass `connectionOptions.tls` with a WebSocket URL; that option belongs to the Node TCP/TLS transport.
+
+## Connection transport is not an RPC mode
+
+RPC describes the message exchange pattern, not the physical connection. `rpc.mode` is independent of the URL in `servers`:
+
+- **Core RPC** uses native NATS request/reply for the lowest latency.
+- **JetStream RPC** persists the command before delivery, then returns the response through a Core NATS inbox.
+- **Events, broadcast, and ordered events** use their JetStream streams and consumers.
+
+All message modes work over either connection transport:
+
+| Message mode | TCP/TLS | WebSocket |
+|---|---:|---:|
+| Durable events | Yes | Yes |
+| Broadcast events | Yes | Yes |
+| Ordered events | Yes | Yes |
+| Core RPC | Yes | Yes |
+| JetStream RPC | Yes | Yes |
+
+For example, JetStream RPC over secure WebSocket requires only the URL and RPC mode:
+
+```typescript
+JetstreamModule.forRoot({
+  name: 'orders',
+  servers: ['wss://nats.example.com/nats'],
+  rpc: { mode: 'jetstream' },
+})
+```
+
+Authentication, reconnect settings, handlers, acknowledgements, and recovery behavior are configured the same way for TCP/TLS and WebSocket connections.
+
+## Custom connection factories
+
+`connectionFactory` remains available as an advanced escape hatch for a custom compatible physical transport or tests. It overrides automatic URL-based selection. See [Module Configuration](/docs/reference/module-configuration#connection-transport-selection-and-connectionfactory).
+
+## Next steps
+
+- [Quick Start](/docs/getting-started/quick-start) — register the module and send events or RPC commands.
+- [RPC](/docs/patterns/rpc) — choose Core or JetStream request/reply.
+- [Module Configuration](/docs/reference/module-configuration) — configure authentication, reconnection, and advanced connection options.

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -8,7 +8,7 @@ schema:
   headline: "Quick Start"
   description: "Complete working example in four steps: register the module, connect the transport, define handlers, and send messages."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-20"
 ---
 
 # Quick Start
@@ -47,6 +47,19 @@ import { GatewayController } from './gateway.controller';
 })
 export class AppModule {}
 ```
+
+The `servers` URL selects the physical connection automatically: `nats://` and `tls://` use the Node TCP/TLS transport, while `ws://` and `wss://` use WebSocket. It does not select the RPC mode or message pattern.
+
+For example, the same service can connect through secure WebSocket without a custom connection factory:
+
+```typescript
+JetstreamModule.forRoot({
+  name: 'orders',
+  servers: ['wss://nats.example.com/nats'],
+})
+```
+
+See [Connection Transports](/docs/getting-started/connection-transports) for the URL table and the transport/message-mode compatibility matrix.
 
 :::tip Naming matters
 The `name` in `forRoot()` identifies **this** service. The `name` in `forFeature()` identifies the **target** service you want to send messages to. When a service sends messages to itself, the two names are the same.
@@ -200,6 +213,7 @@ curl http://localhost:3000/orders/42
 
 ## What's next?
 
+- [**Connection Transports**](/docs/getting-started/connection-transports) — connect through NATS TCP/TLS or WebSocket and understand how this differs from RPC mode
 - [**Module Configuration**](/docs/reference/module-configuration) — learn about all configuration options, async setup, and advanced connection settings
 - [**RPC Patterns**](/docs/patterns/rpc) — deep dive into Core vs JetStream RPC modes
 - [**Events & Broadcast**](/docs/patterns/events) — workqueue events, broadcast fan-out, and ordered events

--- a/website/docs/patterns/rpc.md
+++ b/website/docs/patterns/rpc.md
@@ -8,7 +8,7 @@ schema:
   headline: "NestJS NATS RPC — Core vs JetStream Request/Reply"
   description: "Synchronous NestJS NATS request-reply in Core NATS or JetStream mode, with timeout handling, error serialization, and per-request overrides."
   datePublished: "2026-03-21"
-  dateModified: "2026-04-11"
+  dateModified: "2026-07-20"
 ---
 
 # RPC (Request/Reply)
@@ -17,6 +17,10 @@ schema:
 > **You pick:** **Core** mode for sub-millisecond replies, **JetStream** mode for commands that must survive a restart. Same `@MessagePattern` either way.
 
 Your API gateway needs to fetch an order from the orders microservice. The client sends a command, the handler processes it, and the response travels back within a timeout window. This is request/reply (RPC), and the library offers two modes: **Core** for lowest latency, **JetStream** for persistence.
+
+:::info RPC mode is not the connection transport
+`rpc.mode` controls whether request commands are sent directly through Core NATS or persisted in JetStream. The `servers` URL independently controls the physical connection: NATS TCP/TLS (`nats://`, `tls://`) or WebSocket (`ws://`, `wss://`). Both RPC modes work over either connection. See [Connection Transports](/docs/getting-started/connection-transports).
+:::
 
 ## Core Mode (Default)
 

--- a/website/docs/reference/module-configuration.md
+++ b/website/docs/reference/module-configuration.md
@@ -8,7 +8,7 @@ schema:
   headline: "Module Configuration Reference"
   description: "Reference for forRoot(), forRootAsync(), and forFeature() registration methods with stream, consumer, and connection options."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-20"
 ---
 
 import Since from '@site/src/components/Since';
@@ -20,6 +20,8 @@ Reference for the three registration methods exposed by `JetstreamModule`: `forR
 ## forRoot()
 
 `forRoot()` registers the transport globally. Call it **once** in your root `AppModule`. It creates the shared NATS connection, codec, event bus, and (optionally) the full consumer infrastructure.
+
+The `servers` URL selects the physical connection independently of message behavior: `nats://` and `tls://` use TCP/TLS, while `ws://` and `wss://` use WebSocket. Options such as `rpc.mode`, events, broadcast, and ordered delivery work over either connection. See [Connection Transports](/docs/getting-started/connection-transports).
 
 ```typescript title="src/app.module.ts"
 import { Module } from '@nestjs/common';
@@ -221,7 +223,16 @@ Service name. Used for stream, consumer, and subject naming. Must be unique per 
 
 #### `servers` &mdash; `string[]`
 
-NATS server URLs (e.g., `['nats://localhost:4222']`).
+NATS server URLs. The URL scheme selects the physical connection automatically:
+
+| Scheme | Connection |
+|---|---|
+| `nats://` | NATS over TCP |
+| `tls://` | NATS over TLS |
+| `ws://` | NATS over WebSocket |
+| `wss://` | NATS over secure WebSocket |
+
+All URLs must use the same physical transport family; do not mix WebSocket and TCP/TLS URLs in one list. RPC mode and event delivery are configured separately and work over either family. See [Connection Transports](/docs/getting-started/connection-transports).
 
 ### Optional options
 
@@ -308,7 +319,7 @@ Default: none. Raw NATS `ConnectionOptions` pass-through for TLS, auth, reconnec
 
 #### `connectionFactory` &mdash; `NatsConnectionFactory`
 
-Default: selected from the server URLs. `ws://` and `wss://` use `wsconnect`; TCP/TLS URLs use `connect` from `@nats-io/transport-node`. An explicit factory replaces only the physical connection constructor while keeping the complete JetStream consumer, routing, acknowledgement, and recovery lifecycle. See [connectionFactory](#connectionfactory) below.
+Default: selected from the server URLs. `ws://` and `wss://` use `wsconnect`; TCP/TLS URLs use `connect` from `@nats-io/transport-node`. An explicit factory replaces only the physical connection constructor while keeping the complete JetStream consumer, routing, acknowledgement, and recovery lifecycle. See [connectionFactory](#connection-transport-selection-and-connectionfactory) below.
 
 #### `otel` &mdash; `OtelOptions`
 
@@ -528,9 +539,9 @@ connectionOptions: {
 }
 ```
 
-## connectionFactory
+## Connection transport selection and connectionFactory
 
-The transport automatically selects WebSocket when every configured server starts with `ws://` or `wss://`:
+The URL scheme in `servers` selects the physical connection automatically. WebSocket does not require an explicit `connectionFactory`:
 
 ```typescript
 JetstreamModule.forRoot({
@@ -539,9 +550,11 @@ JetstreamModule.forRoot({
 })
 ```
 
-TCP/TLS URLs continue to use `connect` from `@nats-io/transport-node`. WebSocket and TCP/TLS URLs cannot be mixed in one server list because they require different physical transports.
+TCP/TLS URLs use `connect` from `@nats-io/transport-node`. WebSocket URLs use `wsconnect` from `@nats-io/nats-core`. WebSocket and TCP/TLS URLs cannot be mixed in one server list because they require different physical transports.
 
 Set `connectionFactory` only when an application needs to override this scheme-based selection or provide another compatible transport. The factory receives the fully merged `ConnectionOptions` and returns a compatible `NatsConnection`.
+
+This setting changes only the physical connection. It does not change Core RPC, JetStream RPC, or any event delivery semantics. See [Connection Transports](/docs/getting-started/connection-transports) for the complete distinction.
 
 ## Publisher-only mode
 

--- a/website/docs/reference/module-configuration.md
+++ b/website/docs/reference/module-configuration.md
@@ -308,7 +308,7 @@ Default: none. Raw NATS `ConnectionOptions` pass-through for TLS, auth, reconnec
 
 #### `connectionFactory` &mdash; `NatsConnectionFactory`
 
-Default: `connect` from `@nats-io/transport-node`. Replaces only the physical connection constructor while keeping the complete JetStream consumer, routing, acknowledgement, and recovery lifecycle. Use it for compatible transports such as `wsconnect`. See [connectionFactory](#connectionfactory) below.
+Default: selected from the server URLs. `ws://` and `wss://` use `wsconnect`; TCP/TLS URLs use `connect` from `@nats-io/transport-node`. An explicit factory replaces only the physical connection constructor while keeping the complete JetStream consumer, routing, acknowledgement, and recovery lifecycle. See [connectionFactory](#connectionfactory) below.
 
 #### `otel` &mdash; `OtelOptions`
 
@@ -530,19 +530,18 @@ connectionOptions: {
 
 ## connectionFactory
 
-`connectionFactory` receives the fully merged `ConnectionOptions` and returns a compatible `NatsConnection`. This is useful when the service must connect over WebSocket while retaining the transport's durable pull consumer and self-healing behavior:
+The transport automatically selects WebSocket when every configured server starts with `ws://` or `wss://`:
 
 ```typescript
-import { wsconnect } from '@nats-io/nats-core';
-
 JetstreamModule.forRoot({
   name: 'orders',
   servers: ['wss://nats.example.com'],
-  connectionFactory: (options) => wsconnect(options),
 })
 ```
 
-When `connectionFactory` is omitted, the transport uses `connect` from `@nats-io/transport-node` exactly as before.
+TCP/TLS URLs continue to use `connect` from `@nats-io/transport-node`. WebSocket and TCP/TLS URLs cannot be mixed in one server list because they require different physical transports.
+
+Set `connectionFactory` only when an application needs to override this scheme-based selection or provide another compatible transport. The factory receives the fully merged `ConnectionOptions` and returns a compatible `NatsConnection`.
 
 ## Publisher-only mode
 

--- a/website/docs/reference/module-configuration.md
+++ b/website/docs/reference/module-configuration.md
@@ -306,6 +306,10 @@ Default: `10_000` (10 s). Graceful shutdown timeout in milliseconds. Handlers ex
 
 Default: none. Raw NATS `ConnectionOptions` pass-through for TLS, auth, reconnection, etc. See [connectionOptions](#connectionoptions) below.
 
+#### `connectionFactory` &mdash; `NatsConnectionFactory`
+
+Default: `connect` from `@nats-io/transport-node`. Replaces only the physical connection constructor while keeping the complete JetStream consumer, routing, acknowledgement, and recovery lifecycle. Use it for compatible transports such as `wsconnect`. See [connectionFactory](#connectionfactory) below.
+
 #### `otel` &mdash; `OtelOptions`
 
 Default: enabled with sensible defaults. OpenTelemetry tracing configuration. See [Distributed Tracing](/docs/observability/tracing).
@@ -523,6 +527,22 @@ connectionOptions: {
   reconnectJitter: 500,        // add up to 500ms random jitter
 }
 ```
+
+## connectionFactory
+
+`connectionFactory` receives the fully merged `ConnectionOptions` and returns a compatible `NatsConnection`. This is useful when the service must connect over WebSocket while retaining the transport's durable pull consumer and self-healing behavior:
+
+```typescript
+import { wsconnect } from '@nats-io/nats-core';
+
+JetstreamModule.forRoot({
+  name: 'orders',
+  servers: ['wss://nats.example.com'],
+  connectionFactory: (options) => wsconnect(options),
+})
+```
+
+When `connectionFactory` is omitted, the transport uses `connect` from `@nats-io/transport-node` exactly as before.
 
 ## Publisher-only mode
 


### PR DESCRIPTION
## Summary

Adds native WebSocket connection support to the JetStream transport.

The transport now automatically selects `wsconnect` for `ws://` and `wss://` server URLs while keeping the Node TCP/TLS transport for `nats://` and `tls://`. Explicit `connectionFactory` remains available as an advanced override.

Mixed WebSocket and TCP/TLS server lists are rejected with a clear configuration error. Documentation now distinguishes physical connection transports from Core and JetStream RPC modes.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (`type: description`)
- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic connection transport selection from server URL schemes (TCP, TLS, WebSocket, secure WebSocket).
  * Added support for a custom `connectionFactory` to use compatible transports while keeping JetStream lifecycle behavior.
  * Added validation to reject configurations that mix WebSocket and TCP/TLS server URL families.
* **Documentation**
  * Documented “Connection transports” behavior and how `connectionFactory` interacts with scheme-based selection.
* **Type Updates**
  * Exposed a `NatsConnectionFactory` type and added `connectionFactory` to module options.
* **Tests**
  * Expanded coverage for WebSocket selection and the new validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->