### PR TITLE
docs: tighten prose across the site, readme, examples and code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 <h1 align="center">nestjs-jetstream</h1>
 
 <p align="center">
-  The NATS JetStream transport NestJS microservices need —
-  durable, retried, traced — under the same <code>@EventPattern</code>
-  and <code>@MessagePattern</code> decorators you already use.
+  Durable, retried and traced NATS JetStream transport for NestJS
+  microservices, under the same <code>@EventPattern</code> and
+  <code>@MessagePattern</code> decorators you already use.
 </p>
 
 <p align="center">
@@ -30,21 +30,21 @@
 
 ---
 
-## Why this exists
+## What the built-in transport leaves out
 
-NestJS' [built-in NATS transport](https://docs.nestjs.com/microservices/nats) loses messages on pod restart, doesn't retry on failure, and gives you nothing to debug with. JetStream fixes all three — but wiring it into NestJS by hand is a project on its own.
+NestJS' [built-in NATS transport](https://docs.nestjs.com/microservices/nats) loses messages on pod restart, doesn't retry on failure, and gives you nothing to debug with. JetStream fixes all three, but wiring it into NestJS by hand is a project on its own.
 
 **This library is the swap.** Same `@EventPattern`, same `@MessagePattern`, same `client.emit()`. Durability, retries, and tracing underneath.
 
 ## What you get
 
-- **At-least-once delivery** — every event acked after the handler resolves; bounded retries with exponential backoff.
-- **Broadcast** — one message reaches every running pod via per-service durable consumers.
-- **Ordered delivery** — sequential per partition key without giving up horizontal scale.
-- **RPC** — Core for speed, JetStream for durability — same @MessagePattern either way.
-- **DLQ** — typed sink with original headers preserved after retries are exhausted.
-- **Scheduled messages, per-message TTL, health checks, graceful shutdown** — all the production levers.
-- **OpenTelemetry-compatible** — W3C `traceparent` propagated through every hop.
+- **At-least-once delivery**: every event acked after the handler resolves, with bounded retries and exponential backoff.
+- **Broadcast**: one message reaches every running pod via per-service durable consumers.
+- **Ordered delivery**: sequential per partition key, without giving up horizontal scale.
+- **RPC**: Core for speed, JetStream for durability, under the same `@MessagePattern` either way.
+- **DLQ**: typed sink that keeps the original headers once retries are exhausted.
+- **Scheduled messages, per-message TTL, health checks, graceful shutdown.**
+- **OpenTelemetry-compatible**: W3C `traceparent` propagated through every hop.
 
 ## Install
 
@@ -81,7 +81,7 @@ The full configuration surface, every pattern, and the production checklist live
 
 ## Quality
 
-The transport is covered by an extensive test suite (unit and integration) — see the [Codecov report](https://codecov.io/github/HorizonRepublic/nestjs-jetstream) above. 
+Unit and integration suites cover the transport; the [Codecov report](https://codecov.io/github/HorizonRepublic/nestjs-jetstream) tracks where they reach.
 
 Runnable demos for most supported patterns live under [`examples/`](./examples).
 

--- a/examples/04-dead-letter/app.module.ts
+++ b/examples/04-dead-letter/app.module.ts
@@ -11,7 +11,7 @@ class FailingHandler {
 
   /**
    * This handler always throws. After max_deliver attempts (3) the message
-   * is routed to the dead letter callback.
+   * is republished to the DLQ stream, and the callback is notified afterwards.
    */
   @EventPattern('invoice.generate')
   handleInvoice(@Payload() data: { invoiceId: number }): void {

--- a/examples/04-dead-letter/app.module.ts
+++ b/examples/04-dead-letter/app.module.ts
@@ -10,8 +10,8 @@ class FailingHandler {
   private readonly logger = new Logger('Handlers');
 
   /**
-   * This handler always throws - after max_deliver attempts (3),
-   * the message lands in the dead letter callback.
+   * This handler always throws. After max_deliver attempts (3) the message
+   * is routed to the dead letter callback.
    */
   @EventPattern('invoice.generate')
   handleInvoice(@Payload() data: { invoiceId: number }): void {

--- a/examples/07-publisher-only/app.module.ts
+++ b/examples/07-publisher-only/app.module.ts
@@ -26,7 +26,8 @@ class GatewayController {
 
 /**
  * Publisher-only mode: `consumer: false` skips all stream/consumer
- * infrastructure. The app only publishes - no handlers, no streams.
+ * infrastructure. The app publishes and nothing else, so it registers
+ * neither handlers nor streams.
  *
  * Typical use case: API gateway, BFF, or cron service that
  * dispatches events to downstream microservices.

--- a/examples/10-distributed-tracing/README.md
+++ b/examples/10-distributed-tracing/README.md
@@ -56,8 +56,8 @@ Sentry auto-wire OTel with `Sentry.init({ tracesSampleRate: 1.0 })` and skip
 your own `NodeSDK` setup, or opt out of Sentry's wiring (`skipOpenTelemetrySetup: true`)
 and register Sentry's span processor, context manager, and propagator manually.
 Follow the [Sentry OpenTelemetry guide](https://docs.sentry.io/platforms/javascript/guides/node/opentelemetry/)
-for the exact wiring. The library's spans flow through once the OTel
-TracerProvider Sentry registers becomes the global one.
+for the exact wiring. The library's spans flow through once Sentry's
+registered OTel TracerProvider becomes the global provider.
 
 ### Datadog
 

--- a/examples/10-distributed-tracing/README.md
+++ b/examples/10-distributed-tracing/README.md
@@ -1,4 +1,4 @@
-# Example 10 — Distributed Tracing
+# Example 10: Distributed Tracing
 
 End-to-end demonstration of the library's built-in OpenTelemetry instrumentation.
 
@@ -9,7 +9,7 @@ End-to-end demonstration of the library's built-in OpenTelemetry instrumentation
 - **CONSUMER span** for every handler invocation, parented to the upstream span via the W3C `traceparent` header.
 - **Connection lifecycle INTERNAL span** because this example opts into `JetstreamTrace.ConnectionLifecycle`.
 
-Spans are exported to the console with full attributes — start the example, hit the HTTP endpoint, watch one trace flow across all participants in your terminal.
+Spans are exported to the console with full attributes. Start the example, hit the HTTP endpoint, and watch one trace flow across all participants in your terminal.
 
 ## Prerequisites
 
@@ -30,11 +30,11 @@ curl http://localhost:3009
 
 You'll see a sequence of console-printed spans for one trace:
 
-1. `send orders.place` (CLIENT, kind=2) — the round-trip on the caller side
-2. `publish orders.place` (PRODUCER, kind=3) — the actual NATS publish
-3. `process orders.place` (CONSUMER, kind=4) — the handler on the server
-4. `publish orders.placed` (PRODUCER, kind=3) — the follow-up event
-5. `process orders.placed` (CONSUMER, kind=4) — the audit handler
+1. `send orders.place` (CLIENT, kind=2): the round-trip on the caller side
+2. `publish orders.place` (PRODUCER, kind=3): the NATS publish itself
+3. `process orders.place` (CONSUMER, kind=4): the handler on the server
+4. `publish orders.placed` (PRODUCER, kind=3): the follow-up event
+5. `process orders.placed` (CONSUMER, kind=4): the audit handler
 
 Same `traceId` on all five. `parentSpanId` chains them together.
 
@@ -56,13 +56,13 @@ Sentry auto-wire OTel with `Sentry.init({ tracesSampleRate: 1.0 })` and skip
 your own `NodeSDK` setup, or opt out of Sentry's wiring (`skipOpenTelemetrySetup: true`)
 and register Sentry's span processor, context manager, and propagator manually.
 Follow the [Sentry OpenTelemetry guide](https://docs.sentry.io/platforms/javascript/guides/node/opentelemetry/)
-for the exact wiring — the library's spans flow through once the OTel
+for the exact wiring. The library's spans flow through once the OTel
 TracerProvider Sentry registers becomes the global one.
 
 ### Datadog
 
 `dd-trace` does not bridge external OTel spans by default. Initialise it with
-`require('dd-trace').init()` **and** set `DD_TRACE_OTEL_ENABLED=true`, or register
+`require('dd-trace').init()` and set `DD_TRACE_OTEL_ENABLED=true`, or register
 `dd-trace`'s TracerProvider via `@opentelemetry/api`'s
 `trace.setGlobalTracerProvider(...)`. See the
 [Datadog OpenTelemetry interop docs](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/otel_instrumentation/nodejs/)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-Runnable examples demonstrating key features. Each is self-contained — pick the one closest to your use case and copy-paste.
+Runnable examples demonstrating key features. Each one is self-contained: pick whichever is closest to your use case and copy it.
 
 ## Prerequisites
 
@@ -30,6 +30,6 @@ npx tsx --tsconfig examples/tsconfig.json examples/03-ordered-events/main.ts
 | 05 | [health-checks](./05-health-checks) | 3004 | Health indicator, Terminus-compatible | `GET /health`, `/health/terminus` |
 | 06 | [scheduling](./06-scheduling) | 3005 | Delayed delivery via scheduleAt() (NATS >= 2.12) | `GET /schedule` |
 | 07 | [publisher-only](./07-publisher-only) | 3006 | consumer: false, API gateway pattern | `GET /place-order` |
-| 08 | [per-message-ttl](./08-per-message-ttl) | 3007 | Individual message expiration (NATS >= 2.11) | `GET /token` |
-| 09 | [handler-metadata](./09-handler-metadata) | 3008 | KV metadata registry, service discovery | — |
+| 08 | [per-message-ttl](./08-per-message-ttl) | 3007 | Per-message expiry (NATS >= 2.11) | `GET /token` |
+| 09 | [handler-metadata](./09-handler-metadata) | 3008 | KV metadata registry, service discovery | none |
 | 10 | [distributed-tracing](./10-distributed-tracing) | 3009 | Built-in OpenTelemetry spans, ConsoleSpanExporter, full trace through publish + RPC + event flow | `GET /` |

--- a/src/client/jetstream.client.ts
+++ b/src/client/jetstream.client.ts
@@ -508,7 +508,7 @@ export class JetstreamClient extends ClientProxy {
     // (where `maxReconnectAttempts: -1` keeps connect() pending forever) still
     // settles the span, the pending-message entry, and the caller's
     // subscription instead of leaking them for the life of the process.
-    // `effectiveTimeout` therefore bounds connect + RPC, not just RPC.
+    // `effectiveTimeout` bounds connect and RPC together, not RPC alone.
     this.rpcInbox.armTimeout(correlationId, effectiveTimeout, () => {
       spanHandle.finish({ kind: RpcOutcomeKind.Timeout });
       // RpcTimeout hook + OTel CLIENT span are the canonical signals; no separate log.

--- a/src/client/jetstream.record.ts
+++ b/src/client/jetstream.record.ts
@@ -129,7 +129,7 @@ export class JetstreamRecordBuilder<TData = unknown> {
    * at the specified time. Requires NATS >= 2.12 and `allow_msg_schedules: true`
    * on the event stream (via `events: { stream: { allow_msg_schedules: true } }`).
    *
-   * Only meaningful for events (`client.emit()`). If used with RPC
+   * Applies to events (`client.emit()`) only. If used with RPC
    * (`client.send()`), a warning is logged and the schedule is ignored.
    *
    * @param date - Delivery time. Must be in the future.
@@ -158,7 +158,7 @@ export class JetstreamRecordBuilder<TData = unknown> {
    * independent of the stream's `max_age`. Requires NATS >= 2.11 and
    * `allow_msg_ttl: true` on the stream.
    *
-   * Only meaningful for events (`client.emit()`). If used with RPC
+   * Applies to events (`client.emit()`) only. If used with RPC
    * (`client.send()`), a warning is logged and the TTL is ignored.
    *
    * @param nanos - TTL in nanoseconds. Use {@link toNanos} for human-readable values.

--- a/src/hooks/event-bus.ts
+++ b/src/hooks/event-bus.ts
@@ -9,7 +9,7 @@ type AnyTransportListener = (...args: unknown[]) => unknown;
 /**
  * Central event bus for transport lifecycle notifications.
  *
- * Two emission paths:
+ * Emission paths:
  *  - User hooks registered via `forRoot({ hooks })`: at most one per event.
  *  - Internal subscribers added via `subscribe()`: many per event, used by
  *    metrics and other built-in observers.

--- a/src/interfaces/options.interface.ts
+++ b/src/interfaces/options.interface.ts
@@ -111,7 +111,7 @@ export interface StreamConsumerOverrides {
    * Default: `undefined` (unlimited, naturally bounded by `max_ack_pending`).
    * Set this to protect downstream systems from overload.
    *
-   * **Important:** if `concurrency < max_ack_pending`, messages buffer in RxJS
+   * If `concurrency < max_ack_pending`, messages buffer in RxJS
    * while their NATS ack timer ticks. Increase `ack_wait` proportionally to
    * prevent unnecessary redeliveries.
    */
@@ -353,7 +353,7 @@ export interface JetstreamModuleOptions {
    * When any handler has `meta` in its `@EventPattern` / `@MessagePattern` extras,
    * the transport writes metadata to a NATS KV bucket at startup.
    * External services (API gateways, dashboards, CLI tools) can read or watch
-   * the bucket for dynamic service discovery.
+   * the bucket to discover services at runtime.
    *
    * Auto-enabled when any handler has `meta`. Set to customize bucket name,
    * replicas, or TTL.

--- a/src/metrics/metrics.constants.ts
+++ b/src/metrics/metrics.constants.ts
@@ -7,7 +7,7 @@ export const JETSTREAM_METRICS_CONFIG: unique symbol = Symbol('JETSTREAM_METRICS
 /** DI token for the resolved `prom-client` Registry. */
 export const JETSTREAM_METRICS_REGISTRY: unique symbol = Symbol('JETSTREAM_METRICS_REGISTRY');
 
-/** DI token for the dynamically loaded `prom-client` runtime classes. */
+/** DI token for the `prom-client` runtime classes, loaded on demand. */
 export const JETSTREAM_METRICS_PROM_CLIENT: unique symbol = Symbol('JETSTREAM_METRICS_PROM_CLIENT');
 
 export const DEFAULT_METRICS_PREFIX = 'jetstream_';

--- a/src/metrics/metrics.types.ts
+++ b/src/metrics/metrics.types.ts
@@ -6,7 +6,7 @@ import type { HistogramBuckets } from './metrics.config';
 /**
  * Subset of the `prom-client` runtime surface used by the factory. Injected
  * (rather than statically imported) so nothing here triggers a load until
- * `JetstreamMetricsModule` resolves the peer dependency via dynamic import.
+ * `JetstreamMetricsModule` resolves the peer dependency via `import()`.
  */
 export interface PromClientRuntime {
   Counter: typeof Counter;
@@ -45,7 +45,7 @@ export interface CreateMetricsOptions {
   buckets?: HistogramBuckets;
 }
 
-/** A consumer this service owns: stream + durable + StreamKind for labelling. */
+/** Stream, durable name and StreamKind of a consumer this service owns, used for labelling. */
 export interface ConsumerPollTarget {
   kind: StreamKind;
   stream: string;

--- a/src/otel/__tests__/attributes.spec.ts
+++ b/src/otel/__tests__/attributes.spec.ts
@@ -257,7 +257,7 @@ describe('buildExpectedErrorAttributes', () => {
   });
 
   it('should drop free-form RpcException messages to avoid high-cardinality error codes', () => {
-    // Given: free-form messages can contain PII and must not land on error.code
+    // Given: free-form messages can contain PII, so error.code must stay off them
     const err = new RpcException('User 42 is not authorised for this order');
 
     // When

--- a/src/otel/config.ts
+++ b/src/otel/config.ts
@@ -133,8 +133,8 @@ export interface CaptureBodyOptions {
  */
 export interface OtelOptions {
   /**
-   * Global kill switch. When `false`, no spans are emitted, no propagation
-   * is attempted, and no hooks fire.
+   * Global kill switch. When `false`, the transport skips span creation,
+   * context propagation and hook invocation.
    *
    * @default true
    */

--- a/src/otel/spans/consume.ts
+++ b/src/otel/spans/consume.ts
@@ -81,7 +81,7 @@ const applyUnexpectedError = (span: Span, err: unknown): void => {
  * shape: sync handlers return sync, async handlers return a Promise.
  *
  * Fast paths:
- * - `otel.enabled: false` -> run `fn` directly, no span, no context extract
+ * - `otel.enabled: false` -> run `fn` directly, leaving headers unread
  *   (full kill switch).
  * - `traces` excludes `Consume` or `shouldTraceConsume` returns false ->
  *   still extract the parent from headers and run `fn` under that context
@@ -177,7 +177,7 @@ export const withConsumeSpan = <T>(
     try {
       classification = config.errorClassifier(err);
     } catch {
-      // Fall through with 'unexpected'.
+      // Keep 'unexpected'.
     }
 
     if (classification === 'expected') {

--- a/src/otel/spans/publish.ts
+++ b/src/otel/spans/publish.ts
@@ -78,7 +78,7 @@ export interface PublishSpanContext {
  * errors (infrastructure failure, not a business outcome).
  *
  * Fast paths:
- * - `otel.enabled: false` -> run `fn` with no span, no header injection
+ * - `otel.enabled: false` -> run `fn` directly, leaving headers untouched
  * - `traces` set does not include `Publish` -> inject propagation only
  * - `shouldTracePublish` returns false -> inject propagation only
  */

--- a/src/otel/spans/rpc-client.ts
+++ b/src/otel/spans/rpc-client.ts
@@ -77,7 +77,7 @@ export interface RpcClientSpanHandle {
  * drop, publish reject) mark the span ERROR.
  *
  * Fast paths:
- * - `otel.enabled: false` -> no span, no propagation (full kill switch).
+ * - `otel.enabled: false` -> the tracer stays inert (full kill switch).
  * - `traces` excludes `RpcClientSend` -> no span, but the active context is
  *   still injected so downstream consumers keep the trace chain.
  */
@@ -125,7 +125,8 @@ export const beginRpcClientSpan = (
   const ctxWithSpan = trace.setSpan(context.active(), span);
 
   injectContext(ctxWithSpan, ctx.headers, hdrsSetter);
-  // publishHook deliberately skipped; this is a CLIENT round-trip span, not a PRODUCER span.
+  // publishHook deliberately skipped: the span covers a CLIENT round trip, where the
+  // caller waits for the reply.
   const start = Date.now();
   let finalized = false;
 

--- a/src/server/core-rpc.server.ts
+++ b/src/server/core-rpc.server.ts
@@ -25,7 +25,7 @@ import { PatternRegistry } from './routing/pattern-registry';
  * Subscribes to `{service}.cmd.>` with a queue group for load balancing.
  * Each request is processed and replied to directly via `msg.respond()`.
  *
- * This is the default RPC mode: lowest latency, no persistence overhead.
+ * The default RPC mode: lowest latency, since the request never reaches a stream.
  */
 export class CoreRpcServer {
   private readonly logger = new Logger('Jetstream:CoreRpc');

--- a/src/server/infrastructure/__tests__/infrastructure-binder.spec.ts
+++ b/src/server/infrastructure/__tests__/infrastructure-binder.spec.ts
@@ -293,7 +293,7 @@ describe(InfrastructureBinder.name, () => {
 
   describe('bindStream(); unexpected lookup errors', () => {
     it('should rethrow non-NATS errors untouched', async () => {
-      // Given: streams.info fails with an infrastructure error, not a 404
+      // Given: streams.info fails with an infrastructure error while the stream exists
       const boom = new Error('connection reset');
       const jsm = makeJsm({ streamInfo: vi.fn().mockRejectedValue(boom) });
       const sut = makeSut();
@@ -305,7 +305,7 @@ describe(InfrastructureBinder.name, () => {
 
   describe('bindConsumer(); unexpected lookup errors', () => {
     it('should rethrow non-NATS errors untouched', async () => {
-      // Given: consumers.info fails with an infrastructure error, not a 404
+      // Given: consumers.info fails with an infrastructure error while the consumer exists
       const boom = new Error('connection reset');
       const jsm = makeJsm({ consumerInfo: vi.fn().mockRejectedValue(boom) });
       const sut = makeSut();

--- a/src/server/infrastructure/__tests__/provisioning-summary.spec.ts
+++ b/src/server/infrastructure/__tests__/provisioning-summary.spec.ts
@@ -154,7 +154,7 @@ describe('formatProvisioningSummary', () => {
       // When: no third argument
       const result = formatProvisioningSummary('svc', reservations);
 
-      // Then: existing tests remain valid, no crash, no "external" text
+      // Then: the summary renders as before, with the "external" text left out
       expect(result).not.toContain('external');
     });
   });

--- a/src/server/infrastructure/__tests__/stream-migration.spec.ts
+++ b/src/server/infrastructure/__tests__/stream-migration.spec.ts
@@ -369,7 +369,7 @@ describe(StreamMigration.name, () => {
         return createMock<StreamInfo>();
       });
 
-      // When/Then: the caller sees the migration failure, not the rollback one
+      // When/Then: the migration failure reaches the caller and the rollback one stays hidden
       await expect(sut.migrate(jsm, testStreamName, newConfig)).rejects.toThrow(
         'permission denied',
       );

--- a/src/server/infrastructure/__tests__/stream.provider.spec.ts
+++ b/src/server/infrastructure/__tests__/stream.provider.spec.ts
@@ -286,7 +286,7 @@ describe(StreamProvider, () => {
       );
 
       // When/Then: recreating broadcast-stream would delete every other
-      // service's durable consumers, so fail loudly instead
+      // service's durable consumers, so throw instead
       await expect(sut.ensureStreams([StreamKind.Broadcast])).rejects.toThrow(
         /broadcast-stream.*shared|shared.*broadcast-stream/i,
       );

--- a/src/server/infrastructure/management.ts
+++ b/src/server/infrastructure/management.ts
@@ -24,7 +24,7 @@ export interface KindOptionsBlock {
   subjectPrefix?: string;
 }
 
-/** Single source of truth for navigating from a StreamKind to its options block. */
+/** Single source of truth for resolving a StreamKind to its options block. */
 export const kindOptionsBlock = (
   options: JetstreamModuleOptions,
   kind: StreamKind,

--- a/src/server/infrastructure/message.provider.ts
+++ b/src/server/infrastructure/message.provider.ts
@@ -103,7 +103,7 @@ export class MessageProvider {
    * Start an ordered consumer for strict sequential delivery.
    *
    * Unlike durable consumers, ordered consumers are ephemeral: created at
-   * consumption time, no durable state. nats.js handles auto-recreation.
+   * consumption time and forgotten afterwards. nats.js handles auto-recreation.
    *
    * @param streamName - JetStream stream to consume from.
    * @param filterSubjects - NATS subjects to filter on.
@@ -291,7 +291,7 @@ export class MessageProvider {
       for await (const status of messages.status()) {
         // Threshold: 2 consecutive missed heartbeats triggers restart.
         // One missed heartbeat can happen during normal GC pauses or brief network blips.
-        // Two consecutive misses strongly indicate a stale consumer.
+        // A second miss in a row indicates a stale consumer.
         if (status.type === 'heartbeats_missed' && status.count >= 2) {
           this.logger.warn(`Consumer ${name}: ${status.count} heartbeats missed, restarting`);
           messages.stop();

--- a/src/server/infrastructure/stream-migration.ts
+++ b/src/server/infrastructure/stream-migration.ts
@@ -214,8 +214,8 @@ export class StreamMigration {
 
   /**
    * Lag-based drain check: live publishes cannot fake completion. A fresh
-   * source reports lag 0 / active -1 before its first sync (NATS 2.12.6),
-   * hence the active guard.
+   * source reports lag 0 / active -1 before its first sync (NATS 2.12.6), so
+   * the active guard covers that window.
    */
   private async waitForSourceDrained(
     jsm: JetStreamManager,

--- a/src/server/routing/event-pipeline.ts
+++ b/src/server/routing/event-pipeline.ts
@@ -129,9 +129,9 @@ const createEventResolver = (
  * Build the routing pipeline for workqueue and broadcast streams.
  *
  * The returned function runs the full flow for one message and returns
- * `undefined` when it completed synchronously (sync handler, no awaitable
- * settlement) so the concurrency gate can skip the `.finally()` allocation
- * on the sync path.
+ * `undefined` when it completed synchronously (a sync handler that settles
+ * inline) so the concurrency gate can skip the `.finally()` allocation on the
+ * sync path.
  */
 export const createWorkqueuePipeline = (
   rctx: RoutePipelineContext,
@@ -237,9 +237,9 @@ export const createWorkqueuePipeline = (
 };
 
 /**
- * Build the routing pipeline for ordered streams: no settlement (ordered
- * consumers auto-acknowledge), no dead-letter escalation, strictly
- * sequential delivery enforced by the concurrency gate.
+ * Build the routing pipeline for ordered streams. Ordered consumers
+ * auto-acknowledge, so the pipeline skips settlement and dead-letter
+ * escalation, and the concurrency gate keeps delivery strictly sequential.
  */
 export const createOrderedPipeline = (
   rctx: RoutePipelineContext,

--- a/src/server/routing/rpc.router.ts
+++ b/src/server/routing/rpc.router.ts
@@ -317,7 +317,7 @@ export class RpcRouter {
         // Close the CONSUMER span early via the abort signal; the handler's
         // eventual resolution is ignored (span is idempotent after first finish).
         abortController.abort();
-        // RpcTimeout hook is the canonical signal here, no separate log.
+        // RpcTimeout hook is the canonical signal here and carries the report alone.
         emitRpcTimeout(subject, correlationId);
         // Bare timer callback: an unguarded term throw would be an uncaught exception.
         settleQuietly(logger, `Failed to term ${subject}:`, () => {

--- a/src/utils/ack-extension.ts
+++ b/src/utils/ack-extension.ts
@@ -130,9 +130,9 @@ class AckExtensionPool {
 const pool = new AckExtensionPool();
 
 /**
- * Register a message for ack extension. While the entry is live the pool
- * periodically calls `msg.working()` at the configured interval to keep
- * NATS from redelivering before the handler finishes.
+ * Register a message for ack extension. The pool calls `msg.working()` at the
+ * configured interval for as long as the entry lives, keeping NATS from
+ * redelivering before the handler finishes.
  *
  * @returns Cleanup function that cancels the registration, or `null` when
  *          ack extension is disabled.

--- a/test/integration/dead-letter.spec.ts
+++ b/test/integration/dead-letter.spec.ts
@@ -276,7 +276,7 @@ describe('Dead Letter Queue Hook', () => {
       // When: all delivery attempts are exhausted
       await waitForCondition(() => controller.attempts >= 2, 10_000);
 
-      // Then: the dead letter lands in the DLQ stream without any callback configured
+      // Then: the dead letter reaches the DLQ stream without any callback configured
       const jsm = await jetstreamManager(nc);
       const dlqName = dlqStreamName(serviceName);
 
@@ -332,7 +332,7 @@ describe('Dead Letter Queue Hook', () => {
       // Given: an event pattern no controller handles
       await firstValueFrom(client.emit('order.unknown', { orderId: 'orphan-1' }));
 
-      // Then: the message lands in the DLQ instead of being deleted
+      // Then: the message is stored in the DLQ instead of being deleted
       await waitForCondition(async () => (await dlqMessageCount()) === 1, 10_000);
 
       const jsm = await jetstreamManager(nc);
@@ -353,7 +353,7 @@ describe('Dead Letter Queue Hook', () => {
 
       await js.publish(subject, garbage);
 
-      // Then: the message lands in the DLQ with the original bytes intact
+      // Then: the message is stored in the DLQ with the original bytes intact
       await waitForCondition(async () => (await dlqMessageCount()) === 1, 10_000);
 
       const jsm = await jetstreamManager(nc);

--- a/test/integration/external-infrastructure.spec.ts
+++ b/test/integration/external-infrastructure.spec.ts
@@ -622,7 +622,7 @@ describe('External Infrastructure (bind-only mode)', () => {
       // When: all delivery attempts are exhausted (max_deliver=2, ack_wait=2s)
       await waitForCondition(() => controller.attempts >= 2, 15_000);
 
-      // Then: the dead letter lands in the external DLQ stream
+      // Then: the dead letter reaches the external DLQ stream
       await waitForCondition(async () => {
         const info = await jsm.streams.info(dlqStreamName);
 

--- a/test/integration/nats-container.ts
+++ b/test/integration/nats-container.ts
@@ -80,7 +80,7 @@ export const startNatsContainer = async (): Promise<NatsContainerResult> => {
   return { container, port };
 };
 
-/** For restart tests: dynamic ports may be reassigned on restart, fixed bindings survive. */
+/** For restart tests: a randomly assigned port may change on restart, a fixed binding survives. */
 export const startNatsContainerWithFixedPort = async (
   hostPort: number,
 ): Promise<NatsContainerResult> => {

--- a/test/integration/ordered-events.spec.ts
+++ b/test/integration/ordered-events.spec.ts
@@ -415,7 +415,7 @@ describe('Ordered Event Delivery', () => {
       const startMs = (await lastServerTimeMs()) + 2;
       const startTime = new Date(startMs).toISOString();
 
-      // Publish 'after' until its server timestamp lands past startTime
+      // Publish 'after' until its server timestamp passes startTime
       let afterMs = 0;
 
       for (let attempt = 0; attempt < 10 && afterMs < startMs; attempt += 1) {

--- a/test/integration/otel-publish-consume.spec.ts
+++ b/test/integration/otel-publish-consume.spec.ts
@@ -158,7 +158,7 @@ describe('OTel publish + consume integration', () => {
       await waitForCondition(() => controller.received.length === 1, 5_000);
       await provider.forceFlush();
 
-      // Then: only the two functional spans, no provisioning/connection/etc.
+      // Then: the two functional spans are the only ones recorded
       const spans = exporter.getFinishedSpans();
       const kinds = new Set(spans.map((s) => s.kind));
 

--- a/test/integration/otel-retry-dead-letter.spec.ts
+++ b/test/integration/otel-retry-dead-letter.spec.ts
@@ -156,7 +156,7 @@ describe('OTel retry + dead letter integration', () => {
       const last = consumeSpans[consumeSpans.length - 1]!;
 
       expect(last.status.code).toBe(SpanStatusCode.OK);
-      // The first two attempts threw bare Error, classified unexpected, hence ERROR.
+      // The first two attempts threw bare Error, classified unexpected, so ERROR.
       expect(consumeSpans[0]!.status.code).toBe(SpanStatusCode.ERROR);
       expect(consumeSpans[1]!.status.code).toBe(SpanStatusCode.ERROR);
     }, 20_000);

--- a/test/integration/provisioning.spec.ts
+++ b/test/integration/provisioning.spec.ts
@@ -31,7 +31,7 @@ describe('Provisioning error clarity', () => {
     // Given: a service whose default streams exceed max_file_store
     const serviceName = uniqueServiceName();
 
-    // When / Then: app boot fails with the wrapped, actionable error
+    // When / Then: app boot fails with the wrapped error that names the fix
     let captured: unknown;
 
     try {

--- a/website/docs/development/contributing.md
+++ b/website/docs/development/contributing.md
@@ -6,7 +6,7 @@ schema:
   headline: "Contributing"
   description: "How to contribute to the project."
   datePublished: "2026-03-21"
-  dateModified: "2026-04-11"
+  dateModified: "2026-07-26"
 ---
 
 # Contributing

--- a/website/docs/development/contributing.md
+++ b/website/docs/development/contributing.md
@@ -11,7 +11,7 @@ schema:
 
 # Contributing
 
-We welcome contributions from the community. The full contribution guidelines live in the [`CONTRIBUTING.md`](https://github.com/HorizonRepublic/nestjs-jetstream/blob/main/CONTRIBUTING.md) file at the repository root. This page provides a quick overview.
+We welcome contributions from the community. The full contribution guidelines live in the [`CONTRIBUTING.md`](https://github.com/HorizonRepublic/nestjs-jetstream/blob/main/CONTRIBUTING.md) file at the repository root.
 
 ## Quick Start
 
@@ -88,7 +88,7 @@ docs: update module configuration examples
 ```
 
 :::tip
-Use a scope in parentheses (e.g., `feat(client):`, `fix(strategy):`) to indicate the area of the codebase affected. This shows up in the generated changelog.
+Use a scope in parentheses (e.g., `feat(client):`, `fix(strategy):`) to show the area of the codebase affected. This shows up in the generated changelog.
 :::
 
 ## Pull Request Guidelines
@@ -96,7 +96,7 @@ Use a scope in parentheses (e.g., `feat(client):`, `fix(strategy):`) to indicate
 - Ensure the build passes (`pnpm build`)
 - All linting checks must pass (`pnpm lint`)
 - All existing tests must pass, and new code should include tests
-- Use clear, descriptive PR titles — they become changelog entries via Release Please
+- Use clear, descriptive PR titles: they become changelog entries via Release Please
 - Keep PRs focused on a single concern
 
 ## Coding Standards

--- a/website/docs/development/testing.md
+++ b/website/docs/development/testing.md
@@ -15,16 +15,16 @@ The project uses [Vitest](https://vitest.dev/) v4 with a dual-project configurat
 
 ## Philosophy
 
-This library handles real-time message delivery, consumer lifecycle, and self-healing reconnection — things that are notoriously hard to test with mocks alone. Our testing strategy reflects that:
+This library handles real-time message delivery, consumer lifecycle, and self-healing reconnection, things that are notoriously hard to test with mocks alone. Our testing strategy reflects that:
 
-- **Integration tests are first-class citizens.** Every message flow (events, RPC, broadcast, ordered) is tested against a real NATS server. No hand-waved "it works in production" — if it's not tested end-to-end, it's not done.
-- **Each test suite gets its own NATS container.** No shared state between suites. No "run tests in order". Suites execute in parallel — because if your tests can't run in parallel, your architecture has a problem.
+- **Integration tests are first-class citizens.** Every message flow (events, RPC, broadcast, ordered) is tested against a real NATS server. No hand-waved "it works in production": if it's not tested end-to-end, it's not done.
+- **Each test suite gets its own NATS container.** No shared state between suites. No "run tests in order". Suites execute in parallel: because if your tests can't run in parallel, your architecture has a problem.
 - **Self-healing is proven, not assumed.** We delete consumers via the JetStream Management API and verify the transport recovers. The self-healing flow is tested with real NATS, not mocked RxJS streams.
-- **Unit tests fill the gaps.** Infrastructure error paths (defensive throws, catch blocks, exponential backoff) that can't be triggered through integration get targeted unit tests. Coverage is a tool, not a target — but we track it to make sure we're not lying to ourselves.
+- **Unit tests fill the gaps.** Infrastructure error paths (defensive throws, catch blocks, exponential backoff) that can't be triggered through integration get targeted unit tests. Coverage is a tool, not a target: but we track it to make sure we're not lying to ourselves.
 
 ## Prerequisites
 
-- **Docker** — Testcontainers starts NATS containers automatically. No manual `docker compose up` needed for tests.
+- **Docker**: Testcontainers starts NATS containers automatically. No manual `docker compose up` needed for tests.
 - **Node.js >= 20** and **pnpm**
 
 ## Test Commands
@@ -54,7 +54,7 @@ Unit tests mock all external dependencies and test individual classes/functions 
 
 - **Location:** `test/**/*.spec.ts`
 - **Timeout:** 30 seconds per test (60s for self-healing scenarios)
-- **Parallelism:** Enabled — each suite starts its own NATS container
+- **Parallelism:** Enabled: each suite starts its own NATS container
 - **Container image:** `nats:2.12.6` with JetStream and persistent store
 
 Integration tests verify end-to-end behavior: stream/consumer provisioning, message delivery, RPC round-trips, broadcast fan-out, ordered delivery, dead-letter handling, graceful shutdown, and self-healing recovery.
@@ -114,7 +114,7 @@ The self-healing suite proves that the transport recovers from consumer failures
 4. Verify the self-healing flow (catchError → exponential backoff → retry) picks up the re-created consumer
 5. Deliver another event, confirm receipt
 
-The test uses a 1-second heartbeat interval (vs 5s production default) for faster failure detection. No `sleep(12s)` hacks — consumer deletion triggers the error path immediately.
+The test uses a 1-second heartbeat interval (vs 5s production default) for faster failure detection. No `sleep(12s)` hacks, consumer deletion triggers the error path immediately.
 
 ## Test Conventions
 
@@ -176,9 +176,9 @@ it('should create event stream when it does not exist', async () => {
 
 Tests within a `describe` block follow this order:
 
-1. **Happy path** — the expected successful behavior
-2. **Edge cases** — boundary conditions and unusual inputs
-3. **Error cases** — failure modes and error handling
+1. **Happy path**: the expected successful behavior
+2. **Edge cases**: boundary conditions and unusual inputs
+3. **Error cases**: failure modes and error handling
 
 ### Mock Reset
 
@@ -218,9 +218,9 @@ Run `pnpm test:cov` and open `coverage/index.html` for the HTML report.
 1. Create `test/integration/my-feature.spec.ts`
 2. Follow the container lifecycle pattern (see [How It Works](#how-it-works))
 3. Use `uniqueServiceName()` per test to avoid collisions
-4. Clean up streams in `afterEach` — even though each suite gets its own NATS, cleanup prevents intra-suite leaks
+4. Clean up streams in `afterEach`: even though each suite gets its own NATS, cleanup prevents intra-suite leaks
 5. Use `try/finally` in `afterAll` so `container.stop()` always runs even if `nc.drain()` fails
-6. Run `pnpm test` — your suite will execute in parallel with others
+6. Run `pnpm test`: your suite will execute in parallel with others
 
 ## Vitest Configuration
 

--- a/website/docs/development/testing.md
+++ b/website/docs/development/testing.md
@@ -6,7 +6,7 @@ schema:
   headline: Testing
   description: "Running unit and integration tests with Vitest and Testcontainers."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Testing

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -8,7 +8,7 @@ schema:
   headline: "Quick Start"
   description: "Complete working example in four steps: register the module, connect the transport, define handlers, and send messages."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Quick Start

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 sidebar_label: "Quick Start"
 title: Quick Start
-description: Complete working example in four steps — register, connect, handle, and send.
+description: "Complete working example in four steps: register, connect, handle, and send."
 schema:
   type: Article
   headline: "Quick Start"
@@ -13,7 +13,7 @@ schema:
 
 # Quick Start
 
-Five minutes from now you'll have a NestJS service that emits `order.created`, survives a restart without losing the message, and responds to `order.get` RPCs — all over NATS JetStream. Four steps: register the module, connect the transport, define handlers, send messages.
+Five minutes from now you'll have a NestJS service that emits `order.created`, survives a restart without losing the message, and responds to `order.get` RPCs, all over NATS JetStream. Four steps: register the module, connect the transport, define handlers, send messages.
 
 :::info Prerequisites
 Make sure you have [installed the library](/docs/getting-started/installation) and have a NATS server running with JetStream enabled.
@@ -34,7 +34,7 @@ import { GatewayController } from './gateway.controller';
 
 @Module({
   imports: [
-    // Global setup — creates NATS connection, streams, consumers
+    // Global setup, creates NATS connection, streams, consumers
     JetstreamModule.forRoot({
       name: 'orders',
       servers: ['nats://localhost:4222'],
@@ -72,7 +72,7 @@ const bootstrap = async () => {
 
   // Required so the JetStream transport drains in-flight handlers on SIGTERM.
   // Skip this and messages in flight when the pod dies will be redelivered
-  // only after `ack_wait` expires — slower recovery, noisier metrics.
+  // only after `ack_wait` expires, slower recovery, noisier metrics.
   app.enableShutdownHooks();
 
   await app.startAllMicroservices();
@@ -83,7 +83,7 @@ void bootstrap();
 ```
 
 :::warning Don't instantiate the strategy manually
-Unlike other NestJS transports, you must **not** create the strategy with `new JetstreamStrategy()`. The module creates it through DI with all required dependencies. Always use `app.get(JetstreamStrategy)` to retrieve it.
+Unlike other NestJS transports, you must not create the strategy with `new JetstreamStrategy()`. The module creates it through DI with all required dependencies. Always use `app.get(JetstreamStrategy)` to retrieve it.
 :::
 
 ## 3. Define handlers
@@ -107,7 +107,7 @@ export class OrdersController {
   @EventPattern('order.created')
   handleOrderCreated(@Payload() data: { orderId: number; total: number }): void {
     this.logger.log(`Processing order ${data.orderId}, total: $${data.total}`);
-    // If this throws, the message is nak'd and redelivered (up to max_deliver — default 3)
+    // If this throws, the message is nak'd and redelivered (up to max_deliver, default 3)
   }
 
   /**
@@ -134,7 +134,7 @@ export class OrdersController {
 }
 ```
 
-The decorators above cover the three handler shapes you'll meet first — workqueue events (one instance handles each message), broadcast events (all instances handle every message), and RPC commands (request/reply). Strict-order delivery uses `@EventPattern('...', { ordered: true })`. For the full picture of each, see [Events](/docs/patterns/events), [Broadcast](/docs/patterns/broadcast), [Ordered Events](/docs/patterns/ordered-events), and [RPC](/docs/patterns/rpc).
+The decorators above cover the three handler shapes you'll meet first, workqueue events (one instance handles each message), broadcast events (all instances handle every message), and RPC commands (request/reply). Strict-order delivery uses `@EventPattern('...', { ordered: true })`. For the full picture of each, see [Events](/docs/patterns/events), [Broadcast](/docs/patterns/broadcast), [Ordered Events](/docs/patterns/ordered-events), and [RPC](/docs/patterns/rpc).
 
 ## 4. Send messages
 
@@ -177,7 +177,7 @@ export class GatewayController {
 Use `client.emit()` for fire-and-forget events; at-least-once delivery through JetStream, no response. Use `client.send()` for request/reply RPC; it returns an `Observable<TResponse>` with the handler's reply.
 
 :::info Broadcast prefix
-To send a broadcast event, prefix the pattern with `broadcast:` when calling `emit()`. On the handler side, use `{ broadcast: true }` in the decorator extras — no prefix needed.
+To send a broadcast event, prefix the pattern with `broadcast:` when calling `emit()`. On the handler side, use `{ broadcast: true }` in the decorator extras: no prefix needed.
 :::
 
 ## Test it
@@ -200,7 +200,7 @@ curl http://localhost:3000/orders/42
 
 ## What's next?
 
-- [**Module Configuration**](/docs/reference/module-configuration) — learn about all configuration options, async setup, and advanced connection settings
-- [**RPC Patterns**](/docs/patterns/rpc) — deep dive into Core vs JetStream RPC modes
-- [**Events & Broadcast**](/docs/patterns/events) — workqueue events, broadcast fan-out, and ordered events
-- [**Record Builder & Deduplication**](/docs/guides/record-builder) — custom headers, deterministic message IDs, per-request RPC timeouts, and deduplication
+- [**Module Configuration**](/docs/reference/module-configuration): learn about all configuration options, async setup, and advanced connection settings
+- [**RPC Patterns**](/docs/patterns/rpc): deep dive into Core vs JetStream RPC modes
+- [**Events & Broadcast**](/docs/patterns/events): workqueue events, broadcast fan-out, and ordered events
+- [**Record Builder & Deduplication**](/docs/guides/record-builder): custom headers, deterministic message IDs, per-request RPC timeouts, and deduplication

--- a/website/docs/getting-started/why-jetstream.md
+++ b/website/docs/getting-started/why-jetstream.md
@@ -13,71 +13,71 @@ schema:
 
 # Why JetStream?
 
-The goal of this page isn't to replace the [built-in NestJS NATS transport](https://docs.nestjs.com/microservices/nats) — it's to help you recognize the moment when your system outgrows Core NATS and needs a persistence layer underneath.
+The goal of this page isn't to replace the [built-in NestJS NATS transport](https://docs.nestjs.com/microservices/nats): it's to help you recognize the moment when your system outgrows Core NATS and needs a persistence layer underneath.
 
 Most production systems hit that moment eventually. The sections below walk through when the built-in transport is enough, the concrete scenarios where it silently loses data, and what this library adds on top.
 
 ## When the built-in NATS transport is enough
 
-The official `@nestjs/microservices` NATS transport is built on Core NATS — a fast, fire-and-forget pub/sub layer. It's a solid choice when:
+The official `@nestjs/microservices` NATS transport is built on Core NATS, a fast, fire-and-forget pub/sub layer. It's a solid choice when:
 
 - **All your services run in the same cluster** and restart rarely.
 - **Messages are idempotent hints**, not commands that must be executed exactly once. Cache invalidations, notification fan-out, metric updates.
-- **Losing a message is acceptable** — retrying later or recomputing state is cheap.
-- **You don't need replay** — new consumers don't care about historical messages.
-- **Latency matters more than durability** — you want the lowest possible round-trip time and are willing to trade reliability for speed.
+- **Losing a message is acceptable**: retrying later or recomputing state is cheap.
+- **You don't need replay**: new consumers don't care about historical messages.
+- **Latency matters more than durability**: you want the lowest possible round-trip time and are willing to trade reliability for speed.
 
-If this describes your workload, stop here. Use the built-in transport. Adding persistence has real costs: disk I/O, stream provisioning, consumer state to manage.
+If this describes your workload, stop here. Use the built-in transport. Adding persistence costs you disk I/O, stream provisioning, consumer state to manage.
 
 ## When you outgrow Core NATS
 
 Most production systems eventually hit a scenario where Core NATS silently loses data. These are the moments that motivate a switch.
 
-### Scenario 1 — Deploy kills in-flight messages
+### Scenario 1: Deploy kills in-flight messages
 
-You roll out a new version. Kubernetes sends `SIGTERM` to the old pod while it's processing 40 messages. With Core NATS, those 40 messages are gone — the publisher already got its "delivered" ack, but no handler finished them. Nobody notices until a customer opens a ticket.
+You roll out a new version. Kubernetes sends `SIGTERM` to the old pod while it's processing 40 messages. With Core NATS, those 40 messages are gone: the publisher already got its "delivered" ack, but no handler finished them. Nobody notices until a customer opens a ticket.
 
 With JetStream, messages stay in the stream until a handler **explicitly acks** them. When the pod dies, the messages go back to pending and the next pod picks them up. Zero loss, no code changes in your publishers.
 
-This library enforces this guarantee automatically — handlers ack on successful return, nak on thrown errors, and the module drains in-flight work before the NATS connection closes. One caveat: make sure to call `app.enableShutdownHooks()` in your bootstrap so NestJS triggers the shutdown lifecycle. See [Graceful Shutdown](../guides/graceful-shutdown) for the full flow.
+This library enforces this guarantee automatically, handlers ack on successful return, nak on thrown errors, and the module drains in-flight work before the NATS connection closes. One caveat: make sure to call `app.enableShutdownHooks()` in your bootstrap so NestJS triggers the shutdown lifecycle. See [Graceful Shutdown](../guides/graceful-shutdown) for the full flow.
 
-### Scenario 2 — Downstream service is down for 3 minutes
+### Scenario 2: Downstream service is down for 3 minutes
 
-Your payment service restarts. During the window, 200 "order placed" events try to reach it. Core NATS delivers them into the void — no subscriber, no problem, messages vanish.
+Your payment service restarts. During the window, 200 "order placed" events try to reach it. Core NATS delivers them into the void: no subscriber, no problem, messages vanish.
 
 With JetStream, those 200 events sit in the stream. When the payment service comes back up, it processes them in order, from where it left off. No outbox pattern, no retry queue, no custom replay logic.
 
-### Scenario 3 — A handler keeps failing
+### Scenario 3: A handler keeps failing
 
 A bug in your email sender throws on a specific payload. With Core NATS, the message is lost on the first throw. With raw JetStream, the message redelivers forever, blocking the queue.
 
 The library caps retries (`max_deliver`, default 3), and on the final failure it persists the dead message to a dedicated DLQ stream with tracking headers so you can investigate or replay later. No message is silently discarded. See [Dead Letter Queue](../guides/dead-letter-queue) for the full flow, including the optional callback hook.
 
-### Scenario 4 — A new service needs historical data
+### Scenario 4: A new service needs historical data
 
-You ship a new analytics service that needs the last 7 days of orders. With Core NATS, you write a custom backfill job that queries the database and replays events. With JetStream, you create a new consumer on the existing stream with a `deliver_policy` of "by start time" — and the stream feeds your new consumer the entire history automatically.
+You ship a new analytics service that needs the last 7 days of orders. With Core NATS, you write a custom backfill job that queries the database and replays events. With JetStream, you create a new consumer on the existing stream with a `deliver_policy` of "by start time", and the stream feeds your new consumer the entire history automatically.
 
-### Scenario 5 — Every instance must see every message
+### Scenario 5: Every instance must see every message
 
-You run three replicas of a cache service and each one needs to invalidate its local cache on every config change. Core NATS pub/sub actually handles this well. But when you add "the new replica that just spun up needs the last change it missed during startup" — Core NATS has no answer.
+You run three replicas of a cache service and each one needs to invalidate its local cache on every config change. Core NATS pub/sub actually handles this well. But when you add "the new replica that just spun up needs the last change it missed during startup", Core NATS has no answer.
 
-This library provides a dedicated [Broadcast](../patterns/broadcast) pattern: per-service durable consumers over a shared stream, so every replica catches up on missed broadcasts automatically after startup.
+The library ships a dedicated [Broadcast](../patterns/broadcast) pattern: per-service durable consumers over a shared stream, so every replica catches up on missed broadcasts automatically after startup.
 
 ## What this library adds on top of raw JetStream
 
-JetStream itself is a protocol. Using it from Node.js directly with the `@nats-io/*` client packages works, but you'd rebuild a lot of infrastructure before you could focus on business logic. Here is what the library provides out of the box — each bullet is a link to the dedicated page:
+JetStream itself is a protocol. Using it from Node.js directly with the `@nats-io/*` client packages works, but you'd rebuild a lot of infrastructure before you could focus on business logic. Here is what the library provides out of the box: each bullet is a link to the dedicated page:
 
 **Delivery patterns**
-- [Workqueue events](../patterns/events) — at-least-once delivery with one handler instance per message
-- [Broadcast events](../patterns/broadcast) — fan-out to every subscribing service
-- [Ordered events](../patterns/ordered-events) — strict sequential delivery with ephemeral consumers
-- [RPC (Core or JetStream mode)](../patterns/rpc) — synchronous request/reply with configurable persistence
+- [Workqueue events](../patterns/events): at-least-once delivery with one handler instance per message
+- [Broadcast events](../patterns/broadcast): fan-out to every subscribing service
+- [Ordered events](../patterns/ordered-events): strict sequential delivery with ephemeral consumers
+- [RPC (Core or JetStream mode)](../patterns/rpc): synchronous request/reply with configurable persistence
 
 **Message durability & recovery**
 - [Dead Letter Queue stream](../guides/dead-letter-queue) for messages that fail every retry
-- [Stream migration](../guides/stream-migration) — safely change locked stream settings (like storage type) without losing messages
+- [Stream migration](../guides/stream-migration): safely change locked stream settings (like storage type) without losing messages
 - [Self-healing consumers](../reference/edge-cases#consumer-self-healing) that recover automatically from broker restarts and external deletions
-- [Graceful shutdown](../guides/graceful-shutdown) — in-flight messages finish before the connection closes
+- [Graceful shutdown](../guides/graceful-shutdown): in-flight messages finish before the connection closes
 
 **Publisher features**
 - [Per-message TTL](../guides/per-message-ttl) for individual message expiration
@@ -91,11 +91,11 @@ JetStream itself is a protocol. Using it from Node.js directly with the `@nats-i
 - [Handler metadata registry](../patterns/handler-metadata) backed by NATS KV for cross-service discovery
 - Handlers that run longer than `ack_wait` stay alive automatically via [ack extension](../guides/performance#ack-extension)
 
-All of this is wrapped behind the same NestJS decorators you already use (`@EventPattern`, `@MessagePattern`, `ClientProxy`), so moving from the built-in transport to JetStream is mostly a configuration change, not a rewrite.
+All of this is wrapped behind the same NestJS decorators you already use (`@EventPattern`, `@MessagePattern`, `ClientProxy`), so moving from the built-in transport to JetStream is a configuration change rather than a rewrite.
 
 ## When HTTP is the wrong question
 
-Teams sometimes ask "should I use HTTP or NATS for service-to-service calls?". It's the wrong framing — the two protocols optimize for different things.
+Teams sometimes ask "should I use HTTP or NATS for service-to-service calls?". It's the wrong framing: the two protocols optimize for different things.
 
 - **HTTP** is great at request/response with well-defined endpoints, easy debugging, and mature tooling. But it couples caller and callee in time: if the callee is down, the call fails. Retries, circuit breakers, and timeouts become your problem.
 - **NATS (Core)** is great at low-latency RPC between in-cluster services: multiplexed connections, no connection pooling, minimal per-call overhead.
@@ -105,14 +105,14 @@ In practice, most production systems use all three. HTTP at the edge (ingress fr
 
 ## The NestJS + NATS ecosystem
 
-You have several options when connecting NestJS to NATS. Each project has its own focus, and the right choice depends on your workload. Listed in order of longevity in the ecosystem:
+You have four options when connecting NestJS to NATS. Each project has its own focus, and the right choice depends on your workload. Listed in order of longevity in the ecosystem:
 
-- **[`@nestjs/microservices`](https://docs.nestjs.com/microservices/nats) (built-in NATS transport)** — the official, lean Core NATS integration maintained by the NestJS core team. A solid default for low-latency in-cluster RPC and fire-and-forget pub/sub.
-- **[`@nestjs-plugins/nestjs-nats-jetstream-transport`](https://www.npmjs.com/package/@nestjs-plugins/nestjs-nats-jetstream-transport)** — a community-maintained JetStream transport for NestJS microservices.
-- **[`@mirasys/nestjs-jetstream-transporter`](https://www.npmjs.com/package/@mirasys/nestjs-jetstream-transporter)** — a custom JetStream transporter for NestJS.
-- **`@horizon-republic/nestjs-jetstream`** *(this library)* — a JetStream transport with a focus on production readiness: built-in DLQ, health indicators, and broadcast delivery.
+- **[`@nestjs/microservices`](https://docs.nestjs.com/microservices/nats) (built-in NATS transport)**: the official, lean Core NATS integration maintained by the NestJS core team. A solid default for low-latency in-cluster RPC and fire-and-forget pub/sub.
+- **[`@nestjs-plugins/nestjs-nats-jetstream-transport`](https://www.npmjs.com/package/@nestjs-plugins/nestjs-nats-jetstream-transport)**: a community-maintained JetStream transport for NestJS microservices.
+- **[`@mirasys/nestjs-jetstream-transporter`](https://www.npmjs.com/package/@mirasys/nestjs-jetstream-transporter)**: a custom JetStream transporter for NestJS.
+- **`@horizon-republic/nestjs-jetstream`** *(this library)*: a JetStream transport with a focus on production readiness: built-in DLQ, health indicators, and broadcast delivery.
 
-All of these projects are active parts of the NATS + NestJS ecosystem and we encourage you to compare them against your own requirements. If your workload fits one of the other options better, use it — what matters is that the community keeps growing.
+All of these projects are active parts of the NATS + NestJS ecosystem and we encourage you to compare them against your own requirements. If your workload fits one of the other options better, use it, what matters is that the community keeps growing.
 
 ## When NOT to use this library
 
@@ -125,7 +125,7 @@ Being honest about trade-offs matters. Don't use this library if:
 
 ## Next steps
 
-- Install the package and connect to a local NATS broker — [Installation](./installation)
-- Run the full four-step example in under five minutes — [Quick Start](./quick-start)
-- Explore the patterns you'll use daily — [Events](../patterns/events), [RPC](../patterns/rpc)
-- Skim the production checklist — [Module Configuration](/docs/reference/module-configuration), [DLQ](/docs/guides/dead-letter-queue), [Health Checks](/docs/guides/health-checks), [Graceful Shutdown](/docs/guides/graceful-shutdown)
+- Install the package and connect to a local NATS broker: [Installation](./installation)
+- Run the full four-step example in under five minutes: [Quick Start](./quick-start)
+- Explore the patterns you'll use daily: [Events](../patterns/events), [RPC](../patterns/rpc)
+- Skim the production checklist: [Module Configuration](/docs/reference/module-configuration), [DLQ](/docs/guides/dead-letter-queue), [Health Checks](/docs/guides/health-checks), [Graceful Shutdown](/docs/guides/graceful-shutdown)

--- a/website/docs/getting-started/why-jetstream.md
+++ b/website/docs/getting-started/why-jetstream.md
@@ -8,7 +8,7 @@ schema:
   headline: "Why JetStream? NestJS NATS Transport Comparison"
   description: "When the built-in NestJS NATS transport is enough, and when your system outgrows Core NATS and needs JetStream for durable messaging."
   datePublished: "2026-04-11"
-  dateModified: "2026-04-11"
+  dateModified: "2026-07-26"
 ---
 
 # Why JetStream?

--- a/website/docs/guides/custom-codec.md
+++ b/website/docs/guides/custom-codec.md
@@ -8,7 +8,7 @@ schema:
   headline: "How to use a custom codec with NestJS JetStream"
   description: "Replace JSON with MessagePack, Protobuf, or a custom binary codec for NATS message serialization."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # How to use a custom codec

--- a/website/docs/guides/custom-codec.md
+++ b/website/docs/guides/custom-codec.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 sidebar_label: "Custom Codec"
-title: "How to use a custom codec — NestJS JetStream"
+title: "How to use a custom codec: NestJS JetStream"
 description: "Replace the default JSON codec with the built-in MessagePack codec, Protobuf, or any custom binary format for NATS message serialization."
 schema:
   type: Article
@@ -29,7 +29,7 @@ interface Codec {
 }
 ```
 
-Both methods work with `Uint8Array` — the binary format that NATS uses on the wire.
+Both methods work with `Uint8Array`: the binary format that NATS uses on the wire.
 
 ## Default: JsonCodec
 
@@ -43,11 +43,11 @@ const bytes = codec.encode({ hello: 'world' });   // Uint8Array
 const data = codec.decode(bytes);                  // { hello: 'world' }
 ```
 
-Rule of thumb: stick with JSON until serialization shows up in CPU profiles or your p95 payload exceeds ~1-2 KB on the wire. Below that size, `JsonCodec` wins on constant per-call overhead. Above it, a binary codec like MessagePack starts paying for itself — and the gap widens dramatically as payloads grow.
+Rule of thumb: stick with JSON until serialization shows up in CPU profiles or your p95 payload exceeds ~1-2 KB on the wire. Below that size, `JsonCodec` wins on constant per-call overhead. Above it, a binary codec like MessagePack starts paying for itself, and the gap widens dramatically as payloads grow.
 
 ## Built-in: MsgpackCodec
 
-The library ships a ready-to-use [MessagePack](https://msgpack.org/) codec powered by [`msgpackr`](https://www.npmjs.com/package/msgpackr). MessagePack produces a smaller wire frame than JSON and decodes much faster on structured payloads, while staying cross-language — Python, Go, Java, Rust, and other runtimes all have MessagePack libraries.
+The library ships a ready-to-use [MessagePack](https://msgpack.org/) codec powered by [`msgpackr`](https://www.npmjs.com/package/msgpackr). MessagePack produces a smaller wire frame than JSON and decodes much faster on structured payloads, while staying cross-language, Python, Go, Java, Rust, and other runtimes all have MessagePack libraries.
 
 ### When to use it
 
@@ -60,7 +60,7 @@ The library ships a ready-to-use [MessagePack](https://msgpack.org/) codec power
 
 Stick with `JsonCodec` when:
 
-- Payloads are mostly small (`< 1 KB`) flat objects — JSON is faster there
+- Payloads are small (`< 1 KB`) flat objects: JSON is faster there
 - You need a JSON-compatible wire format for tooling (`nats sub`, log aggregators parsing payloads, etc.)
 - A non-Node language in your fleet does not have a maintained MessagePack library
 
@@ -70,7 +70,7 @@ Measured on the library's own codec bench, sync `decode` throughput. Payload buc
 
 | Payload         | Shape          | vs JSON  |
 |-----------------|----------------|----------|
-| tiny (~64 B)    | flat / nested  | JSON wins by 15-34% |
+| ~64 B           | flat / nested  | JSON wins by 15-34% |
 | small (~1 KB)   | flat / nested  | JSON wins by ~12%   |
 | small (~1 KB)   | string-heavy   | **msgpack +18%**    |
 | medium (~10 KB) | flat           | **msgpack +193%**   |
@@ -78,11 +78,11 @@ Measured on the library's own codec bench, sync `decode` throughput. Payload buc
 | medium (~10 KB) | string-heavy   | **msgpack +264%**   |
 | large (~100 KB) | flat           | **msgpack +478%**   |
 | large (~100 KB) | string-heavy   | **msgpack +490%**   |
-| huge (~1 MB)    | string-heavy   | **msgpack +325%**   |
+| ~1 MB           | string-heavy   | **msgpack +325%**   |
 
 ### Installation
 
-`msgpackr` is an **optional** peer dependency — install it only if you opt into this codec:
+`msgpackr` is an **optional** peer dependency, install it only if you opt into this codec:
 
 ```bash
 npm install msgpackr
@@ -130,7 +130,7 @@ For strongly-typed schemas and cross-language compatibility, Protocol Buffers ar
 import type { Codec } from '@horizon-republic/nestjs-jetstream';
 
 /**
- * Conceptual example — adapt to your Protobuf library
+ * Conceptual example, adapt to your Protobuf library
  * (protobufjs, ts-proto, google-protobuf, etc.)
  */
 export class ProtobufCodec implements Codec {
@@ -212,7 +212,7 @@ When omitted, `forFeature()` inherits the global codec from `forRoot()`.
 ## Codec consistency rule
 
 :::danger All communicating services must use the same codec
-The codec determines the wire format. If the publisher encodes with MsgPack but the consumer expects JSON, deserialization will fail. Ensure every service that publishes to or consumes from a given stream uses the same codec.
+The codec determines the wire format. If the publisher encodes with MsgPack but the consumer expects JSON, deserialization will fail. Ensure every service that publishes to or consumes from one stream uses the same codec.
 
 This applies across service boundaries: if `orders-service` publishes events that `notifications-service` consumes, both must use the same codec.
 :::
@@ -221,7 +221,7 @@ This applies across service boundaries: if `orders-service` publishes events tha
 
 When `codec.decode()` throws (e.g., a MsgPack consumer receives a JSON-encoded message), the transport handles it safely:
 
-- **Workqueue and RPC messages**: the message is **terminated** (`msg.term()`) — it will not be redelivered. Retrying a message that cannot be decoded would cause an infinite failure loop.
+- **Workqueue and RPC messages**: the message is **terminated** (`msg.term()`): it will not be redelivered. Retrying a message that cannot be decoded would cause an infinite failure loop.
 - **Ordered events**: the message is **skipped** (logged and dropped) since ordered consumers do not support `term()`.
 
 In both cases, the error is logged with the full subject and error details.
@@ -237,6 +237,6 @@ To switch codecs without downtime, deploy consumers that can handle both formats
 
 ## Next steps
 
-- [Record Builder & Deduplication](./record-builder.md) — attach headers and dedup IDs to outbound messages
-- [Handler Context](./handler-context.md) — access decoded payloads and metadata in handlers
-- [Module Configuration](/docs/reference/module-configuration) — full reference for `forRoot()` and `forFeature()` options
+- [Record Builder & Deduplication](./record-builder.md): attach headers and dedup IDs to outbound messages
+- [Handler Context](./handler-context.md): access decoded payloads and metadata in handlers
+- [Module Configuration](/docs/reference/module-configuration): full reference for `forRoot()` and `forFeature()` options

--- a/website/docs/guides/dead-letter-queue.md
+++ b/website/docs/guides/dead-letter-queue.md
@@ -1,8 +1,8 @@
 ---
 sidebar_position: 2
 sidebar_label: "Dead Letter Queue"
-title: "How to configure a Dead Letter Queue — NestJS JetStream"
-description: "Capture NestJS NATS JetStream messages that exhaust all delivery attempts — via a built-in DLQ stream with tracking headers or an onDeadLetter callback."
+title: "How to configure a Dead Letter Queue: NestJS JetStream"
+description: "Capture NestJS NATS JetStream messages that exhaust all delivery attempts: via a built-in DLQ stream with tracking headers or an onDeadLetter callback."
 schema:
   type: Article
   headline: "How to configure a Dead Letter Queue"
@@ -19,14 +19,14 @@ import Since from '@site/src/components/Since';
 
 When a message fails on every delivery attempt and exhausts its `max_deliver` limit, the transport treats it as a **dead letter**. Instead of silently discarding it, the library gives you two mechanisms to capture it:
 
-1. **A built-in DLQ stream** *(added in v2.9.0)* — `dlq: { stream }` in your module options. Exhausted messages get republished to a dedicated JetStream stream with tracking headers. This is the recommended default.
-2. **An `onDeadLetter` callback** — a hook with full dead letter context for custom persistence (database, S3, external queue).
+1. **A built-in DLQ stream** *(added in v2.9.0)*: `dlq: { stream }` in your module options. Exhausted messages get republished to a dedicated JetStream stream with tracking headers. This is the recommended default.
+2. **An `onDeadLetter` callback**: a hook with full dead letter context for custom persistence (database, S3, external queue).
 
-Start with either. For maximum durability, use them together — the full fallback chain is described in [Built-in DLQ stream](#built-in-dlq-stream) below.
+Start with either. For maximum durability, use them together: the full fallback chain is described in [Built-in DLQ stream](#built-in-dlq-stream) below.
 
 ## What is a dead letter?
 
-In NATS JetStream, each consumer has a `max_deliver` setting (default: **3**). Every time a handler throws an exception; or requests a business retry via [`ctx.retry()`](/docs/guides/handler-context); the message is `nak`'d and redelivered. Once the delivery count reaches `max_deliver`, the message has nowhere to go — it's "dead."
+In NATS JetStream, each consumer has a `max_deliver` setting (default: **3**). Every time a handler throws an exception; or requests a business retry via [`ctx.retry()`](/docs/guides/handler-context); the message is `nak`'d and redelivered. Once the delivery count reaches `max_deliver`, the message has nowhere to go: it's "dead."
 
 Without a DLQ strategy, the transport would simply `term()` the message after the final failed attempt. With the DLQ stream or callback, you get a chance to save it before it's gone.
 
@@ -54,12 +54,12 @@ sequenceDiagram
         C->>DLQ: republish with tracking headers
         DLQ-->>C: ack
         opt onDeadLetter also configured
-            C->>CB: onDeadLetter(info) — notification
+            C->>CB: onDeadLetter(info), notification
             Note over CB: errors here are logged,<br/>message still terminates
         end
         C-->>S: term() original message
     else dlq not configured
-        C->>CB: onDeadLetter(info) — primary
+        C->>CB: onDeadLetter(info), primary
         CB-->>C: resolved
         C-->>S: term() original message
     end
@@ -110,15 +110,15 @@ See [Bring Your Own Infrastructure](/docs/guides/external-infrastructure#externa
 
 On application start, the library provisions (or updates) the DLQ JetStream stream with these defaults:
 
-- **Stream name** &mdash; `{service}__microservice_dlq-stream` (e.g. `orders__microservice_dlq-stream`).
-- **Retention** &mdash; `Workqueue`. Messages are removed when a DLQ consumer acks them.
-- **`max_age`** &mdash; 30 days.
-- **`max_bytes`** &mdash; 5 GB.
-- **`max_msgs`** &mdash; 50,000,000.
-- **`max_msg_size`** &mdash; 10 MB.
-- **`max_consumers`** &mdash; 100.
-- **`allow_rollup_hdrs`** &mdash; `false`.
-- **`duplicate_window`** &mdash; 2 minutes.
+- **Stream name**, `{service}__microservice_dlq-stream` (e.g. `orders__microservice_dlq-stream`).
+- **Retention**, `Workqueue`. Messages are removed when a DLQ consumer acks them.
+- **`max_age`**, 30 days.
+- **`max_bytes`**, 5 GB.
+- **`max_msgs`**, 50,000,000.
+- **`max_msg_size`**, 10 MB.
+- **`max_consumers`**, 100.
+- **`allow_rollup_hdrs`**, `false`.
+- **`duplicate_window`**, 2 minutes.
 
 You can override any of these via `dlq.stream`, for example to shorten retention or raise the byte cap. The stream name is always derived from your service name; any `name` field you set on `dlq.stream` is ignored, which keeps DLQ streams predictable across services. Full defaults live in `DEFAULT_DLQ_STREAM_CONFIG`.
 
@@ -128,23 +128,23 @@ The `dlqStreamName(serviceName)` helper is exported from the package so you can 
 
 Every message republished to the DLQ stream carries metadata headers so you can investigate, replay, or filter without decoding the payload first:
 
-- **`x-dead-letter-reason`** &mdash; the error message from the last handler failure (extracted from `Error.message` or coerced via `String(error)`).
-- **`x-original-subject`** &mdash; the subject the message was originally published to.
-- **`x-original-stream`** &mdash; the source stream the message came from.
-- **`x-failed-at`** &mdash; ISO 8601 timestamp of the moment the message entered the DLQ.
-- **`x-delivery-count`** &mdash; how many times the message was delivered before it was marked dead.
+- **`x-dead-letter-reason`**: the error message from the last handler failure (extracted from `Error.message` or coerced via `String(error)`).
+- **`x-original-subject`**: the subject the message was originally published to.
+- **`x-original-stream`**: the source stream the message came from.
+- **`x-failed-at`**, ISO 8601 timestamp of the moment the message entered the DLQ.
+- **`x-delivery-count`**, how many times the message was delivered before it was marked dead.
 
-The `JetstreamDlqHeader` enum is exported from the package — use it for type-safe header access in your DLQ consumer.
+The `JetstreamDlqHeader` enum is exported from the package, use it for type-safe header access in your DLQ consumer.
 
 ### Fallback chain
 
 The transport uses a strict, **no-silent-loss** chain when handling a dead letter:
 
-1. **Emit `TransportEvent.DeadLetter`** — fires for every dead letter, regardless of configuration (for observability). Happens unconditionally.
-2. **Try DLQ stream publish (up to 3 attempts)** — if `dlq` is configured, publish the payload and tracking headers to the DLQ stream. A transient broker hiccup is retried in-process before giving up; this matters because the server never redelivers a message past `max_deliver`, so these attempts are the only second chance a dead letter gets.
-3. **On successful publish — notify `onDeadLetter`** — if a callback is also registered, it is invoked as a **notification hook** (logging, metrics, alerting). Any error thrown by the callback at this stage is logged and swallowed; the original message still terminates successfully.
-4. **On failed publish — fall back to `onDeadLetter`**; if every DLQ publish attempt throws (broker rejection, connectivity issue, disk full), the transport falls back to the callback so the payload still has a chance to land somewhere. On success, the message is terminated; on failure, it is `nak`'d.
-5. **`nak()` as last resort**; if no callback is configured and the DLQ publish fails, or if the fallback callback also throws, the message is `nak`'d rather than silently terminated. Because the delivery count has reached `max_deliver`, NATS will **not** redeliver it; the message stays in the stream, visible to operators, until it is recovered manually or expires via `max_age`. An error log records every such case.
+1. **Emit `TransportEvent.DeadLetter`**: fires for every dead letter, regardless of configuration (for observability). Happens unconditionally.
+2. **Try DLQ stream publish (up to 3 attempts)**: if `dlq` is configured, publish the payload and tracking headers to the DLQ stream. A transient broker hiccup is retried in-process before giving up; this matters because the server never redelivers a message past `max_deliver`, so these attempts are the only second chance a dead letter gets.
+3. **On successful publish: notify `onDeadLetter`**: if a callback is also registered, it is invoked as a **notification hook** (logging, metrics, alerting). Any error thrown by the callback at this stage is logged and swallowed; the original message still terminates successfully.
+4. **On failed publish: fall back to `onDeadLetter`**; if every DLQ publish attempt throws (broker rejection, connectivity issue, disk full), the transport falls back to the callback so the payload still has a chance to land somewhere. On success, the message is terminated; on failure, it is `nak`'d.
+5. **`nak()` as last resort**; if no callback is configured and the DLQ publish fails, or if the fallback callback also throws, the message is `nak`'d rather than silently terminated. Because the delivery count has reached `max_deliver`, NATS will not redeliver it; the message stays in the stream, visible to operators, until it is recovered manually or expires via `max_age`. An error log records every such case.
 
 This chain guarantees that no message is terminated without passing through at least one recovery path.
 
@@ -156,8 +156,8 @@ With `dlq` configured, the callback is a **notification + safety net**; it fires
 
 The `onDeadLetter` callback can be used in two ways:
 
-- **Standalone** — no `dlq` option, just the callback. The transport calls it for every dead letter so you can persist the payload wherever you want (database, S3, external queue). This is the right choice when you need custom logic at the moment of failure (e.g., trigger an incident, update a UI, enrich with business context).
-- **Alongside a DLQ stream** — used together with `dlq: { stream }`. The DLQ stream is the primary persistence path. The callback fires as a **notification hook** after every successful DLQ publish (errors are logged but do not block termination) and as a **fallback** if the DLQ publish itself throws. See the [Fallback chain](#fallback-chain) above for the full sequence.
+- **Standalone**: no `dlq` option, just the callback. The transport calls it for every dead letter so you can persist the payload wherever you want (database, S3, external queue). This is the right choice when you need custom logic at the moment of failure (e.g., trigger an incident, update a UI, enrich with business context).
+- **Alongside a DLQ stream**: used together with `dlq: { stream }`. The DLQ stream is the primary persistence path. The callback fires as a **notification hook** after every successful DLQ publish (errors are logged but do not block termination) and as a **fallback** if the DLQ publish itself throws. See the [Fallback chain](#fallback-chain) above for the full sequence.
 
 Register `onDeadLetter` in `forRoot()` or `forRootAsync()`:
 
@@ -213,16 +213,16 @@ When `dlq` is not configured and only the callback is registered, the flow is:
 2. The transport builds a `DeadLetterInfo` object.
 3. The `TransportEvent.DeadLetter` hook fires (for observability).
 4. `onDeadLetter(info)` is called and awaited.
-5. On success: the message is `term()`'d (terminated — removed from the stream permanently).
-6. On failure: the message is `nak()`'d and stays in the stream — see the warning below.
+5. On success: the message is `term()`'d (terminated: removed from the stream permanently).
+6. On failure: the message is `nak()`'d and stays in the stream: see the warning below.
 
 :::warning Callback failures keep the message in the stream
-If your `onDeadLetter` callback throws (e.g., the database is down), the message is **not** terminated; it is `nak`'d so the data is preserved. But the delivery count has already reached `max_deliver`, so NATS will **not** deliver it again: the message remains in the stream until you recover it manually (e.g. with `nats stream get` / a replay tool) or it expires via `max_age`. Each occurrence is recorded with an error log. If you combine the callback with `dlq: { stream }`, the DLQ publish (with its in-process retries) runs first, and the callback is only a fallback.
+If your `onDeadLetter` callback throws (e.g., the database is down), the message is not terminated; it is `nak`'d so the data is preserved. But the delivery count has already reached `max_deliver`, so NATS will not deliver it again: the message remains in the stream until you recover it manually (e.g. with `nats stream get` / a replay tool) or it expires via `max_age`. Each occurrence is recorded with an error log. If you combine the callback with `dlq: { stream }`, the DLQ publish (with its in-process retries) runs first, and the callback is only a fallback.
 :::
 
 ## DI integration with forRootAsync
 
-In real applications, the dead letter callback typically needs access to injected services — a repository, a queue client, a logger. Use `forRootAsync()` to inject dependencies:
+In real applications, the dead letter callback typically needs access to injected services, a repository, a queue client, a logger. Use `forRootAsync()` to inject dependencies:
 
 ```typescript title="src/app.module.ts"
 import { Module } from '@nestjs/common';
@@ -283,7 +283,7 @@ export class DlqService {
 
 ## Observability with TransportEvent.DeadLetter
 
-In addition to the `onDeadLetter` callback, the transport emits a `TransportEvent.DeadLetter` hook event every time a dead letter is detected. This fires **before** the callback, regardless of whether `onDeadLetter` is configured.
+Also to the `onDeadLetter` callback, the transport emits a `TransportEvent.DeadLetter` hook event every time a dead letter is detected. This fires **before** the callback, regardless of whether `onDeadLetter` is configured.
 
 Use it for metrics, alerting, or structured logging:
 
@@ -308,19 +308,19 @@ JetstreamModule.forRoot({
 ```
 
 :::tip Hook vs callback
-The `TransportEvent.DeadLetter` **hook** is synchronous and fire-and-forget; use it for lightweight observability (metrics, logs). The `onDeadLetter` **callback** is async and awaited — use it for persistence that must succeed before the message is terminated. See [Lifecycle Hooks](/docs/guides/lifecycle-hooks) for more on the difference.
+The `TransportEvent.DeadLetter` **hook** is synchronous and fire-and-forget; use it for lightweight observability (metrics, logs). The `onDeadLetter` **callback** is async and awaited, use it for persistence that must succeed before the message is terminated. See [Lifecycle Hooks](/docs/guides/lifecycle-hooks) for more on the difference.
 :::
 
 ## Scope
 
 Dead letter detection applies to [**workqueue events**](/docs/patterns/events) and [**broadcast events**](/docs/patterns/broadcast) only. It does not apply to:
 
-- [**RPC messages**](/docs/patterns/rpc) — RPC uses a request/reply pattern with its own timeout mechanism. Failed RPC handlers return error responses to the caller rather than entering a dead letter flow.
-- [**Ordered events**](/docs/patterns/ordered-events) — Ordered consumers are ephemeral and auto-acknowledged by the NATS client. There is no ack/nak cycle, so there is no concept of delivery exhaustion.
+- [**RPC messages**](/docs/patterns/rpc): RPC uses a request/reply pattern with its own timeout mechanism. Failed RPC handlers return error responses to the caller rather than entering a dead letter flow.
+- [**Ordered events**](/docs/patterns/ordered-events): Ordered consumers are ephemeral and auto-acknowledged by the NATS client. Without an ack/nak cycle, delivery exhaustion has no meaning here.
 
 ## What's next?
 
-- [**Events (Workqueue)**](/docs/patterns/events) — retry flow and delivery semantics
-- [**Broadcast Events**](/docs/patterns/broadcast) — fan-out delivery with per-instance DLQ
-- [**Lifecycle Hooks**](/docs/guides/lifecycle-hooks) — observe transport events including dead letters
-- [**Module Configuration**](/docs/reference/module-configuration) — `forRoot()` and `forRootAsync()` options reference
+- [**Events (Workqueue)**](/docs/patterns/events): retry flow and delivery semantics
+- [**Broadcast Events**](/docs/patterns/broadcast): fan-out delivery with per-instance DLQ
+- [**Lifecycle Hooks**](/docs/guides/lifecycle-hooks): observe transport events including dead letters
+- [**Module Configuration**](/docs/reference/module-configuration): `forRoot()` and `forRootAsync()` options reference

--- a/website/docs/guides/dead-letter-queue.md
+++ b/website/docs/guides/dead-letter-queue.md
@@ -8,7 +8,7 @@ schema:
   headline: "How to configure a Dead Letter Queue"
   description: "Capture NestJS NATS JetStream messages that exhaust all delivery attempts via a DLQ stream or onDeadLetter callback."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/guides/external-infrastructure.md
+++ b/website/docs/guides/external-infrastructure.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 sidebar_label: "Bring Your Own Infrastructure"
-title: "Bring Your Own Infrastructure (bind-only mode) — NestJS JetStream"
+title: "Bring Your Own Infrastructure (bind-only mode): NestJS JetStream"
 description: "Bind NestJS JetStream to externally managed NATS streams and consumers provisioned by Terraform, ArgoCD, or a platform team. No auto-provisioning."
 schema:
   type: Article
@@ -17,7 +17,7 @@ import Since from '@site/src/components/Since';
 
 <Since version="2.10.0" />
 
-By default, the transport provisions and updates every JetStream stream and consumer it needs. If your organization owns the infrastructure layer — Terraform, ArgoCD, Helm, or a dedicated platform team — you can opt out of that auto-management and instead tell the library to bind to resources that already exist.
+By default, the transport provisions and updates every JetStream stream and consumer it needs. If your organization owns the infrastructure layer (Terraform, ArgoCD, Helm, or a dedicated platform team) you can opt out of that auto-management and instead tell the library to bind to resources that already exist.
 
 In **Manual** mode the library never creates, updates, or migrates an entity. At startup it reads the live state from the NATS server, validates that it is suitable for the application's handlers, and fails fast with a detailed error when it is not.
 
@@ -29,14 +29,14 @@ In **Manual** mode the library never creates, updates, or migrates an entity. At
 - You want audit-trail guarantees: stream configuration changes must go through version control, not happen silently at service startup.
 
 :::tip
-If none of the above apply, the default `Auto` mode is simpler — the transport provisions everything and keeps it up to date without any extra configuration.
+If none of the above apply, the default `Auto` mode is simpler: the transport provisions everything and keeps it up to date without any extra configuration.
 :::
 
 ## Quick start
 
 ### 1. Provision the stream and consumer externally
 
-The stream and consumer must exist before the application boots. Use whatever tool your team uses — the example below uses the `nats` CLI:
+The stream and consumer must exist before the application boots. Use whatever tool your team uses: the example below uses the `nats` CLI:
 
 ```bash
 # Stream: workqueue retention, file storage
@@ -130,9 +130,9 @@ export class OrdersController {
 
 The mode is resolved per entity (stream or consumer) using the following chain, from highest to lowest priority:
 
-1. **Per-entity override** — `events.management.stream` / `events.management.consumer` (and the equivalent on `broadcast`, `ordered`, `rpc`, `dlq`).
-2. **Global default** — `provisioning.management`.
-3. **Library default** — `ManagementMode.Auto` when neither of the above is set.
+1. **Per-entity override**: `events.management.stream` / `events.management.consumer` (and the equivalent on `broadcast`, `ordered`, `rpc`, `dlq`).
+2. **Global default**: `provisioning.management`.
+3. **Library default**: `ManagementMode.Auto` when neither of the above is set.
 
 ### Mixed ownership
 
@@ -173,7 +173,7 @@ events: {
 
 ### Subject prefix
 
-The `subjectPrefix` field changes the subject pattern used to build and match subjects for a given kind. The trailing dot is normalized automatically.
+The `subjectPrefix` field changes the subject pattern used to build and match subjects for one kind. The trailing dot is normalized automatically.
 
 ```typescript
 events: {
@@ -189,7 +189,7 @@ When a custom `subjectPrefix` is set:
 
 ## Subject contract per kind
 
-When the library binds to an external entity it validates that the entity's configuration satisfies certain requirements. The table below describes what each kind needs from an externally provisioned stream and consumer.
+When the library binds to an external entity it validates that the entity's configuration satisfies these requirements. The table below describes what each kind needs from an externally provisioned stream and consumer.
 
 ### Event stream (workqueue)
 
@@ -220,7 +220,7 @@ Setting broadcast to Manual means the shared cluster-wide `broadcast-stream` is 
 | Requirement | What to configure externally |
 |---|---|
 | Stream subjects must cover all ordered-event subjects registered by this service | Subjects use the `{service}__microservice.ordered.{pattern}` convention unless a custom prefix is set |
-| Consumer filter (ordered consumers are recreated automatically by the client) | No filter configuration needed — ordered consumers are ephemeral |
+| Consumer filter (ordered consumers are recreated automatically by the client) | No filter configuration needed: ordered consumers are ephemeral |
 
 ### DLQ stream
 
@@ -268,7 +268,7 @@ Provisioning 3 stream(s) for "orders":
 
 ## Self-healing for Manual consumers
 
-When the transport loses a consumer iterator (NATS reconnect, server restart, or external deletion), the self-healing loop tries to rebind. For a Manual consumer it **never recreates** it — if the consumer is absent it logs a recoverable error and keeps retrying on the same backoff schedule:
+When the transport loses a consumer iterator (NATS reconnect, server restart, or external deletion), the self-healing loop tries to rebind. For a Manual consumer it **never recreates** it, if the consumer is absent it logs a recoverable error and keeps retrying on the same backoff schedule:
 
 ```text
 Consumer ext_orders_worker on ext_orders_stream is externally managed and currently absent; waiting for it to be restored.
@@ -276,7 +276,7 @@ Consumer ext_orders_worker on ext_orders_stream is externally managed and curren
 
 Once your platform team (or Terraform) restores the consumer, the next retry succeeds and processing resumes automatically. No application restart is needed.
 
-This is the key difference from Auto mode: in Auto mode a missing consumer is silently recreated; in Manual mode the library waits, because recreating an externally owned resource would be a policy violation.
+Auto mode differs here: it recreates a missing consumer silently, in Manual mode the library waits, because recreating an externally owned resource would be a policy violation.
 
 ## External DLQ
 
@@ -313,7 +313,7 @@ nats stream add ext_dlq \
   --defaults
 ```
 
-The `dlq.management` field accepts only a `stream` override — there is no consumer to bind for the DLQ stream.
+The `dlq.management` field accepts only a `stream` override: there is no consumer to bind for the DLQ stream.
 
 ## Scheduling with a custom prefix
 
@@ -338,7 +338,7 @@ nats stream add ext_orders_stream \
   --storage file \
   --replicas 1 \
   --defaults
-# "ext.orders.>" already covers "ext.orders._sch.>" — no extra entry needed
+# "ext.orders.>" already covers "ext.orders._sch.>", no extra entry needed
 ```
 
 If the default naming convention is used (no `subjectPrefix`), the schedule wildcard is `{service}__microservice._sch.>` and must appear in the external stream's subjects.
@@ -346,7 +346,7 @@ If the default naming convention is used (no `subjectPrefix`), the schedule wild
 ## Interaction with allowDestructiveMigration
 
 :::warning
-Setting `allowDestructiveMigration: true` at the same time as a global `provisioning.management: Manual` is contradictory — Manual streams are never migrated regardless of the flag. The library logs a warning at boot:
+Setting `allowDestructiveMigration: true` at the same time as a global `provisioning.management: Manual` is contradictory, Manual streams are never migrated regardless of the flag. The library logs a warning at boot:
 
 ```text
 allowDestructiveMigration has no effect under provisioning.management: Manual; the library never migrates externally managed streams.
@@ -357,7 +357,7 @@ The `allowDestructiveMigration` flag only applies to `Auto`-managed streams. See
 
 ## What's next?
 
-- [**Stream Migration**](/docs/guides/stream-migration) — how the transport migrates Auto-managed streams
-- [**Dead Letter Queue**](/docs/guides/dead-letter-queue) — DLQ stream configuration
-- [**Scheduling**](/docs/guides/scheduling) — scheduled message delivery and the `_sch.` subject prefix
-- [**Module Configuration**](/docs/reference/module-configuration) — full `management`, `subjectPrefix`, and custom name reference
+- [**Stream Migration**](/docs/guides/stream-migration): how the transport migrates Auto-managed streams
+- [**Dead Letter Queue**](/docs/guides/dead-letter-queue): DLQ stream configuration
+- [**Scheduling**](/docs/guides/scheduling): scheduled message delivery and the `_sch.` subject prefix
+- [**Module Configuration**](/docs/reference/module-configuration): full `management`, `subjectPrefix`, and custom name reference

--- a/website/docs/guides/external-infrastructure.md
+++ b/website/docs/guides/external-infrastructure.md
@@ -8,7 +8,7 @@ schema:
   headline: "Bring Your Own Infrastructure (bind-only mode)"
   description: "Bind NestJS JetStream to externally managed NATS streams and consumers provisioned by Terraform, ArgoCD, or a platform team."
   datePublished: "2026-06-12"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/guides/graceful-shutdown.md
+++ b/website/docs/guides/graceful-shutdown.md
@@ -17,11 +17,11 @@ The transport handles shutdown automatically through the NestJS application life
 
 The `JetstreamModule` implements NestJS's `OnApplicationShutdown` interface. When the application receives a termination signal (SIGTERM, SIGINT), NestJS calls the module's `onApplicationShutdown()` method, which triggers the following sequence:
 
-1. **Emit `ShutdownStart` hook** — notifies lifecycle hooks that shutdown has begun.
-2. **Stop consumers** — calls `strategy.close()`, which closes all RxJS subscriptions and stops JetStream consumer iterators. No new messages are accepted. In-flight handlers in the RxJS pipeline continue to run to completion.
-3. **Drain NATS connection** — calls `nc.drain()`, which flushes any pending publishes and waits for active subscriptions to finish, then closes the connection.
-4. **Safety timeout** — if drain doesn't complete within `shutdownTimeout` milliseconds, the transport proceeds with shutdown anyway. This prevents a stuck handler from blocking the process indefinitely.
-5. **Emit `ShutdownComplete` hook** — notifies lifecycle hooks that shutdown is finished.
+1. **Emit `ShutdownStart` hook**: notifies lifecycle hooks that shutdown has begun.
+2. **Stop consumers**: calls `strategy.close()`, which closes all RxJS subscriptions and stops JetStream consumer iterators. No new messages are accepted. In-flight handlers in the RxJS pipeline continue to run to completion.
+3. **Drain NATS connection**: calls `nc.drain()`, which flushes any pending publishes and waits for active subscriptions to finish, then closes the connection.
+4. **Safety timeout**: if drain doesn't complete within `shutdownTimeout` milliseconds, the transport proceeds with shutdown anyway. This prevents a stuck handler from blocking the process indefinitely.
+5. **Emit `ShutdownComplete` hook**: notifies lifecycle hooks that shutdown is finished.
 
 ```mermaid
 flowchart LR
@@ -43,7 +43,7 @@ NATS `drain()` is a graceful shutdown primitive. When you drain a connection:
 - The client waits for all pending message handlers to complete and send their ack/nak.
 - Once all in-flight work is done, the connection closes cleanly.
 
-This ensures that messages are not lost or left in an ambiguous state. A message that was being processed when shutdown started will either be acknowledged (if the handler succeeds) or nak'd (if it fails), so NATS can redeliver it to another instance.
+No message is dropped or left in an ambiguous state. A message that was being processed when shutdown started will either be acknowledged (if the handler succeeds) or nak'd (if it fails), so NATS can redeliver it to another instance.
 
 ## Configuring the timeout
 
@@ -69,7 +69,7 @@ export class AppModule {}
 Set `shutdownTimeout` to slightly more than your longest handler's expected duration. If your slowest handler takes 20 seconds, a timeout of 25-30 seconds gives it room to finish. Too short, and handlers may be abandoned mid-execution; too long, and your deployment pipeline will wait unnecessarily.
 :::
 
-If the timeout fires before drain completes, the transport closes the connection immediately. Any in-flight handlers that haven't finished will be interrupted — their messages will not be acknowledged, so NATS will redeliver them to another instance after the consumer's `ack_wait` expires.
+If the timeout fires before drain completes, the transport closes the connection immediately. Any in-flight handlers that haven't finished will be interrupted: their messages will not be acknowledged, so NATS will redeliver them to another instance after the consumer's `ack_wait` expires.
 
 ## Enabling shutdown hooks
 
@@ -88,7 +88,7 @@ async function bootstrap() {
     { inheritAppConfig: true },
   );
 
-  // Required for graceful shutdown to work — without this, SIGTERM
+  // Required for graceful shutdown to work, without this, SIGTERM
   // terminates the process before onApplicationShutdown() runs.
   app.enableShutdownHooks();
 
@@ -100,7 +100,7 @@ void bootstrap();
 ```
 
 :::warning Without enableShutdownHooks(), shutdown is not graceful
-If you skip `enableShutdownHooks()`, the process will terminate immediately on SIGTERM/SIGINT without calling `onApplicationShutdown()`. The NATS connection will drop abruptly, and in-flight messages will be redelivered after `ack_wait` expires — which works, but is not clean.
+If you skip `enableShutdownHooks()`, the process will terminate immediately on SIGTERM/SIGINT without calling `onApplicationShutdown()`. The NATS connection will drop abruptly, and in-flight messages will be redelivered after `ack_wait` expires, which works, but is not clean.
 :::
 
 ## No manual shutdown code needed

--- a/website/docs/guides/graceful-shutdown.md
+++ b/website/docs/guides/graceful-shutdown.md
@@ -6,7 +6,7 @@ schema:
   headline: "Graceful Shutdown"
   description: "Automatic shutdown handling with in-flight message completion and NATS connection drain."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Graceful Shutdown

--- a/website/docs/guides/handler-context.md
+++ b/website/docs/guides/handler-context.md
@@ -8,7 +8,7 @@ schema:
   headline: "RpcContext: Handler Context & Message Settlement"
   description: "Access JetStream metadata and control ack, retry, and terminate actions in NestJS message handlers via RpcContext."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/guides/handler-context.md
+++ b/website/docs/guides/handler-context.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 2
 sidebar_label: "Handler Context"
-title: "RpcContext — Handler Context & Message Settlement"
+title: "RpcContext: Handler Context & Message Settlement"
 description: "Access JetStream metadata and control ack, retry, and terminate actions in NestJS message handlers via RpcContext."
 schema:
   type: Article
-  headline: "RpcContext — Handler Context & Message Settlement"
+  headline: "RpcContext: Handler Context & Message Settlement"
   description: "Access JetStream metadata and control ack, retry, and terminate actions in NestJS message handlers via RpcContext."
   datePublished: "2026-03-21"
   dateModified: "2026-06-12"
@@ -55,7 +55,7 @@ class RpcContext {
   /** All NATS message headers (raw MsgHdrs from @nats-io/transport-node). */
   getHeaders(): MsgHdrs | undefined;
 
-  /** Type guard — true when the message is a JetStream message. */
+  /** Type guard, true when the message is a JetStream message. */
   isJetStream(): boolean;
 
   /**
@@ -70,7 +70,7 @@ class RpcContext {
 
 <Since version="2.7.0" />
 
-These return `undefined` for Core NATS messages — no type guard needed.
+These return `undefined` for Core NATS messages: no type guard needed.
 
 ```typescript
 class RpcContext {
@@ -95,7 +95,7 @@ class RpcContext {
 
 <Since version="2.7.0" />
 
-Control how the transport acknowledges the message — without throwing errors.
+Control how the transport acknowledges the message, without throwing errors.
 
 **`ctx.retry({ delayMs? })`** -> `msg.nak(delayMs)`, redelivering the message. Use for business-level retries (external service unavailable, resource locked). Each retry consumes a delivery attempt; a `retry()` on the final permitted delivery is routed through [dead-letter handling](/docs/guides/dead-letter-queue) just like a throwing handler, so the message is captured instead of stranded.
 
@@ -126,7 +126,7 @@ async handle(@Payload() data: PaymentDto, @Ctx() ctx: RpcContext) {
   const attempt = ctx.getDeliveryCount() ?? 0;
 
   if (attempt >= 3) {
-    // 3rd attempt — try a different payment provider
+    // 3rd attempt, try a different payment provider
     await this.fallbackProvider.process(data);
     return;
   }
@@ -152,7 +152,7 @@ async handle(@Payload() data: FulfillDto, @Ctx() ctx: RpcContext) {
   }
 
   await this.fulfillOrder(data);
-  // auto-ack — no flags set
+  // auto-ack, no flags set
 }
 ```
 
@@ -185,13 +185,13 @@ async handle(@Payload() data: OrderDto, @Ctx() ctx: RpcContext) {
 ```mermaid
 flowchart TD
     A[Handler returns] --> B{ctx.shouldTerminate?}
-    B -->|yes| C[msg.term — permanent reject]
+    B -->|yes| C[msg.term, permanent reject]
     B -->|no| D{ctx.shouldRetry?}
-    D -->|yes| E[msg.nak — redeliver]
-    D -->|no| F[msg.ack — done]
+    D -->|yes| E[msg.nak, redeliver]
+    D -->|no| F[msg.ack, done]
     G[Handler throws] --> H{Dead letter?}
     H -->|yes| I[onDeadLetter → msg.term]
-    H -->|no| J[msg.nak — retry]
+    H -->|no| J[msg.nak, retry]
 ```
 
 :::warning Mutual exclusivity
@@ -252,12 +252,12 @@ if (ctx.isJetStream()) {
 ```
 
 :::warning Manual acknowledgment
-Calling `msg.ack()`, `msg.nak()`, or `msg.term()` directly bypasses the transport's settlement logic. Use `ctx.retry()` and `ctx.terminate()` instead — they integrate with ack extension, dead letter handling, and observability hooks.
+Calling `msg.ack()`, `msg.nak()`, or `msg.term()` directly bypasses the transport's settlement logic. Use `ctx.retry()` and `ctx.terminate()` instead: they integrate with ack extension, dead letter handling, and observability hooks.
 :::
 
 ## See also
 
-- [Record Builder & Deduplication](./record-builder.md) — set custom headers and message IDs on the publisher side
-- [Custom Codec](./custom-codec.md) — control how the `@Payload()` data is serialized and deserialized
-- [Dead Letter Queue](./dead-letter-queue.md) — what happens when retries are exhausted
-- [Troubleshooting](./troubleshooting.md) — common issues with message delivery
+- [Record Builder & Deduplication](./record-builder.md): set custom headers and message IDs on the publisher side
+- [Custom Codec](./custom-codec.md): control how the `@Payload()` data is serialized and deserialized
+- [Dead Letter Queue](./dead-letter-queue.md): what happens when retries are exhausted
+- [Troubleshooting](./troubleshooting.md): common issues with message delivery

--- a/website/docs/guides/health-checks.md
+++ b/website/docs/guides/health-checks.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 sidebar_label: "Health Checks"
-title: "How to expose health checks — NestJS JetStream"
+title: "How to expose health checks: NestJS JetStream"
 description: "Expose NATS connection status and RTT latency as a Kubernetes readiness/liveness probe with the JetstreamHealthIndicator, with or without @nestjs/terminus."
 schema:
   type: Article
@@ -17,14 +17,14 @@ import Since from '@site/src/components/Since';
 
 <Since version="2.1.0" />
 
-The library provides a `JetstreamHealthIndicator` that reports the NATS connection status and round-trip latency. It is auto-registered by [`forRoot()`](/docs/reference/module-configuration#forroot) and exported from the module — no additional setup required.
+The library provides a `JetstreamHealthIndicator` that reports the NATS connection status and round-trip latency. It is auto-registered by [`forRoot()`](/docs/reference/module-configuration#forroot) and exported from the module: no extra setup required.
 
 ## What it checks
 
 Every health check call performs two things:
 
-1. **Connection status** — is the NATS connection open?
-2. **RTT latency** — a round-trip ping to the NATS server via `nc.rtt()`, measuring actual network latency in milliseconds.
+1. **Connection status**: is the NATS connection open?
+2. **RTT latency**: a round-trip ping to the NATS server via `nc.rtt()`, measuring actual network latency in milliseconds.
 
 If the connection is closed or the RTT ping fails, the indicator reports the connection as unhealthy.
 
@@ -37,7 +37,7 @@ The health indicator exposes two methods for different use cases:
 | `check()` | No | Custom health endpoints, monitoring integrations |
 | `isHealthy(key?)` | Yes | @nestjs/terminus integration |
 
-### check() — plain status object
+### check(): plain status object
 
 `check()` returns a `JetstreamHealthStatus` object and **never throws**. Use it when you want to inspect the status programmatically without try/catch:
 
@@ -73,7 +73,7 @@ export class HealthController {
 }
 ```
 
-### isHealthy(key?) — Terminus-compatible
+### isHealthy(key?): Terminus-compatible
 
 `isHealthy()` follows the @nestjs/terminus convention: returns `{ [key]: { status: 'up', ... } }` on success, **throws** on failure. The `key` parameter defaults to `'jetstream'`.
 
@@ -172,7 +172,7 @@ export class HealthController {
 }
 ```
 
-This gives you full control over the response shape and HTTP status code without any additional dependency.
+The response shape and HTTP status code stay yours, with no extra dependency.
 
 ## Auto-registration
 
@@ -198,4 +198,4 @@ No need to add it to any `providers` array or re-import `JetstreamModule`; it's 
 
 ## See also
 
-If you want more than a point-in-time check, [lifecycle hooks](/docs/guides/lifecycle-hooks) give you push-based visibility into every `Connect`, `Disconnect`, and `Reconnect` event — useful for streaming connection state into your metrics pipeline alongside the health indicator.
+If you want more than a point-in-time check, [lifecycle hooks](/docs/guides/lifecycle-hooks) give you push-based visibility into every `Connect`, `Disconnect`, and `Reconnect` event, useful for streaming connection state into your metrics pipeline alongside the health indicator.

--- a/website/docs/guides/health-checks.md
+++ b/website/docs/guides/health-checks.md
@@ -8,7 +8,7 @@ schema:
   headline: "How to expose health checks for NATS JetStream"
   description: "Expose NATS connection status and RTT latency as a Kubernetes readiness/liveness probe using JetstreamHealthIndicator."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/guides/lifecycle-hooks.md
+++ b/website/docs/guides/lifecycle-hooks.md
@@ -8,7 +8,7 @@ schema:
   headline: "How to register lifecycle hooks for NestJS JetStream"
   description: "Subscribe to transport events for monitoring, alerting, and logging integration."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/guides/lifecycle-hooks.md
+++ b/website/docs/guides/lifecycle-hooks.md
@@ -1,8 +1,8 @@
 ---
 sidebar_position: 4
 sidebar_label: "Lifecycle Hooks"
-title: "How to register lifecycle hooks — NestJS JetStream"
-description: "Subscribe to NATS JetStream transport events — connection, disconnect, reconnect, errors, RPC timeouts, message routing, dead letters, and shutdown — for monitoring and alerting."
+title: "How to register lifecycle hooks: NestJS JetStream"
+description: "Subscribe to NATS JetStream transport events: connection, disconnect, reconnect, errors, RPC timeouts, message routing, dead letters, and shutdown: for monitoring and alerting."
 schema:
   type: Article
   headline: "How to register lifecycle hooks for NestJS JetStream"
@@ -15,7 +15,7 @@ import Since from '@site/src/components/Since';
 
 # How to register lifecycle hooks
 
-The transport emits lifecycle events at key moments — connection changes, errors, message routing, shutdown, dead letters, and observability checkpoints. Register hook callbacks to integrate with your monitoring, alerting, or logging infrastructure.
+The transport emits lifecycle events at key moments, connection changes, errors, message routing, shutdown, dead letters, and observability checkpoints. Register hook callbacks to integrate with your monitoring, alerting, or logging infrastructure.
 
 ## Available events
 
@@ -41,7 +41,7 @@ The `MessageKind` enum on `MessageRouted` has two values; `Event` and `Rpc`; and
 
 ## Registering hooks
 
-Pass a `hooks` object in `forRoot()` or `forRootAsync()`. Only register the events you care about — unregistered events are silently ignored.
+Pass a `hooks` object in `forRoot()` or `forRootAsync()`. Only register the events you care about, unregistered events are silently ignored.
 
 ```typescript title="src/app.module.ts"
 import { Module } from '@nestjs/common';
@@ -171,7 +171,7 @@ JetstreamModule.forRoot({
 
 ## No hook = silence
 
-Events without a registered hook are silently ignored — no default logging, no warnings, no overhead. The `EventBus` checks if a hook is registered and returns immediately if not. This is intentional: the transport doesn't make assumptions about what you want to observe.
+Events without a registered hook are silently ignored: no default logging, no warnings, no overhead. The `EventBus` checks if a hook is registered and returns immediately if not. This is intentional: the transport doesn't make assumptions about what you want to observe.
 
 If you want to log everything during development, register hooks for all events. In production, register only the ones that feed your monitoring stack.
 
@@ -201,7 +201,7 @@ The transport has two dead letter mechanisms that serve different purposes:
 |---|---|---|
 | **Type** | Sync or async hook (fire-and-forget) | Async callback (awaited) |
 | **Fires** | Always, before the callback | Only if configured |
-| **Affects message fate?** | No | Yes — success = `term()`, failure = `nak()` |
+| **Affects message fate?** | No | Yes: success = `term()`, failure = `nak()` |
 | **Use case** | Metrics, logging, alerting | Persisting dead letters to a store |
 | **Error behavior** | Caught and logged | Causes message to be `nak`'d for retry |
 
@@ -228,7 +228,7 @@ The hook fires first, then the callback. If the callback fails and the message i
 
 ## What's next?
 
-- [**Dead Letter Queue**](/docs/guides/dead-letter-queue) — full guide on dead letter handling and the `onDeadLetter` callback
-- [**Health Checks**](/docs/guides/health-checks) — monitor connection health with RTT latency
-- [**Graceful Shutdown**](/docs/guides/graceful-shutdown) — `ShutdownStart` and `ShutdownComplete` events in context
-- [**Module Configuration**](/docs/reference/module-configuration) — `hooks` option in the full options reference
+- [**Dead Letter Queue**](/docs/guides/dead-letter-queue): full guide on dead letter handling and the `onDeadLetter` callback
+- [**Health Checks**](/docs/guides/health-checks): monitor connection health with RTT latency
+- [**Graceful Shutdown**](/docs/guides/graceful-shutdown): `ShutdownStart` and `ShutdownComplete` events in context
+- [**Module Configuration**](/docs/reference/module-configuration): `hooks` option in the full options reference

--- a/website/docs/guides/migration.md
+++ b/website/docs/guides/migration.md
@@ -2,7 +2,7 @@
 sidebar_position: 5
 sidebar_label: "Migrate from built-in NATS"
 title: "How to migrate from @nestjs/microservices NATS to JetStream"
-description: "Step-by-step migration from the built-in NestJS NATS transport (@nestjs/microservices) to @horizon-republic/nestjs-jetstream — durable delivery, automatic retries, and dead letter handling."
+description: "Step-by-step migration from the built-in NestJS NATS transport (@nestjs/microservices) to @horizon-republic/nestjs-jetstream: durable delivery, automatic retries, and dead letter handling."
 schema:
   type: Article
   headline: "How to migrate from @nestjs/microservices NATS to JetStream"
@@ -13,7 +13,7 @@ schema:
 
 # How to migrate from `@nestjs/microservices` NATS to JetStream
 
-This guide walks through replacing the built-in NestJS NATS transport (`@nestjs/microservices` package, `Transport.NATS`) with `@horizon-republic/nestjs-jetstream`. Your `ClientProxy` already talks to NATS — switching to JetStream is mostly configuration.
+This guide walks through replacing the built-in NestJS NATS transport (`@nestjs/microservices` package, `Transport.NATS`) with `@horizon-republic/nestjs-jetstream`. Your `ClientProxy` already talks to NATS, switching to JetStream is configuration work, not a rewrite.
 
 You will end up with durable delivery, automatic retries, dead letter handling, and W3C trace context for the same `@EventPattern` / `@MessagePattern` handlers you already have.
 
@@ -32,7 +32,7 @@ The semantic shift is from at-most-once to at-least-once delivery:
 - **Dead letters.** Built-in silently drops failed messages. JetStream provides a configurable dead-letter flow ([Dead Letter Queue](/docs/guides/dead-letter-queue)).
 - **Decorators.** Unchanged. `@EventPattern` and `@MessagePattern` work identically.
 
-## Step 1 — Install the library
+## Step 1: Install the library
 
 ```bash
 npm install @horizon-republic/nestjs-jetstream @nats-io/transport-node @nats-io/jetstream
@@ -40,7 +40,7 @@ npm install @horizon-republic/nestjs-jetstream @nats-io/transport-node @nats-io/
 
 You can remove `@nestjs/microservices` if no other transport (Redis, RabbitMQ, Kafka) is in use.
 
-## Step 2 — Replace module registration
+## Step 2: Replace module registration
 
 Before:
 
@@ -68,7 +68,7 @@ import { JetstreamModule } from '@horizon-republic/nestjs-jetstream';
 
 @Module({
   imports: [
-    // Once in your root module — creates the connection + consumer infrastructure
+    // Once in your root module, creates the connection + consumer infrastructure
     JetstreamModule.forRoot({
       name: 'orders',
       servers: ['nats://localhost:4222'],
@@ -83,7 +83,7 @@ export class AppModule {}
 
 The `name` field is the service identity used to derive stream, consumer, and subject names. See [Naming Conventions](/docs/reference/naming-conventions) for the rules.
 
-## Step 3 — Keep your handlers
+## Step 3: Keep your handlers
 
 No changes to handler signatures. `@EventPattern` and `@MessagePattern` work identically.
 
@@ -105,7 +105,7 @@ export class OrdersController {
 }
 ```
 
-## Step 4 — Replace client injection
+## Step 4: Replace client injection
 
 Before:
 
@@ -126,7 +126,7 @@ constructor(@Inject(getClientToken('payments')) private readonly client: ClientP
 
 `client.emit()` and `client.send()` keep their existing signatures.
 
-## Step 5 — Adjust for acknowledgment semantics
+## Step 5: Adjust for acknowledgment semantics
 
 JetStream is **at-least-once**. A message may be redelivered after a handler throws or a pod restarts mid-execution. Make handlers idempotent:
 
@@ -140,13 +140,13 @@ After migration, you get these capabilities for free:
 
 - Messages survive NATS server restarts.
 - Failed messages are automatically retried up to `max_deliver`.
-- Dead letter handling for exhausted retries — see [Dead Letter Queue](/docs/guides/dead-letter-queue).
-- Health checks with RTT monitoring — see [Health Checks](/docs/guides/health-checks).
-- Graceful shutdown with message drain — see [Graceful Shutdown](/docs/guides/graceful-shutdown).
-- Broadcast fan-out to all service instances — see [Broadcast Events](/docs/patterns/broadcast).
-- Ordered sequential delivery mode — see [Ordered Events](/docs/patterns/ordered-events).
-- W3C trace context end-to-end — see [Distributed Tracing](/docs/observability/tracing).
-- Prometheus metrics out of the box — see [Prometheus Metrics](/docs/observability/metrics).
+- Dead letter handling for exhausted retries: see [Dead Letter Queue](/docs/guides/dead-letter-queue).
+- Health checks with RTT monitoring: see [Health Checks](/docs/guides/health-checks).
+- Graceful shutdown with message drain: see [Graceful Shutdown](/docs/guides/graceful-shutdown).
+- Broadcast fan-out to all service instances: see [Broadcast Events](/docs/patterns/broadcast).
+- Ordered sequential delivery mode: see [Ordered Events](/docs/patterns/ordered-events).
+- W3C trace context end-to-end: see [Distributed Tracing](/docs/observability/tracing).
+- Prometheus metrics out of the box: see [Prometheus Metrics](/docs/observability/metrics).
 
 ## Upgrading between versions
 
@@ -154,18 +154,18 @@ After migration, you get these capabilities for free:
 
 **Behavior change: `stream.name` and `consumer.durable_name` overrides are now honored.**
 
-In previous releases, setting `stream.name` or `consumer.durable_name` inside a stream's `overrides` block was silently accepted but had no effect — the transport continued to derive names from its [naming conventions](/docs/reference/naming-conventions). Starting with v2.13, these fields are read and applied, so the library will use or create entities under the names you supply.
+In previous releases, setting `stream.name` or `consumer.durable_name` inside a stream's `overrides` block was silently accepted but had no effect: the transport continued to derive names from its [naming conventions](/docs/reference/naming-conventions). Starting with v2.13, these fields are read and applied, so the library will use or create entities under the names you supply.
 
 **What this means for you:**
 
-- If you intentionally set custom names to bind the library to externally provisioned infrastructure, this is the release that makes it work. Combined with the new `ManagementMode.Manual` / `provisioning.management` options, you can now run in full bind-only mode — see [Bring Your Own Infrastructure](/docs/guides/external-infrastructure).
-- If you had `stream.name` or `consumer.durable_name` set by accident (copy-pasted config, leftover experiments), the library will now attempt to use or create streams and consumers under those names instead of the convention-derived ones. **Review your `overrides` blocks before upgrading** — remove any unintentional name fields to keep the previous behavior.
+- If you intentionally set custom names to bind the library to externally provisioned infrastructure, this is the release that makes it work. Combined with the new `ManagementMode.Manual` / `provisioning.management` options, you can now run in full bind-only mode: see [Bring Your Own Infrastructure](/docs/guides/external-infrastructure).
+- If you had `stream.name` or `consumer.durable_name` set by accident (copy-pasted config, leftover experiments), the library will now attempt to use or create streams and consumers under those names instead of the convention-derived ones. **Review your `overrides` blocks before upgrading**: remove any unintentional name fields to keep the previous behavior.
 
 No other breaking changes. Applications that do not set `stream.name` or `consumer.durable_name` are unaffected.
 
 ## See also
 
-- [Installation](/docs/getting-started/installation) — setup requirements
-- [Module Configuration](/docs/reference/module-configuration) — full options reference
-- [Quick Start](/docs/getting-started/quick-start) — first handler in 5 minutes
-- [Release Notes](/docs/reference/release-notes) — version-by-version changelog
+- [Installation](/docs/getting-started/installation): setup requirements
+- [Module Configuration](/docs/reference/module-configuration): full options reference
+- [Quick Start](/docs/getting-started/quick-start): first handler in 5 minutes
+- [Release Notes](/docs/reference/release-notes): version-by-version changelog

--- a/website/docs/guides/migration.md
+++ b/website/docs/guides/migration.md
@@ -8,7 +8,7 @@ schema:
   headline: "How to migrate from @nestjs/microservices NATS to JetStream"
   description: "Step-by-step migration from the built-in NestJS NATS transport to durable JetStream-backed delivery."
   datePublished: "2026-03-26"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # How to migrate from `@nestjs/microservices` NATS to JetStream

--- a/website/docs/guides/per-message-ttl.md
+++ b/website/docs/guides/per-message-ttl.md
@@ -8,7 +8,7 @@ schema:
   headline: "How to set per-message TTL on NATS JetStream messages"
   description: "Set individual message expiration via the Nats-TTL header (NATS 2.11, ADR-43)."
   datePublished: "2026-04-02"
-  dateModified: "2026-05-27"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/guides/per-message-ttl.md
+++ b/website/docs/guides/per-message-ttl.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 sidebar_label: "Per-Message TTL"
-title: "How to set per-message TTL — NestJS JetStream"
+title: "How to set per-message TTL: NestJS JetStream"
 description: "Set individual NATS JetStream message expiration via the Nats-TTL header (NATS 2.11, ADR-43), independent of the stream's max_age."
 schema:
   type: Article
@@ -38,7 +38,7 @@ JetstreamModule.forRoot({
 });
 ```
 
-This flag can be safely added to existing streams — NATS applies it as a regular update without recreation or downtime.
+This flag can be safely added to existing streams, NATS applies it as a regular update without recreation or downtime.
 
 ## Usage
 
@@ -55,14 +55,14 @@ const record = new JetstreamRecordBuilder({ token: 'abc123', userId: 42 })
 await lastValueFrom(this.client.emit('session.token', record));
 ```
 
-The consumer handles it like any normal event — no changes needed on the receiving side. After 30 minutes, NATS automatically removes the message from the stream.
+The consumer handles it like any normal event: no changes needed on the receiving side. After 30 minutes, NATS automatically removes the message from the stream.
 
 ## Use cases
 
 | Scenario | TTL | Why |
 |----------|-----|-----|
 | Session tokens | 30 minutes | Auto-expire inactive sessions |
-| OTP codes | 5 minutes | Security — short-lived by design |
+| OTP codes | 5 minutes | Security: short-lived by design |
 | Cache entries | 1 hour | Stale cache auto-cleans |
 | Feature flags | 24 hours | Temporary overrides that self-remove |
 | Rate limit counters | 1 minute | Rolling window without cleanup jobs |
@@ -87,11 +87,11 @@ Per-message TTL works **independently** from stream `max_age`:
 - **Events only.** `ttl()` is ignored for RPC ([`client.send()`](/docs/patterns/rpc)); a warning is logged instead.
 - **NATS >= 2.11.** `allow_msg_ttl` is not supported by older server versions.
 - **Per-stream opt-in.** Each stream must have `allow_msg_ttl: true` explicitly.
-- **No consumer-side awareness.** Consumers don't know if a message has TTL — they process it normally before expiry.
+- **No consumer-side awareness.** Consumers don't know if a message has TTL: they process it normally before expiry.
 
 ## See also
 
-- [Record Builder & Deduplication](/docs/guides/record-builder) — full `JetstreamRecordBuilder` API including `.ttl()`, `.setMessageId()`, `.scheduleAt()`
-- [Scheduling (Delayed Jobs)](/docs/guides/scheduling) — the sibling feature for one-shot delayed delivery
-- [Default Configs](/docs/reference/default-configs#enable-only-can-be-turned-on-but-never-off) — `allow_msg_ttl` in the enable-only stream properties table
-- [Module Configuration](/docs/reference/module-configuration) — where to set `events.stream.allow_msg_ttl`
+- [Record Builder & Deduplication](/docs/guides/record-builder): full `JetstreamRecordBuilder` API including `.ttl()`, `.setMessageId()`, `.scheduleAt()`
+- [Scheduling (Delayed Jobs)](/docs/guides/scheduling): the sibling feature for one-shot delayed delivery
+- [Default Configs](/docs/reference/default-configs#enable-only-can-be-turned-on-but-never-off): `allow_msg_ttl` in the enable-only stream properties table
+- [Module Configuration](/docs/reference/module-configuration): where to set `events.stream.allow_msg_ttl`

--- a/website/docs/guides/performance.md
+++ b/website/docs/guides/performance.md
@@ -15,7 +15,7 @@ This guide covers how to tune the transport for high-throughput workloads. The m
 
 ## Backpressure & flow control
 
-Pull consumers provide **implicit backpressure** — the client controls how fast it pulls messages from the server. The transport never receives more messages than it can handle.
+Pull consumers provide **implicit backpressure**: the client controls how fast it pulls messages from the server. The transport never receives more messages than it can handle.
 
 The message flow through the system:
 
@@ -23,7 +23,7 @@ The message flow through the system:
 NATS Server -> pull consumer (max_ack_pending) -> consume() buffer -> RxJS mergeMap (concurrency) -> handler -> ack -> frees slot
 ```
 
-The primary flow control knob is `max_ack_pending` on the consumer. It limits how many messages can be in-flight (delivered but not yet acknowledged) at any time. When the limit is reached, the server stops delivering new messages until existing ones are acknowledged — creating natural backpressure.
+The primary flow control knob is `max_ack_pending` on the consumer. It limits how many messages can be in-flight (delivered but not yet acknowledged) at any time. When the limit is reached, the server stops delivering new messages until existing ones are acknowledged, creating natural backpressure.
 
 ### Configuration options
 
@@ -41,7 +41,7 @@ The primary flow control knob is `max_ack_pending` on the consumer. It limits ho
 - **`concurrency`** controls how many messages are processed in parallel by your handlers. If `concurrency` is lower than `max_ack_pending`, excess messages wait in the internal buffer.
 - **`consume.max_messages`** and **`consume.threshold_messages`** control the prefetch buffer; how many messages the `@nats-io/jetstream` client requests from the server in a single batch and when it requests more.
 
-For most workloads, tuning `max_ack_pending` and `concurrency` is sufficient.
+For most workloads, tuning `max_ack_pending` and `concurrency` is enough.
 
 ## Consume options
 
@@ -57,7 +57,7 @@ events: {
 }
 ```
 
-The `idle_heartbeat` option enables the server to send periodic heartbeats when there are no messages to deliver. This allows the client to detect broken connections and re-establish the subscription.
+The `idle_heartbeat` option enables the server to send periodic heartbeats when there are no messages to deliver. The client detects broken connections this way and re-establishes the subscription.
 
 ## Concurrency control
 
@@ -88,21 +88,21 @@ When enabled, the transport calls `msg.working()` at regular intervals (at half 
 
 **When to use:**
 - Handlers that call slow external APIs or run complex computations.
-- RPC handlers with long timeouts — `ackExtension` keeps the command message alive while the handler runs.
+- RPC handlers with long timeouts: `ackExtension` keeps the command message alive while the handler runs.
 
 **Interaction with RPC timeout:** For JetStream RPC, the RPC timeout determines how long the caller waits. The `ackExtension` keeps the server-side message alive independently. Both should be configured to accommodate the expected handler duration.
 
 ## S2 compression
 
-All streams default to [S2 compression](https://github.com/klauspost/compress/tree/master/s2) (a Snappy-compatible codec), reducing disk I/O and storage with modest CPU overhead. The actual cost varies with payload entropy, message size, and CPU — measure before assuming it's free. Requires **NATS Server >= 2.10**.
+All streams default to [S2 compression](https://github.com/klauspost/compress/tree/master/s2) (a Snappy-compatible codec), reducing disk I/O and storage with modest CPU overhead. The actual cost varies with payload entropy, message size, and CPU, measure before assuming it's free. Requires **NATS Server >= 2.10**.
 
-See [Default Configs — S2 Compression](/docs/reference/default-configs) for details and how to override per stream kind.
+See [Default Configs, S2 Compression](/docs/reference/default-configs) for details and how to override per stream kind.
 
 ## Connection defaults
 
-The transport configures unlimited reconnection attempts (`maxReconnectAttempts: -1`) and a 1-second reconnection interval by default. This ensures the application automatically recovers from transient network failures.
+The transport configures unlimited reconnection attempts (`maxReconnectAttempts: -1`) and a 1-second reconnection interval by default. The application recovers from transient network failures on its own.
 
-See [Default Configs — Connection Defaults](/docs/reference/default-configs#connection-defaults) for the full list and how to override.
+See [Default Configs, Connection Defaults](/docs/reference/default-configs#connection-defaults) for the full list and how to override.
 
 ## Complete example
 
@@ -140,24 +140,24 @@ This configuration:
 
 ## Performance expectations
 
-Published benchmark numbers for this library don't exist yet — any figures you see elsewhere are guesses. A real benchmark suite is planned (see the project issues), and this section will be updated with reproducible results when it lands.
+Published benchmark numbers for this library don't exist yet, any figures you see elsewhere are guesses. A real benchmark suite is planned (see the project issues), and this section will be updated with reproducible results when it lands.
 
 In the meantime, here is what you can rely on without numbers:
 
 - **The bottleneck is almost always the handler**, not the transport. Database writes, external API calls, and serialization dominate. Profile the handler first.
-- **Core NATS RPC is the lowest-latency path of the two RPC modes** — no stream write, no inbox routing. Use it when in-cluster latency is the priority.
+- **Core NATS RPC is the lowest-latency path of the two RPC modes**: no stream write, no inbox routing. Use it when in-cluster latency is the priority.
 - **JetStream RPC adds a stream persist plus an inbox reply** on top of Core NATS. You trade a fixed amount of added latency for the guarantee that the command survives a server restart. Quantify the trade-off on your own workload before planning around it.
-- **Event handler throughput scales with [`concurrency`](/docs/guides/performance#concurrency-control)** up to the point where your downstream dependencies become the bottleneck. CPU-bound handlers generally scale with core count; I/O-bound handlers benefit from higher concurrency and a larger `max_ack_pending`.
-- **Broadcast is not a throughput hit** — each instance processes its copy independently through its own consumer.
+- **Event handler throughput scales with [`concurrency`](/docs/guides/performance#concurrency-control)** up to the point where your downstream dependencies become the bottleneck. CPU-bound handlers generally scale with core count; I/O-bound handlers gain from higher concurrency and a larger `max_ack_pending`.
+- **Broadcast is not a throughput hit**: each instance processes its copy independently through its own consumer.
 
 ### Measuring your throughput
 
 1. **NATS monitoring:** Enable the [NATS monitoring endpoint](https://docs.nats.io/running-a-nats-service/configuration/monitoring) (`-m 8222`) and check `msgs_in`/`msgs_out` rates.
-2. **Consumer lag:** `nats consumer info <stream> <consumer>` — watch "Num Pending" to detect falling behind.
+2. **Consumer lag:** `nats consumer info <stream> <consumer>`: watch "Num Pending" to detect falling behind.
 3. **Application metrics:** Use [Lifecycle Hooks](/docs/guides/lifecycle-hooks) to emit Prometheus counters for `MessageRouted`, `Error`, and `RpcTimeout` events.
 
 ## See also
 
-- [Default Configs](/docs/reference/default-configs) — all stream, consumer, and connection defaults
-- [Module Configuration](/docs/reference/module-configuration) — where to set these options
-- [Troubleshooting](/docs/guides/troubleshooting#consumer-issues) — diagnosing consumer lag
+- [Default Configs](/docs/reference/default-configs): all stream, consumer, and connection defaults
+- [Module Configuration](/docs/reference/module-configuration): where to set these options
+- [Troubleshooting](/docs/guides/troubleshooting#consumer-issues): diagnosing consumer lag

--- a/website/docs/guides/performance.md
+++ b/website/docs/guides/performance.md
@@ -6,7 +6,7 @@ schema:
   headline: "Performance Tuning"
   description: "Tune ackWait, maxAckPending, batch sizes, and ack extension for high-throughput workloads."
   datePublished: "2026-03-26"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Performance Tuning

--- a/website/docs/guides/record-builder.md
+++ b/website/docs/guides/record-builder.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
 sidebar_label: "Record Builder"
-title: "JetstreamRecordBuilder — Headers, Message IDs & Deduplication"
+title: "JetstreamRecordBuilder: Headers, Message IDs & Deduplication"
 description: "Build NestJS NATS messages with custom headers, deterministic message IDs for publish-side deduplication, and per-request RPC timeouts."
 schema:
   type: Article
-  headline: "JetstreamRecordBuilder — Headers, Message IDs & Deduplication"
+  headline: "JetstreamRecordBuilder: Headers, Message IDs & Deduplication"
   description: "Build NestJS NATS messages with custom headers, deterministic message IDs for publish-side deduplication, and per-request RPC timeouts."
   datePublished: "2026-03-21"
   dateModified: "2026-06-12"
@@ -68,13 +68,13 @@ const record = new JetstreamRecordBuilder(data)
 
 <Since version="2.4.0" />
 
-JetStream has built-in **server-side deduplication**. When a message is published with a message ID, the server remembers that ID for a configurable time window. If a second message with the same ID arrives within the window, it is silently dropped — no duplicate processing occurs.
+JetStream has built-in **server-side deduplication**. When a message is published with a message ID, the server remembers that ID for a configurable time window. If a second message with the same ID arrives within the window, it is silently dropped: no duplicate processing occurs.
 
 ### How the dedup window works
 
 Each JetStream stream has a `duplicate_window` setting that controls how long the server remembers message IDs. The default window is **2 minutes** for event, broadcast, and ordered streams, and **30 seconds** for command (RPC) streams.
 
-If you do **not** set a message ID, the transport generates a random UUID for every publish. This means no deduplication by default — each publish is treated as a unique message.
+If you do not set a message ID, the transport generates a random UUID for every publish. Deduplication is so off by default: each publish counts as a unique message.
 
 ### Setting a deterministic message ID
 
@@ -91,7 +91,7 @@ await lastValueFrom(this.client.emit('order.created', record));
 Now if a network retry or application restart causes the same event to be published twice, the JetStream server drops the duplicate automatically.
 
 :::tip Choose IDs carefully
-Good message IDs are derived from business identifiers: `order-${orderId}`, `payment-${paymentId}-refund`, `user-${userId}-email-changed`. Avoid timestamps or random values — they defeat the purpose of deduplication.
+Good message IDs are derived from business identifiers: `order-${orderId}`, `payment-${paymentId}-refund`, `user-${userId}-email-changed`. Avoid timestamps or random values: they defeat the purpose of deduplication.
 :::
 
 :::warning Window expiration
@@ -129,7 +129,7 @@ const record = new JetstreamRecordBuilder({ orderId: 42, type: 'reminder' })
 await lastValueFrom(this.client.emit('order.reminder', record));
 ```
 
-Scheduling requires NATS Server >= 2.12 and `allow_msg_schedules: true` on the event stream. The consumer handles scheduled messages like any normal event — no changes needed on the receiving side.
+Scheduling requires NATS Server >= 2.12 and `allow_msg_schedules: true` on the event stream. The consumer handles scheduled messages like any normal event: no changes needed on the receiving side.
 
 :::note Events only
 `scheduleAt()` only works with `client.emit()`. If used with `client.send()` (RPC), the schedule is silently ignored and a warning is logged.
@@ -158,19 +158,19 @@ new JetstreamRecordBuilder(data)
 ```
 
 :::note
-The error is thrown on `setHeader()`, not on `build()`. This gives you immediate feedback at the call site.
+The error is thrown on `setHeader()`, not on `build()`. The failure surfaces at the call site.
 :::
 
 ## Auto-set transport headers
 
-In addition to reserved headers, the transport automatically sets two informational headers on every outbound message:
+Also to reserved headers, the transport automatically sets two informational headers on every outbound message:
 
 | Header | Value | Description |
 |---|---|---|
 | `x-subject` | NATS subject | The original subject the message was published to |
 | `x-caller-name` | Service name | The internal name of the sending service |
 
-These headers are read-only from the handler's perspective — you can access them via `ctx.getHeader('x-subject')` but cannot override them via the builder.
+These headers are read-only from the handler's perspective: you can access them via `ctx.getHeader('x-subject')` but cannot override them via the builder.
 
 ## API summary
 
@@ -221,8 +221,8 @@ if (RESERVED_HEADERS.has(key)) {
 
 ## Next steps
 
-- [Per-Message TTL](/docs/guides/per-message-ttl) — set individual message lifetimes via `.ttl()`
-- [Scheduling (Delayed Jobs)](/docs/guides/scheduling) — delay message delivery to a future time
-- [Handler Context](/docs/guides/handler-context) — access headers and message metadata in your handlers
-- [Custom Codec](/docs/guides/custom-codec) — control how payloads are serialized
-- [Module Configuration](/docs/reference/module-configuration) — configure dedup windows via stream overrides
+- [Per-Message TTL](/docs/guides/per-message-ttl): set individual message lifetimes via `.ttl()`
+- [Scheduling (Delayed Jobs)](/docs/guides/scheduling): delay message delivery to a future time
+- [Handler Context](/docs/guides/handler-context): access headers and message metadata in your handlers
+- [Custom Codec](/docs/guides/custom-codec): control how payloads are serialized
+- [Module Configuration](/docs/reference/module-configuration): configure dedup windows via stream overrides

--- a/website/docs/guides/record-builder.md
+++ b/website/docs/guides/record-builder.md
@@ -8,7 +8,7 @@ schema:
   headline: "JetstreamRecordBuilder: Headers, Message IDs & Deduplication"
   description: "Build NestJS NATS messages with custom headers, deterministic message IDs for publish-side deduplication, and per-request RPC timeouts."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/guides/scheduling.md
+++ b/website/docs/guides/scheduling.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 sidebar_label: "Scheduling (Delayed Jobs)"
-title: "How to schedule delayed messages — NestJS JetStream (NATS 2.12)"
+title: "How to schedule delayed messages: NestJS JetStream (NATS 2.12)"
 description: "One-shot delayed NestJS NATS JetStream message delivery via the Nats-Schedule header (NATS 2.12, ADR-51). Replace Bull or Agenda for simple delayed jobs."
 schema:
   type: Article
@@ -40,7 +40,7 @@ JetstreamModule.forRoot({
 });
 ```
 
-This flag is not enabled by default to maintain backward compatibility with NATS < 2.12. It can be safely added to existing streams — NATS applies it as a regular update without recreation or downtime.
+This flag is not enabled by default to maintain backward compatibility with NATS < 2.12. It can be safely added to existing streams, NATS applies it as a regular update without recreation or downtime.
 
 ## Usage
 
@@ -58,7 +58,7 @@ const record = new JetstreamRecordBuilder({ orderId: 42, type: 'reminder' })
 await lastValueFrom(this.client.emit('order.reminder', record));
 ```
 
-The consumer handles it like any normal event — no changes needed on the receiving side:
+The consumer handles it like any normal event: no changes needed on the receiving side:
 
 ```typescript
 @EventPattern('order.reminder')
@@ -70,8 +70,8 @@ handleReminder(@Payload() data: OrderReminder) {
 ## How it works
 
 1. `scheduleAt(date)` stores the delivery time in the record
-2. On publish, the library routes to a per-message unique `_sch` subject within the event stream (a library convention to separate scheduled messages from regular events). The unique suffix matters: the server stores schedules as rollup messages — one active schedule per subject ([ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md)) — so a shared subject would silently replace a pending schedule on every publish
-3. The publish includes `Nats-Schedule` and `Nats-Schedule-Target` headers (ADR-51) — the server uses these headers, not the subject, to manage scheduling
+2. On publish, the library routes to a per-message unique `_sch` subject within the event stream (a library convention to separate scheduled messages from regular events). The unique suffix matters: the server stores schedules as rollup messages: one active schedule per subject ([ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md)): so a shared subject would silently replace a pending schedule on every publish
+3. The publish includes `Nats-Schedule` and `Nats-Schedule-Target` headers (ADR-51): the server uses these headers, not the subject, to manage scheduling
 4. NATS holds the message until the scheduled time, then publishes a **new message** to the target event subject and purges the fired schedule holder, so unique `_sch` subjects do not accumulate
 5. The event consumer processes it normally
 
@@ -91,7 +91,7 @@ flowchart LR
 
 ## Important: `max_age` consideration
 
-Scheduled messages are stored in the event stream like any other message. If the stream's `max_age` expires before the scheduled delivery time, **NATS silently purges the message** — no delivery, no error.
+Scheduled messages are stored in the event stream like any other message. If the stream's `max_age` expires before the scheduled delivery time, **NATS silently purges the message**: no delivery, no error.
 
 The default event stream `max_age` is **7 days**. If you need to schedule messages further in the future, increase `max_age`:
 
@@ -99,7 +99,7 @@ The default event stream `max_age` is **7 days**. If you need to schedule messag
 events: {
   stream: {
     allow_msg_schedules: true,
-    max_age: 0, // no expiry — use when scheduling beyond 7 days
+    max_age: 0, // no expiry, use when scheduling beyond 7 days
   },
 },
 ```
@@ -123,16 +123,16 @@ If the stream is **externally managed** (`ManagementMode.Manual`), it must cover
 Stream "…" has scheduling enabled (allow_msg_schedules=true) but its subjects do not cover the schedule prefix "…". Add "…>" to the stream's subjects.
 ```
 
-For example, a stream with `subjects: ["company.orders.>"]` already covers `company.orders._sch.>` because the wildcard `>` matches any suffix. No additional entry is needed.
+For example, a stream with `subjects: ["company.orders.>"]` already covers `company.orders._sch.>` because the wildcard `>` matches any suffix. No extra entry is needed.
 
 If you used a prefix like `company.orders.events.` (narrower wildcard), you must add `company.orders._sch.>` explicitly or widen the wildcard.
 
-See [Bring Your Own Infrastructure — Scheduling with a custom prefix](/docs/guides/external-infrastructure#scheduling-with-a-custom-prefix) for a full provisioning example.
+See [Bring Your Own Infrastructure, Scheduling with a custom prefix](/docs/guides/external-infrastructure#scheduling-with-a-custom-prefix) for a full provisioning example.
 
 ## Limitations
 
 - **One-shot only.** No cron or interval scheduling. NATS supports these ([ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md)), but the library currently exposes only `scheduleAt()` for one-shot delivery.
-- **Workqueue events and broadcasts only.** `scheduleAt()` is ignored for RPC ([`client.send()`](/docs/patterns/rpc)) with a logged warning, and **throws** for [`ordered:` patterns](/docs/patterns/ordered-events) — the schedule holder cannot live in the same stream as an ordered target, which the server requires.
+- **Workqueue events and broadcasts only.** `scheduleAt()` is ignored for RPC ([`client.send()`](/docs/patterns/rpc)) with a logged warning, and **throws** for [`ordered:` patterns](/docs/patterns/ordered-events): the schedule holder cannot live in the same stream as an ordered target, which the server requires.
 - **Future dates only.** `scheduleAt()` throws if the date is not in the future.
 - **NATS >= 2.12.** `allow_msg_schedules` is not supported by older server versions.
 - **`max_age` constraint.** Schedule delay must not exceed the stream's `max_age`; the pending schedule is an ordinary stored message and expires with the stream's retention. Note the **broadcast stream default is 1 hour**: scheduling a broadcast further out requires raising its `max_age`.
@@ -141,7 +141,7 @@ See [Bring Your Own Infrastructure — Scheduling with a custom prefix](/docs/gu
 
 ## See also
 
-- [Record Builder & Deduplication](/docs/guides/record-builder#scheduled-delivery) — `JetstreamRecordBuilder.scheduleAt()` in the full builder API
-- [Per-Message TTL](/docs/guides/per-message-ttl) — sibling feature for per-message expiration
-- [Naming Conventions — Scheduling subjects](/docs/reference/naming-conventions#scheduling-subjects) — how the transport routes scheduled messages internally
-- [Default Configs](/docs/reference/default-configs#enable-only-can-be-turned-on-but-never-off) — `allow_msg_schedules` in the enable-only stream properties table
+- [Record Builder & Deduplication](/docs/guides/record-builder#scheduled-delivery): `JetstreamRecordBuilder.scheduleAt()` in the full builder API
+- [Per-Message TTL](/docs/guides/per-message-ttl): sibling feature for per-message expiration
+- [Naming Conventions: Scheduling subjects](/docs/reference/naming-conventions#scheduling-subjects): how the transport routes scheduled messages internally
+- [Default Configs](/docs/reference/default-configs#enable-only-can-be-turned-on-but-never-off): `allow_msg_schedules` in the enable-only stream properties table

--- a/website/docs/guides/scheduling.md
+++ b/website/docs/guides/scheduling.md
@@ -8,7 +8,7 @@ schema:
   headline: "How to schedule delayed messages with NestJS JetStream"
   description: "One-shot delayed message delivery via the Nats-Schedule header (NATS 2.12, ADR-51)."
   datePublished: "2026-04-01"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/guides/storage-budgeting.md
+++ b/website/docs/guides/storage-budgeting.md
@@ -8,7 +8,7 @@ schema:
   headline: "Storage budgeting & provisioning"
   description: "How JetStream stream reservations relate to the server max_file_store, and how to read the boot-time provisioning summary."
   datePublished: "2026-06-02"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Storage budgeting & provisioning

--- a/website/docs/guides/storage-budgeting.md
+++ b/website/docs/guides/storage-budgeting.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 6
 sidebar_label: "Storage budgeting"
-title: "Storage budgeting & provisioning — NestJS JetStream"
+title: "Storage budgeting & provisioning: NestJS JetStream"
 description: "How JetStream stream reservations relate to the server max_file_store, and how to read the boot-time provisioning summary."
 schema:
   type: Article
@@ -51,12 +51,12 @@ from this service alone.
 
 If a stream cannot be created, the transport throws a `JetstreamProvisioningError` with the
 stream name, the requested `max_bytes`/`num_replicas`, the reservation, the NATS `err_code` and
-description, and a remediation hint — instead of crashing with an opaque API error. Two common
+description, and a remediation hint, instead of crashing with an opaque API error. Two common
 cases:
 
-- **Insufficient storage** — the aggregate reservation exceeds `max_file_store`. Lower
+- **Insufficient storage**: the aggregate reservation exceeds `max_file_store`. Lower
   `max_bytes`/`num_replicas` for the service, or raise `max_file_store` on the servers.
-- **No suitable peers** — fewer healthy peers than `num_replicas`, or no peer with enough
+- **No suitable peers**: fewer healthy peers than `num_replicas`, or no peer with enough
   headroom. Reduce replicas or add/repair nodes.
 
 ## Opt-in pre-flight check
@@ -75,11 +75,11 @@ JetstreamModule.forRoot({
 
 This is a best-effort heuristic, not a guarantee:
 
-- The server-side `max_file_store` is **not** exposed to clients. If the account has no explicit
+- The server-side `max_file_store` is not exposed to clients. If the account has no explicit
   `max_storage` limit, the check logs that it cannot verify the real ceiling.
 - Account info is an aggregate, not per-node, so a cluster with skewed placement can still fail.
 - It is subject to a check-then-act race with other services.
 
-Setting an **account-level** `max_storage` (in addition to, or instead of, the server
+Setting an **account-level** `max_storage` (besides, or instead of, the server
 `max_file_store`) makes the pre-flight accurate and admission control predictable. Either way, the
 `JetstreamProvisioningError` on the actual failure remains the source of truth.

--- a/website/docs/guides/stream-migration.md
+++ b/website/docs/guides/stream-migration.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 sidebar_label: "Stream Migration"
-title: "How to migrate immutable stream properties — NestJS JetStream"
+title: "How to migrate immutable stream properties: NestJS JetStream"
 description: "Safely change immutable NATS JetStream stream properties (storage, retention) without losing messages, via automatic blue-green sourcing."
 schema:
   type: Article
@@ -21,15 +21,15 @@ Safely change immutable stream properties (like `storage`) without losing messag
 
 ## When is migration needed?
 
-Most stream config changes are **mutable** — the transport applies them on startup via a simple update. No downtime, no message loss. See the [full property classification](/docs/reference/default-configs#immutable-vs-mutable-stream-properties).
+Most stream config changes are **mutable**: the transport applies them on startup via a simple update. No downtime, no message loss. See the [full property classification](/docs/reference/default-configs#immutable-vs-mutable-stream-properties).
 
 Migration is only needed for **immutable** properties that NATS locks after stream creation:
 
 | Property | Example change | Requires migration |
 |----------|---------------|-------------------|
 | `storage` | `File` -> `Memory` | **Yes** |
-| `retention` | `Workqueue` -> `Limits` | **Not allowed** — controlled by the transport |
-| `max_age`, `num_replicas`, etc. | Any value | No — mutable, updated automatically |
+| `retention` | `Workqueue` -> `Limits` | **Not allowed**: controlled by the transport |
+| `max_age`, `num_replicas`, etc. | Any value | No: mutable, updated automatically |
 
 ## How to enable
 
@@ -51,7 +51,7 @@ Without `allowDestructiveMigration`, the transport logs a warning and continues 
 
 ## How it works
 
-The transport uses **blue-green recreation** via [NATS stream sourcing](https://docs.nats.io/nats-concepts/jetstream/streams#sources) — a server-side message copy mechanism that preserves all messages:
+The transport uses **blue-green recreation** via [NATS stream sourcing](https://docs.nats.io/nats-concepts/jetstream/streams#sources), a server-side message copy mechanism that preserves all messages:
 
 ```text
 Phase 1/4  Quiesce: remove the original's subjects
@@ -69,25 +69,25 @@ Phase 4/4  Original ← sourcing ← backup
 
 The stream keeps its original name. Consumers are recreated automatically after migration by each pod's startup sequence or self-healing.
 
-Every acknowledged publish is preserved: a producer either gets a successful ack (the message survives the migration) or a loud rejection it can retry — never an ack for a message that later disappears.
+Every acknowledged publish is preserved: a producer either gets a successful ack (the message survives the migration) or a loud rejection it can retry, never an ack for a message that later disappears.
 
 ### Backup stream as a distributed lock
 
 During migration, the backup stream (`{stream}__migration_backup`) serves a dual purpose:
 
 1. **Temporary message storage** between delete and recreate
-2. **Distributed lock** — other pods' self-healing detects the backup and waits instead of recreating consumers, preventing interference with message restoration
+2. **Distributed lock**: other pods' self-healing detects the backup and waits instead of recreating consumers, preventing interference with message restoration
 
 ## What happens during migration
 
 ### To publishers
 
-From the quiesce (Phase 1) until the restore completes, publishes to the migrating stream are **rejected** — the subject has no stream behind it, so producers receive "no stream matches subject" / no-responders errors.
+From the quiesce (Phase 1) until the restore completes, publishes to the migrating stream are **rejected**: the subject has no stream behind it, so producers receive "no stream matches subject" / no-responders errors.
 
-- **`client.emit()`** (fire-and-forget) — the publish rejects with an error. Implement retry logic in the caller if you need delivery during migration.
-- **`client.send()`** (RPC) — the caller receives an error and can retry.
+- **`client.emit()`** (fire-and-forget): the publish rejects with an error. Implement retry logic in the caller if you need delivery during migration.
+- **`client.send()`** (RPC): the caller receives an error and can retry.
 
-The rejection window lasts as long as the message copy does — milliseconds for small streams. This is deliberate: a rejected publish is retryable, while an acknowledged write into a stream that is about to be deleted would be silent data loss. If you need a zero-rejection migration, schedule it during a maintenance window with publishers paused.
+The rejection window lasts as long as the message copy does, milliseconds for small streams. This is deliberate: a rejected publish is retryable, while an acknowledged write into a stream that is about to be deleted would be silent data loss. If you need a zero-rejection migration, schedule it during a maintenance window with publishers paused.
 
 ### To consumers on other pods (rolling updates)
 
@@ -98,8 +98,8 @@ When one pod migrates the stream, other pods' consumers break because the stream
 3. Migration completes → backup deleted → next retry creates consumer → consumption resumes
 
 This prevents two critical issues:
-- **Config overwrite** — old pods cannot overwrite a newer pod's consumer configuration
-- **Message consumption during restore** — consumers cannot eat messages from the workqueue while they're being sourced back
+- **Config overwrite**: old pods cannot overwrite a newer pod's consumer configuration
+- **Message consumption during restore**: consumers cannot eat messages from the workqueue while they're being sourced back
 
 ### To the migrating pod itself
 
@@ -107,13 +107,13 @@ The pod that triggers migration blocks during startup until all phases complete.
 
 ## Performance
 
-Migration speed depends on message count, message size, and NATS server performance. Stream sourcing is a server-side operation — no messages travel back over the network — so throughput is bounded by the NATS server's disk or memory, not the transport.
+Migration speed depends on message count, message size, and NATS server performance. Stream sourcing is a server-side operation (no messages travel back over the network) so throughput is bounded by the NATS server's disk or memory, not the transport.
 
-Expect migration time to scale roughly linearly with message count. For small streams (thousands of messages) the migration is effectively instantaneous from an operator's standpoint; for very large streams (hundreds of thousands or more), measure on your own hardware before scheduling a rolling update. Proper benchmarks will be published alongside the broader performance suite.
+Expect migration time to scale roughly linearly with message count. For small streams (thousands of messages) the migration is effectively instantaneous from an operator's standpoint; for large streams (hundreds of thousands or more), measure on your own hardware before scheduling a rolling update. Proper benchmarks will be published alongside the broader performance suite.
 
 ## Error handling
 
-- **Failure before the original is deleted.** The quiesce is rolled back (subjects restored), the backup is removed, and an error is thrown — the original stream is intact and serving traffic.
+- **Failure before the original is deleted.** The quiesce is rolled back (subjects restored), the backup is removed, and an error is thrown: the original stream is intact and serving traffic.
 - **Failure after the original is deleted.** The backup is the only copy of the data and is always preserved. Restoration resumes automatically on the next application startup.
 - **Sourcing timeout (30s default).** Same as above: the backup is preserved and the restore resumes on the next startup. Nothing is lost.
 - **Process killed mid-migration.** Detected on the next startup: a stranded backup is restored into the stream (recreating it first if the crash happened between delete and create), then cleaned up.
@@ -123,10 +123,10 @@ Expect migration time to scale roughly linearly with message count. For small st
 
 Streams managed in `ManagementMode.Manual` (externally provisioned) are never created, updated, or migrated by the library; regardless of `allowDestructiveMigration`. The library only binds to them and validates their configuration at boot.
 
-Setting `allowDestructiveMigration: true` together with a global `provisioning.management: ManagementMode.Manual` is therefore a no-op for all streams. The library logs a warning at boot when this combination is detected:
+Setting `allowDestructiveMigration: true` together with a global `provisioning.management: ManagementMode.Manual` is so a no-op for all streams. The library logs a warning at boot when this combination is detected:
 
 ```
-allowDestructiveMigration has no effect under provisioning.management: Manual — the library never migrates externally managed streams.
+allowDestructiveMigration has no effect under provisioning.management: Manual, the library never migrates externally managed streams.
 ```
 
 If you use **mixed ownership** (some streams Auto, some Manual), `allowDestructiveMigration` applies only to the Auto-managed streams.
@@ -137,8 +137,8 @@ See [Bring Your Own Infrastructure](/docs/guides/external-infrastructure) for th
 
 - **`retention` is not migratable.** It is controlled by the transport (`Workqueue` for events/commands, `Limits` for broadcast/ordered). A mismatch always throws an error on startup.
 - **The publisher gap is inherent.** NATS does not support atomic stream rename or swap. The millisecond window between delete and create cannot be eliminated.
-- **`allowDestructiveMigration` applies to all service-owned streams.** It's a single flag at the module level — if any of them has an immutable conflict, it will be migrated.
-- **The shared broadcast stream is never destructively migrated.** `broadcast-stream` is shared by every service in the cluster; recreating it would delete other services' durable consumers and replay retained history to them. An immutable conflict on it throws an error instead — coordinate that change manually.
+- **`allowDestructiveMigration` applies to all service-owned streams.** It's a single flag at the module level: if any of them has an immutable conflict, it will be migrated.
+- **The shared broadcast stream is never destructively migrated.** `broadcast-stream` is shared by every service in the cluster; recreating it would delete other services' durable consumers and replay retained history to them. An immutable conflict on it throws an error instead: coordinate that change manually.
 - **Manual streams are never migrated.** See the section above.
 
 ## Example: switching to in-memory streams
@@ -146,13 +146,13 @@ See [Bring Your Own Infrastructure](/docs/guides/external-infrastructure) for th
 A common use case is switching from `File` (persistent disk) to `Memory` (RAM) storage for lower latency in development or staging:
 
 ```typescript
-// Before — File storage (default)
+// Before, File storage (default)
 JetstreamModule.forRoot({
   name: 'orders',
   servers: ['nats://localhost:4222'],
 });
 
-// After — Memory storage with migration enabled
+// After, Memory storage with migration enabled
 JetstreamModule.forRoot({
   name: 'orders',
   servers: ['nats://localhost:4222'],
@@ -163,10 +163,10 @@ JetstreamModule.forRoot({
 });
 ```
 
-After all pods restart with the new config, you can remove `allowDestructiveMigration` — it's only needed for the migration itself:
+After all pods restart with the new config, you can remove `allowDestructiveMigration`: it's only needed for the migration itself:
 
 ```typescript
-// After migration — remove the flag
+// After migration, remove the flag
 JetstreamModule.forRoot({
   name: 'orders',
   servers: ['nats://localhost:4222'],
@@ -178,7 +178,7 @@ JetstreamModule.forRoot({
 
 ## See also
 
-- [Default Configs — Immutable vs mutable stream properties](/docs/reference/default-configs#immutable-vs-mutable-stream-properties) — which properties require migration
-- [Self-healing consumers](/docs/reference/edge-cases#consumer-self-healing) — how consumers on other pods wait out a migration
-- [Troubleshooting — Stream migration](/docs/guides/troubleshooting#stream-migration) — recovery from interrupted migrations
-- [Module Configuration](/docs/reference/module-configuration) — `allowDestructiveMigration` in the options reference
+- [Default Configs: Immutable vs mutable stream properties](/docs/reference/default-configs#immutable-vs-mutable-stream-properties): which properties require migration
+- [Self-healing consumers](/docs/reference/edge-cases#consumer-self-healing): how consumers on other pods wait out a migration
+- [Troubleshooting: Stream migration](/docs/guides/troubleshooting#stream-migration): recovery from interrupted migrations
+- [Module Configuration](/docs/reference/module-configuration): `allowDestructiveMigration` in the options reference

--- a/website/docs/guides/stream-migration.md
+++ b/website/docs/guides/stream-migration.md
@@ -8,7 +8,7 @@ schema:
   headline: "How to migrate immutable stream properties"
   description: "Safely change immutable stream properties without losing messages via blue-green sourcing."
   datePublished: "2026-04-02"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -8,7 +8,7 @@ schema:
   headline: "Troubleshooting: NestJS JetStream Transport"
   description: "Fix common NestJS JetStream issues: NATS connection errors, consumer lag, RPC timeouts, DLQ publish failures, and stream migration recovery."
   datePublished: "2026-03-26"
-  dateModified: "2026-04-11"
+  dateModified: "2026-07-26"
 ---
 
 # Troubleshooting

--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 6
 sidebar_label: "Troubleshooting"
-title: "Troubleshooting — NestJS JetStream Transport"
+title: "Troubleshooting: NestJS JetStream Transport"
 description: "Fix common NestJS JetStream issues: NATS connection errors, consumer lag, RPC timeouts, DLQ publish failures, and stream migration recovery."
 schema:
   type: Article
-  headline: "Troubleshooting — NestJS JetStream Transport"
+  headline: "Troubleshooting: NestJS JetStream Transport"
   description: "Fix common NestJS JetStream issues: NATS connection errors, consumer lag, RPC timeouts, DLQ publish failures, and stream migration recovery."
   datePublished: "2026-03-26"
   dateModified: "2026-04-11"
@@ -13,7 +13,7 @@ schema:
 
 # Troubleshooting
 
-If something isn't working, start here. The sections below are grouped by symptom — scan them before opening an issue.
+If something isn't working, start here. The sections below are grouped by symptom, scan them before opening an issue.
 
 ## Connection errors
 
@@ -70,11 +70,11 @@ The transport defaults to unlimited reconnection (`maxReconnectAttempts: -1`). I
 ### Messages not being delivered
 
 **Checklist:**
-1. **Handler registered?** — Check startup logs for `Registered handlers: X RPC, Y events, Z broadcasts` (plus `N ordered` when ordered handlers are present). A zero count means the decorator didn't hit the registry — usually an import-order or module-wiring problem.
-2. **Stream exists?** — The transport creates streams on startup. Check with `nats stream ls`.
-3. **Consumer exists?** — Check with `nats consumer ls <stream-name>`.
-4. **Subject matches?** — Use `nats sub "servicename__microservice.ev.>"` to see if messages arrive on the expected subject.
-5. **Publisher-only mode?** — If `consumer: false` is set, no handlers are registered.
+1. **Handler registered?**: Check startup logs for `Registered handlers: X RPC, Y events, Z broadcasts` (plus `N ordered` when ordered handlers are present). A zero count means the decorator didn't hit the registry, which points to an import-order or module-wiring problem.
+2. **Stream exists?**: The transport creates streams on startup. Check with `nats stream ls`.
+3. **Consumer exists?**: Check with `nats consumer ls <stream-name>`.
+4. **Subject matches?**: Use `nats sub "servicename__microservice.ev.>"` to see if messages arrive on the expected subject.
+5. **Publisher-only mode?**: If `consumer: false` is set, no handlers are registered.
 
 ### Messages redelivered unexpectedly
 
@@ -96,7 +96,7 @@ If your consumer is falling behind (messages accumulating faster than they're pr
 
 1. **Increase concurrency:** `events: { concurrency: 200 }`
 2. **Increase `max_ack_pending`:** `consumer: { max_ack_pending: 500 }`
-3. **Scale horizontally:** Deploy more instances — each gets a share of the workqueue messages.
+3. **Scale horizontally:** Deploy more instances: each gets a share of the workqueue messages.
 4. **Check handler performance:** Profile your handlers. Database queries, external API calls, and heavy computations are common bottlenecks.
 
 Monitor lag with the NATS CLI:
@@ -108,13 +108,13 @@ nats consumer info <stream> <consumer> | grep "Num Pending"
 
 ### `RPC timeout` errors
 
-The caller didn't receive a response within the timeout period.
+The caller didn't receive a response before the timeout expired.
 
 **Causes:**
 - Handler is slow or stuck
 - No handler registered for the pattern
 - Network partition between publisher and consumer
-- Wrong RPC mode — publisher uses `core` but handler expects `jetstream` (or vice versa)
+- Wrong RPC mode: publisher uses `core` but handler expects `jetstream` (or vice versa)
 
 **Diagnosis:**
 ```typescript
@@ -156,11 +156,11 @@ The callback only fires when **all** of these conditions are met:
 
 ### DLQ callback throws
 
-If your `onDeadLetter` callback throws, the message is nak'd for another retry instead of being terminated. This is intentional — it allows transient failures (e.g., DLQ database is down) to recover.
+If your `onDeadLetter` callback throws, the message is nak'd for another retry instead of being terminated. This is intentional: it allows transient failures (e.g., DLQ database is down) to recover.
 
 ### DLQ stream publish fails
 
-When `dlq: { stream }` is configured, the transport republishes exhausted messages to a dedicated DLQ stream. If that publish fails, the transport falls back to the `onDeadLetter` callback and then to `nak()` as a last resort — the full sequence is documented in the [Fallback chain](/docs/guides/dead-letter-queue#fallback-chain).
+When `dlq: { stream }` is configured, the transport republishes exhausted messages to a dedicated DLQ stream. If that publish fails, the transport falls back to the `onDeadLetter` callback and then to `nak()` as a last resort: the full sequence is documented in the [Fallback chain](/docs/guides/dead-letter-queue#fallback-chain).
 
 **Causes:**
 - DLQ stream was deleted manually (`nats stream rm orders__microservice_dlq-stream`)
@@ -169,7 +169,7 @@ When `dlq: { stream }` is configured, the transport republishes exhausted messag
 
 **Fix:**
 1. Check that the DLQ stream exists: `nats stream ls | grep dlq-stream`
-2. If it was deleted, restart the pod — the transport's `ensureDlqStream()` recreates it on startup when `dlq` is configured
+2. If it was deleted, restart the pod: the transport's `ensureDlqStream()` recreates it on startup when `dlq` is configured
 3. Check NATS server disk usage: `nats server report accounts`
 4. Ensure the `dlq.stream` config (if overridden) is compatible with the server's resource limits
 
@@ -177,7 +177,7 @@ When `dlq: { stream }` is configured, the transport republishes exhausted messag
 
 ### Entries missing from the KV bucket
 
-The transport only publishes handler metadata when the handler has a `meta` field in its decorator extras. Handlers without `meta` are intentionally skipped — see [Handler Metadata](/docs/patterns/handler-metadata) for the quick-start example.
+The transport only publishes handler metadata when the handler has a `meta` field in its decorator extras. Handlers without `meta` are intentionally skipped, see [Handler Metadata](/docs/patterns/handler-metadata) for the quick-start example.
 
 **Checklist:**
 1. Does the handler have `meta: { ... }` in `@EventPattern` / `@MessagePattern`?
@@ -189,7 +189,7 @@ The transport only publishes handler metadata when the handler has a `meta` fiel
 
 NATS KV buckets have immutable config for some fields (`replicas`, `ttl`). If you change these in `forRoot()` after the bucket already exists, startup fails.
 
-**Fix:** Delete your configured metadata bucket — the default name is `handler_registry`, but if you overrode `metadata.bucket` in `forRoot()`, substitute your own. Entries are re-published on the next startup, so the delete is safe.
+**Fix:** Delete your configured metadata bucket: the default name is `handler_registry`, but if you overrode `metadata.bucket` in `forRoot()`, substitute your own. Entries are re-published on the next startup, so the delete is safe.
 
 ```bash
 # Replace `handler_registry` with your metadata.bucket value if you overrode it
@@ -202,16 +202,16 @@ nats kv rm handler_registry
 
 ### Consumer self-healing waits on "migration in progress"
 
-If a previous migration was interrupted (process killed mid-phase, NATS crash), an orphaned `{stream}__migration_backup` stream exists. During **consumer self-healing** (after a live consumer's iterator breaks), the transport detects the backup stream and refuses to recreate the consumer until the backup is gone — the self-healing loop waits with exponential backoff. This check runs only in the recovery path, not during initial application startup.
+If a previous migration was interrupted (process killed mid-phase, NATS crash), an orphaned `{stream}__migration_backup` stream exists. During **consumer self-healing** (after a live consumer's iterator breaks), the transport detects the backup stream and refuses to recreate the consumer until the backup is gone: the self-healing loop waits with exponential backoff. This check runs only in the recovery path, not during initial application startup.
 
 **Diagnosis:**
 ```bash
 nats stream ls | grep migration_backup
 ```
 
-**Fix:** None needed in most cases — self-healing will recover automatically once the migrating pod finishes and cleans up the backup. If the backup is orphaned permanently (the migrating pod died and nobody retried), manually inspect it and either retain it (if it contains messages you need) or delete it with `nats stream rm <stream>__migration_backup` so self-healing can resume.
+**Fix:** None needed in most cases, self-healing will recover automatically once the migrating pod finishes and cleans up the backup. If the backup is orphaned permanently (the migrating pod died and nobody retried), manually inspect it and either retain it (if it contains messages you need) or delete it with `nats stream rm <stream>__migration_backup` so self-healing can resume.
 
-See [Stream Migration — Error handling](/docs/guides/stream-migration#error-handling) for the full recovery flow.
+See [Stream Migration, Error handling](/docs/guides/stream-migration#error-handling) for the full recovery flow.
 
 ### Publisher errors during rolling update
 
@@ -226,8 +226,8 @@ During the brief window between Phase 2 (delete) and Phase 3 (create) of a strea
 ### `listen() hangs` on startup
 
 If the application doesn't finish starting:
-1. **Ordered consumer can't connect** — The stream might not exist yet. Check that the ordered stream is created before the consumer tries to connect.
-2. **NATS connection timeout** — The initial connection attempt blocks startup.
+1. **Ordered consumer can't connect**: The stream might not exist yet. Check that the ordered stream is created before the consumer tries to connect.
+2. **NATS connection timeout**: The initial connection attempt blocks startup.
 
 ### `Stream already exists with different config`
 
@@ -255,11 +255,11 @@ try {
   const code = (err as { code?: number }).code;
 
   if (code === NatsErrorCode.StreamNotFound) {
-    // 10059 — stream does not exist yet, safe to create
+    // 10059, stream does not exist yet, safe to create
   } else if (code === NatsErrorCode.ConsumerNotFound) {
-    // 10014 — consumer was deleted externally
+    // 10014, consumer was deleted externally
   } else if (code === NatsErrorCode.ConsumerAlreadyExists) {
-    // 10148 — race on consumer create, fetch the existing one instead
+    // 10148, race on consumer create, fetch the existing one instead
   } else {
     throw err;
   }
@@ -270,7 +270,7 @@ The library itself uses these constants in its self-healing flows (`src/server/i
 
 ## See also
 
-- [Lifecycle Hooks](/docs/guides/lifecycle-hooks) — register hooks for observability
-- [Health Checks](/docs/guides/health-checks) — monitor connection status
-- [Default Configs](/docs/reference/default-configs) — all default values
-- [Edge Cases](/docs/reference/edge-cases) — less obvious behaviors
+- [Lifecycle Hooks](/docs/guides/lifecycle-hooks): register hooks for observability
+- [Health Checks](/docs/guides/health-checks): monitor connection status
+- [Default Configs](/docs/reference/default-configs): all default values
+- [Edge Cases](/docs/reference/edge-cases): less obvious behaviors

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -2,11 +2,11 @@
 slug: /
 sidebar_position: 1
 sidebar_label: "Introduction"
-title: "NestJS NATS Transport with JetStream — Introduction"
+title: "NestJS NATS Transport with JetStream: Introduction"
 description: "A NestJS NATS microservice transport backed by JetStream: durable events, broadcast, ordered delivery, RPC, and dead letter queues."
 schema:
   type: Article
-  headline: "NestJS NATS Transport with JetStream — Introduction"
+  headline: "NestJS NATS Transport with JetStream: Introduction"
   description: "A NestJS NATS microservice transport backed by JetStream: durable events, broadcast, ordered delivery, RPC, and dead letter queues."
   datePublished: "2026-03-21"
   dateModified: "2026-04-11"
@@ -14,9 +14,9 @@ schema:
 
 # Introduction
 
-NestJS' [built-in NATS transport](https://docs.nestjs.com/microservices/nats) loses messages on pod restart, doesn't retry on failure, and gives you nothing to debug with. [JetStream](https://docs.nats.io/nats-concepts/jetstream) fixes all three — but wiring it into NestJS by hand is a project on its own.
+NestJS' [built-in NATS transport](https://docs.nestjs.com/microservices/nats) loses messages on pod restart, doesn't retry on failure, and gives you nothing to debug with. [JetStream](https://docs.nats.io/nats-concepts/jetstream) fixes all three, but wiring it into NestJS by hand is a project on its own.
 
-**`nestjs-jetstream` is the swap.** Same `@EventPattern`, same `@MessagePattern`, same `client.emit()`. Durability, retries, dead letters, and W3C tracing — underneath, automatic.
+**`nestjs-jetstream` is the swap.** Same `@EventPattern`, same `@MessagePattern`, same `client.emit()`. Durability, retries, dead letters, and W3C tracing, underneath, automatic.
 
 For a side-by-side with the built-in transport and the scenarios that force the switch, read [**Why JetStream?**](/docs/getting-started/why-jetstream).
 
@@ -24,13 +24,13 @@ For a side-by-side with the built-in transport and the scenarios that force the 
 
 Pick an entry point based on where you are in your journey:
 
-- **New to the library?** — [Installation](/docs/getting-started/installation) → [Quick Start](/docs/getting-started/quick-start)
-- **Comparing transports?** — [Why JetStream?](/docs/getting-started/why-jetstream) covers when Core NATS is enough and when you outgrow it
-- **Migrating from `@nestjs/microservices` NATS?** — [Migration Guide](/docs/guides/migration)
-- **Planning a production rollout?** — [Module Configuration](/docs/reference/module-configuration), [Dead Letter Queue](/docs/guides/dead-letter-queue), [Graceful Shutdown](/docs/guides/graceful-shutdown), [Health Checks](/docs/guides/health-checks), [Performance Tuning](/docs/guides/performance)
-- **Looking for a specific delivery pattern?** — [Workqueue Events](/docs/patterns/events), [RPC (Request/Reply)](/docs/patterns/rpc), [Broadcast](/docs/patterns/broadcast), [Ordered Events](/docs/patterns/ordered-events)
+- **New to the library?**: [Installation](/docs/getting-started/installation) → [Quick Start](/docs/getting-started/quick-start)
+- **Comparing transports?**: [Why JetStream?](/docs/getting-started/why-jetstream) covers when Core NATS is enough and when you outgrow it
+- **Migrating from `@nestjs/microservices` NATS?**: [Migration Guide](/docs/guides/migration)
+- **Planning a production rollout?**: [Module Configuration](/docs/reference/module-configuration), [Dead Letter Queue](/docs/guides/dead-letter-queue), [Graceful Shutdown](/docs/guides/graceful-shutdown), [Health Checks](/docs/guides/health-checks), [Performance Tuning](/docs/guides/performance)
+- **Looking for a specific delivery pattern?**: [Workqueue Events](/docs/patterns/events), [RPC (Request/Reply)](/docs/patterns/rpc), [Broadcast](/docs/patterns/broadcast), [Ordered Events](/docs/patterns/ordered-events)
 
-The full feature catalog lives in the sidebar on the left — every page is one click away.
+The full feature catalog lives in the sidebar on the left: every page is one click away.
 
 :::tip Runnable examples
 The GitHub repository ships [9 self-contained demos](https://github.com/HorizonRepublic/nestjs-jetstream/tree/main/examples) covering events, RPC, ordered delivery, DLQ, health checks, scheduling, publisher-only mode, per-message TTL, and the handler metadata registry. Clone and run.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -9,7 +9,7 @@ schema:
   headline: "NestJS NATS Transport with JetStream: Introduction"
   description: "A NestJS NATS microservice transport backed by JetStream: durable events, broadcast, ordered delivery, RPC, and dead letter queues."
   datePublished: "2026-03-21"
-  dateModified: "2026-04-11"
+  dateModified: "2026-07-26"
 ---
 
 # Introduction

--- a/website/docs/observability/index.md
+++ b/website/docs/observability/index.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 0
 sidebar_label: "Overview"
-title: "Observability — NestJS JetStream Transport"
+title: "Observability: NestJS JetStream Transport"
 description: "Built-in distributed tracing and Prometheus metrics for NATS JetStream. Trace individual messages end-to-end across services, and alert on aggregate health from a single /metrics endpoint."
 schema:
   type: Article
-  headline: "Observability — NestJS JetStream Transport"
+  headline: "Observability: NestJS JetStream Transport"
   description: "Distributed tracing and Prometheus metrics built into the transport. Zero-config integration with OpenTelemetry SDKs and prom-client-based exporters."
   datePublished: "2026-05-27"
   dateModified: "2026-06-12"
@@ -15,15 +15,15 @@ schema:
 
 The transport ships with two complementary observability surfaces. Both work out of the box, both are designed for production, and both stay invisible when you don't need them.
 
-[**Distributed tracing →**](/docs/observability/tracing) — answers "where did this one request go, and where did it slow down?" Backed by OpenTelemetry spans with W3C Trace Context propagation across services.
+[**Distributed tracing →**](/docs/observability/tracing), answers "where did this one request go, and where did it slow down?" Backed by OpenTelemetry spans with W3C Trace Context propagation across services.
 
-[**Prometheus metrics →**](/docs/observability/metrics) — answers "is the system healthy in aggregate? What should I alert on?" Backed by `prom-client` counters, histograms, and gauges written to a registry your exporter already serves.
+[**Prometheus metrics →**](/docs/observability/metrics), answers "is the system healthy in aggregate? What should I alert on?" Backed by `prom-client` counters, histograms, and gauges written to a registry your exporter already serves.
 
 ## Picking what you need
 
 **Reach for tracing when** debugging a specific request: a slow order, a dropped event, an RPC that failed in a weird way. A single trace shows the full path through `client.emit() -> consumer -> handler -> reply` across every service that touched the message.
 
-**Reach for metrics when** running the system day to day: alert if consumer lag exceeds a threshold, dashboard p99 handler latency over time, get paged when the error rate spikes. Aggregated numbers — not individual requests — are what you want here.
+**Reach for metrics when** running the system day to day: alert if consumer lag exceeds a threshold, dashboard p99 handler latency over time, get paged when the error rate spikes. Aggregated numbers (not individual requests) are what you want here.
 
 Both surfaces complement each other. Most production deployments enable both: traces feed an APM (Sentry, Datadog, Jaeger, Tempo, Honeycomb), metrics feed a Prometheus + Grafana stack, and alerts route through both depending on whether the symptom is "this one request" or "the whole system."
 
@@ -39,8 +39,8 @@ You can enable either independently, or both. They share the same `EventBus` for
 ## Quick start
 
 ```ts
-// 1. Tracing — register any OpenTelemetry SDK before your AppModule loads.
-// Sentry, Datadog, NewRelic, or @opentelemetry/sdk-node — pick one.
+// 1. Tracing, register any OpenTelemetry SDK before your AppModule loads.
+// Sentry, Datadog, NewRelic, or @opentelemetry/sdk-node, pick one.
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 new NodeSDK({
@@ -48,7 +48,7 @@ new NodeSDK({
   traceExporter: new OTLPTraceExporter({ url: 'http://collector:4318/v1/traces' }),
 }).start();
 
-// 2. Metrics — enable in forRoot.
+// 2. Metrics, enable in forRoot.
 import { PrometheusModule } from '@willsoto/nestjs-prometheus';
 import { JetstreamModule } from '@horizon-republic/nestjs-jetstream';
 

--- a/website/docs/observability/index.md
+++ b/website/docs/observability/index.md
@@ -8,7 +8,7 @@ schema:
   headline: "Observability: NestJS JetStream Transport"
   description: "Distributed tracing and Prometheus metrics built into the transport. Zero-config integration with OpenTelemetry SDKs and prom-client-based exporters."
   datePublished: "2026-05-27"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Observability

--- a/website/docs/observability/metrics.md
+++ b/website/docs/observability/metrics.md
@@ -8,7 +8,7 @@ schema:
   headline: "Prometheus Metrics: NestJS JetStream Transport"
   description: "Production-ready Prometheus metrics for NATS JetStream transport: throughput, handler latency, consumer lag, dead letters, and publish errors."
   datePublished: "2026-05-27"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Prometheus Metrics

--- a/website/docs/observability/metrics.md
+++ b/website/docs/observability/metrics.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 2
 sidebar_label: "Prometheus Metrics"
-title: "Prometheus Metrics — NestJS JetStream Transport"
+title: "Prometheus Metrics: NestJS JetStream Transport"
 description: "Production-ready Prometheus metrics for NATS JetStream transport: throughput, handler latency, consumer lag, dead letters, and publish errors. Zero-config integration with @willsoto/nestjs-prometheus."
 schema:
   type: Article
-  headline: "Prometheus Metrics — NestJS JetStream Transport"
+  headline: "Prometheus Metrics: NestJS JetStream Transport"
   description: "Production-ready Prometheus metrics for NATS JetStream transport: throughput, handler latency, consumer lag, dead letters, and publish errors."
   datePublished: "2026-05-27"
   dateModified: "2026-06-12"
@@ -13,11 +13,11 @@ schema:
 
 # Prometheus Metrics
 
-The transport ships built-in Prometheus metrics covering throughput, handler latency, consumer lag, publish errors, dead letters, and connection health. Metrics are written to a `prom-client` registry; the de-facto standard in the NestJS ecosystem; so any `/metrics` endpoint exporter picks them up without additional wiring.
+The transport ships built-in Prometheus metrics covering throughput, handler latency, consumer lag, publish errors, dead letters, and connection health. Metrics are written to a `prom-client` registry; the de-facto standard in the NestJS ecosystem; so any `/metrics` endpoint exporter picks them up without extra wiring.
 
-## Why this exists
+## What it covers
 
-Traces tell you what happened to one message; metrics tell you what's happening to the system as a whole. NATS JetStream is a queue, a stream store, and an RPC bus rolled into one, and operators need to know things like "is my consumer falling behind?" or "what's the p99 handler latency for `orders.created` over the last hour?" Those are aggregate questions — Prometheus territory, not APM territory.
+Traces tell you what happened to one message; metrics tell you what's happening to the system as a whole. NATS JetStream is a queue, a stream store, and an RPC bus rolled into one, and operators need to know things like "is my consumer falling behind?" or "what's the p99 handler latency for `orders.created` over the last hour?" Those are aggregate questions, Prometheus territory, not APM territory.
 
 The library exposes everything an operator typically alerts on:
 
@@ -110,12 +110,12 @@ JetstreamModule.forRoot({
 })
 ```
 
-### Disabled by default — zero overhead
+### Disabled by default: zero overhead
 
 When the `metrics` option is omitted or set to `false`:
 
 - `prom-client` is never imported (the dynamic `import()` only runs when `metrics` is truthy).
-- The transport's hot paths add ~30 nanoseconds per message (a single `Map.get` to check if a listener exists) — effectively free.
+- The transport's hot paths add ~30 nanoseconds per message (a single `Map.get` to check if a listener exists): effectively free.
 
 Production deployments that don't need metrics pay nothing for the feature.
 
@@ -165,17 +165,17 @@ Setting `pollInterval: 0` (or `false`) disables the polling loop entirely. Count
 
 ### Label values
 
-Every label value is bounded — no free-form data ever reaches a label. The `subject` label is sourced from the **declared pattern** in `@EventPattern` / `@MessagePattern`, not from the wire NATS subject, so cardinality is bounded by your handler count.
+Every label value is bounded: no free-form data ever reaches a label. The `subject` label is sourced from the **declared pattern** in `@EventPattern` / `@MessagePattern`, not from the wire NATS subject, so cardinality is bounded by your handler count.
 
-- **`kind`** &mdash; `event`, `command`, `broadcast`, `ordered`.
-- **`status`** on handler metrics &mdash; `success`, `error`, `retried`, `terminated`.
-- **`status`** on publish metrics &mdash; `success`, `error`.
-- **`status`** on RPC round-trip metrics &mdash; `success`, `error`, `timeout`.
-- **`context`** on `jetstream_errors_total` &mdash; `connection`, `codec`, `publish`, `consume`, `handler`, `shutdown`, `other`.
+- **`kind`**, `event`, `command`, `broadcast`, `ordered`.
+- **`status`** on handler metrics, `success`, `error`, `retried`, `terminated`.
+- **`status`** on publish metrics, `success`, `error`.
+- **`status`** on RPC round-trip metrics, `success`, `error`, `timeout`.
+- **`context`** on `jetstream_errors_total`, `connection`, `codec`, `publish`, `consume`, `handler`, `shutdown`, `other`.
 
 ## PromQL examples
 
-Throughput — messages received per second by stream kind:
+Throughput, messages received per second by stream kind:
 
 ```promql
 sum by (kind) (rate(jetstream_messages_received_total[1m]))
@@ -227,23 +227,23 @@ histogram_quantile(
 The polling loop pulls `consumer.info()` and `streams.info()` from the NATS server at the configured `pollInterval`. The loop is deliberately conservative:
 
 - **Backpressure**: if a previous tick has not completed by the time the next interval fires, the new tick is skipped (no queueing). A warn log is emitted so operators can tell when the configured interval is too aggressive for the load.
-- **Per-target error isolation**: a failing `consumer.info()` call increments `jetstream_metrics_poll_errors_total{target="consumer.info"}` but does not abort the remainder of the cycle. Streams and other consumers in the same tick still update.
+- **Per-target error isolation**: a failing `consumer.info()` call increments `jetstream_metrics_poll_errors_total{target="consumer.info"}` but does not abort the rest of the cycle. Streams and other consumers in the same tick still update.
 - **Graceful shutdown**: `OnModuleDestroy` cancels the timer and awaits the in-flight tick before resolving, so the process exits cleanly.
-- **Connection-loss tolerance**: while NATS is disconnected, polling fails fast and increments the poll-error counter. Gauges become stale (not zero) — which is the correct semantic: we do not know the values, so we do not lie about them.
+- **Connection-loss tolerance**: while NATS is disconnected, polling fails fast and increments the poll-error counter. Gauges become stale (not zero): which is the correct semantic: we do not know the values, so we do not lie about them.
 
-The Command (RPC) consumer is only polled in JetStream RPC mode. Core RPC mode does not create a JetStream stream for commands, so there is nothing to poll. Ordered consumers are ephemeral and do not have a stable durable name, so they are excluded from polling — use `jetstream_messages_processed_total{kind="ordered"}` to monitor ordered throughput instead.
+The Command (RPC) consumer is only polled in JetStream RPC mode. Core RPC mode does not create a JetStream stream for commands, so there is nothing to poll. Ordered consumers are ephemeral and do not have a stable durable name, so they are excluded from polling, use `jetstream_messages_processed_total{kind="ordered"}` to monitor ordered throughput instead.
 
 ## Cardinality safety
 
 Prometheus performance degrades sharply with high cardinality, so the design avoids unbounded labels:
 
-- `subject` uses the **declared** pattern (e.g. `orders.created`) from `@EventPattern`, never the wire NATS subject. Subject wildcards are not supported in handler patterns — the router uses exact-match lookup — so declared and wire subjects coincide today. Pinning to the declared form future-proofs the metric.
+- `subject` uses the **declared** pattern (e.g. `orders.created`) from `@EventPattern`, never the wire NATS subject. Subject wildcards are not supported in handler patterns: the router uses exact-match lookup: so declared and wire subjects coincide today. Pinning to the declared form future-proofs the metric.
 - `kind`, `status`, and `context` are all enum-typed with a small bounded set of values.
 - `stream` and `consumer` are deterministic functions of `serviceName` and `StreamKind`.
 - `server` is bounded by the NATS cluster size.
-- For unmatched messages, `subject="<unmatched>"` is used as a single sentinel rather than the actual subject — preventing an attacker from blowing up cardinality by publishing to random subjects.
+- For unmatched messages, `subject="<unmatched>"` is used as a single sentinel rather than the actual subject: preventing an attacker from blowing up cardinality by publishing to random subjects.
 
-If you set `defaultLabels` with high-cardinality values (e.g. per-request IDs), Prometheus performance is on you — the transport never injects unbounded labels itself.
+If you set `defaultLabels` with high-cardinality values (e.g. per-request IDs), Prometheus performance is on you: the transport never injects unbounded labels itself.
 
 ## Performance characteristics
 
@@ -254,9 +254,9 @@ Per-message overhead with metrics enabled:
 - 1× `PatternRegistry.resolveDeclared()` (a `Map.get`) inside the metrics service.
 - 1× `Counter.inc()` + 1× `Histogram.observe()` in `prom-client`.
 
-Aggregate cost: **~5–10 microseconds per message** on modern hardware. For a service handling 10,000 messages per second, that is ~50ms of CPU time per second of wall clock — well under 5% overhead and dominated by the NATS round-trip itself.
+Aggregate cost: **~5 to 10 microseconds per message** on modern hardware. For a service handling 10,000 messages per second, that is ~50ms of CPU time per second of wall clock, well under 5% overhead and dominated by the NATS round-trip itself.
 
-Polling cost: 1 `consumer.info` + 1 `streams.info` per consumer kind every `pollInterval` ms. For a service with both event and RPC handlers in JetStream mode, that's roughly 0.27 NATS requests per second at the default 15s interval — negligible.
+Polling cost: 1 `consumer.info` + 1 `streams.info` per consumer kind every `pollInterval` ms. For a service with both event and RPC handlers in JetStream mode, that's roughly 0.27 NATS requests per second at the default 15s interval, negligible.
 
 Memory: each metric family allocates roughly 200 bytes per label combination. With ~100 declared subjects × 4 statuses × 4 kinds, all 19 metric families together stay under ~10 MB of heap.
 
@@ -277,7 +277,7 @@ JetstreamModule.forRoot({
 });
 ```
 
-The `HandlerCompleted`, `Published`, and `RpcCompleted` events used internally by the metrics service are also part of the public `TransportHooks` surface — register your own listeners if you want to add custom alerting on top of the built-in counters.
+The `HandlerCompleted`, `Published`, and `RpcCompleted` events used internally by the metrics service are also part of the public `TransportHooks` surface, register your own listeners if you want to add custom alerting on top of the built-in counters.
 
 ## Multi-registry deployments
 

--- a/website/docs/observability/tracing.md
+++ b/website/docs/observability/tracing.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
 sidebar_label: "Distributed Tracing"
-title: "Distributed Tracing — NestJS JetStream Transport"
+title: "Distributed Tracing: NestJS JetStream Transport"
 description: "Built-in W3C Trace Context propagation and OpenTelemetry spans for every publish, consume, and RPC round-trip. Works zero-config with Sentry, Datadog, Jaeger, Tempo, Honeycomb, and any OTel-compatible APM."
 schema:
   type: Article
-  headline: "Distributed Tracing — NestJS JetStream Transport"
+  headline: "Distributed Tracing: NestJS JetStream Transport"
   description: "Built-in W3C Trace Context propagation and OpenTelemetry spans for every publish, consume, and RPC round-trip."
   datePublished: "2026-04-24"
   dateModified: "2026-06-12"
@@ -15,18 +15,18 @@ schema:
 
 The transport produces OpenTelemetry spans for every publish, every consume, and every RPC round-trip. Trace context propagates through NATS message headers using the W3C Trace Context standard, so a single trace flows end-to-end across services regardless of language or runtime.
 
-## Why this exists
+## What it covers
 
-Aggregate metrics tell you the system is slow; traces tell you _which_ message was slow and _where_ it spent its time. When a customer reports a failed order, you want a single waterfall view that follows the request from `client.emit('orders.created')` through every consumer, RPC hop, and dead-letter branch — across multiple services if needed. That's what tracing is for.
+Aggregate metrics tell you the system is slow; traces tell you _which_ message was slow and _where_ it spent its time. When a customer reports a failed order, you want a single waterfall view that follows the request from `client.emit('orders.created')` through every consumer, RPC hop, and dead-letter branch, across multiple services if needed. That's what tracing is for.
 
-The library emits OpenTelemetry spans on the same paths the metrics surface counts. If you already run an APM (Sentry, Datadog, Honeycomb, Jaeger, Tempo, …), no transport-side configuration is required — traces appear the moment your application registers an OTel SDK.
+The library emits OpenTelemetry spans on the same paths the metrics surface counts. If you already run an APM (Sentry, Datadog, Honeycomb, Jaeger, Tempo, …), no transport-side configuration is required, traces appear the moment your application registers an OTel SDK.
 
 ## Setup
 
 Tracing activates automatically the moment your application registers an OpenTelemetry SDK. **No transport-side configuration is required.** If no SDK is registered, the library's tracer calls are no-ops and there is zero runtime cost.
 
 ```ts
-// tracing.ts — load this BEFORE your AppModule
+// tracing.ts, load this BEFORE your AppModule
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
@@ -43,7 +43,7 @@ That's it. Spans appear in your backend immediately.
 Every modern Node.js APM SDK ships with OpenTelemetry under the hood. Pick whichever you already use:
 
 ```ts
-// Sentry — automatic OTel setup with tracesSampleRate
+// Sentry, automatic OTel setup with tracesSampleRate
 import * as Sentry from '@sentry/node';
 Sentry.init({ dsn: process.env.SENTRY_DSN, tracesSampleRate: 1.0 });
 ```
@@ -55,7 +55,7 @@ tracer.init({ service: 'orders-service' });
 ```
 
 ```ts
-// Jaeger / Tempo / OTel Collector — NodeSDK + OTLP
+// Jaeger / Tempo / OTel Collector, NodeSDK + OTLP
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 new NodeSDK({
@@ -64,18 +64,18 @@ new NodeSDK({
 }).start();
 ```
 
-### Disabled by default — zero overhead
+### Disabled by default: zero overhead
 
-When no OpenTelemetry SDK is registered in the host application, every internal `trace.getTracer()` call resolves to a no-op tracer. The transport still walks through the span helpers, but each call exits on the first guard. There is no measurable overhead on the hot path, and `@opentelemetry/api` is declared as an optional peer dependency — applications that do not want tracing do not pay for it in their bundle either.
+When no OpenTelemetry SDK is registered in the host application, every internal `trace.getTracer()` call resolves to a no-op tracer. The transport still walks through the span helpers, but each call exits on the first guard. The hot path carries no measurable overhead, and `@opentelemetry/api` is declared as an optional peer dependency, applications that do not want tracing do not pay for it in their bundle either.
 
 ## What gets traced
 
 The default trace set covers the message-flow operations that map onto a distributed trace waterfall:
 
-- **`publish`** &mdash; `PRODUCER` span. Fires for every `client.emit()` and for the publish portion of an RPC `client.send()`.
-- **`consume`** &mdash; `CONSUMER` span. Fires for every handler invocation. Retries produce additional spans with `messaging.nats.message.delivery_count > 1`.
-- **`rpc.client.send`** &mdash; `CLIENT` span. Covers the full RPC round-trip on the caller side, from publish through reply or timeout.
-- **`dead_letter`** &mdash; `INTERNAL` span. Fires when a message exhausts `maxDeliver` and the DLQ flow runs.
+- **`publish`**, `PRODUCER` span. Fires for every `client.emit()` and for the publish portion of an RPC `client.send()`.
+- **`consume`**, `CONSUMER` span. Fires for every handler invocation. Retries produce extra spans with `messaging.nats.message.delivery_count > 1`.
+- **`rpc.client.send`**, `CLIENT` span. Covers the full RPC round-trip on the caller side, from publish through reply or timeout.
+- **`dead_letter`**, `INTERNAL` span. Fires when a message exhausts `maxDeliver` and the DLQ flow runs.
 
 Infrastructure trace kinds (connection lifecycle, self-healing, provisioning, migration, shutdown) exist in the `JetstreamTrace` enum but are off by default. Enable them explicitly when you need that level of detail.
 
@@ -98,7 +98,7 @@ JetstreamModule.forRoot({
 
 Use `traces: 'all'` to enable every kind, `traces: 'none'` to suppress span emission entirely while keeping context propagation alive.
 
-For an env-driven toggle, the option also accepts a plain boolean — `otel: true` for defaults, `otel: false` for `{ enabled: false }`.
+For an env-driven toggle, the option also accepts a plain boolean, `otel: true` for defaults, `otel: false` for `{ enabled: false }`.
 
 ## Configuration reference
 
@@ -141,10 +141,10 @@ otel?: boolean | {
 
 ## Error classification
 
-Handler errors are classified by exception type. The classifier drives **only** OpenTelemetry span status — it does not affect logs, hooks, or the reply envelope returned to the caller.
+Handler errors are classified by exception type. The classifier drives **only** OpenTelemetry span status: it does not affect logs, hooks, or the reply envelope returned to the caller.
 
-- **`RpcException` / `HttpException`** &mdash; span status `OK`, with `jetstream.rpc.reply.has_error` and `jetstream.rpc.reply.error.code` attributes attached.
-- **Bare `Error` / unknown thrown value** &mdash; span status `ERROR`, with `span.recordException(err)` attached.
+- **`RpcException` / `HttpException`**, span status `OK`, with `jetstream.rpc.reply.has_error` and `jetstream.rpc.reply.error.code` attributes attached.
+- **Bare `Error` / unknown thrown value**, span status `ERROR`, with `span.recordException(err)` attached.
 
 This keeps APM error rates clean for business outcomes that are part of the contract (auth denials, validation failures) while loud-failing on real bugs and infrastructure problems. Override the default with a custom classifier when your team uses other primitives:
 
@@ -171,10 +171,10 @@ Captures matching message headers as `messaging.header.<name>` span attributes. 
 The library-internal `x-correlation-id` is never emitted as a `messaging.header.*` attribute even if added to the allowlist; it surfaces on RPC spans as the standard `messaging.message.conversation_id` attribute instead, which keeps the OpenTelemetry semantic-conventions contract intact and avoids duplicating the same value under two keys.
 
 :::warning
-Headers frequently carry authentication tokens, session identifiers, and other sensitive data. Captured values are exported to your OTel backend (Sentry, Datadog, etc.). **Never set `captureHeaders: true` in production** — that captures every header. Use an explicit allowlist.
+Headers frequently carry authentication tokens, session identifiers, and other sensitive data. Captured values are exported to your OTel backend (Sentry, Datadog, etc.). **Never set `captureHeaders: true` in production**: that captures every header. Use an explicit allowlist.
 :::
 
-The library always excludes propagator-owned headers (`traceparent`, `tracestate`, `baggage`, `sentry-trace`, `b3`, `x-b3-*`, Jaeger format) from capture even when the matcher would pass them — they are noise and already represented by the span's own context.
+The library always excludes propagator-owned headers (`traceparent`, `tracestate`, `baggage`, `sentry-trace`, `b3`, `x-b3-*`, Jaeger format) from capture even when the matcher would pass them: they are noise and already represented by the span's own context.
 
 ### `captureBody`
 
@@ -210,7 +210,7 @@ otel: {
 }
 ```
 
-Hooks are synchronous — they run inline with span creation and termination. Errors thrown from a hook are caught and logged at `debug` level; they cannot disrupt the message flow.
+Hooks are synchronous: they run inline with span creation and termination. Errors thrown from a hook are caught and logged at `debug` level; they cannot disrupt the message flow.
 
 ## Skipping spans for noisy subjects
 
@@ -241,4 +241,4 @@ This requires an OpenTelemetry `ContextManager` (typically `AsyncLocalStorageCon
 Review your `captureHeaders` allowlist; set explicit headers, never `true`. Confirm `captureBody` is `false`. If you need backend-side scrubbing, register a custom `SpanProcessor` that drops or rewrites attributes in `onEnd`.
 
 **Span name format looks "reversed" in my APM.**
-The library uses the OpenTelemetry messaging convention: `{operation} {destination}` (`publish orders.created`, `process orders.created`). Some older APMs render it differently — rendering is a UI concern, not a span data issue.
+The library uses the OpenTelemetry messaging convention: `{operation} {destination}` (`publish orders.created`, `process orders.created`). Some older APMs render it differently, rendering is a UI concern, not a span data issue.

--- a/website/docs/observability/tracing.md
+++ b/website/docs/observability/tracing.md
@@ -8,7 +8,7 @@ schema:
   headline: "Distributed Tracing: NestJS JetStream Transport"
   description: "Built-in W3C Trace Context propagation and OpenTelemetry spans for every publish, consume, and RPC round-trip."
   datePublished: "2026-04-24"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Distributed Tracing

--- a/website/docs/patterns/broadcast.md
+++ b/website/docs/patterns/broadcast.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
 sidebar_label: "Broadcast Events"
-title: "Broadcast Events — NestJS JetStream Fan-Out Delivery"
+title: "Broadcast Events: NestJS JetStream Fan-Out Delivery"
 description: "Fan-out NATS JetStream events to every NestJS service instance via per-service durable consumers on a shared broadcast stream."
 schema:
   type: Article
-  headline: "Broadcast Events — NestJS JetStream Fan-Out Delivery"
+  headline: "Broadcast Events: NestJS JetStream Fan-Out Delivery"
   description: "Fan-out NATS JetStream events to every NestJS service instance via per-service durable consumers on a shared broadcast stream."
   datePublished: "2026-03-21"
   dateModified: "2026-04-11"
@@ -14,13 +14,13 @@ schema:
 # Broadcast Events
 
 > **Use when:** every running service must react to the same message (cache invalidation, feature-flag flips, config reload).
-> **You get:** per-service durable consumers on a shared stream — late-joining replicas catch up automatically.
+> **You get:** per-service durable consumers on a shared stream, late-joining replicas catch up automatically.
 
 Broadcast events implement **fan-out** delivery: every subscribing service receives a copy of each message. This is the opposite of [workqueue events](/docs/patterns/events) (one instance processes each message) and distinct from [ordered events](/docs/patterns/ordered-events) (every instance receives a full sequential replay).
 
 ## When to use
 
-Imagine a multi-service platform where an admin updates a feature flag. Every service — orders, payments, notifications, analytics — must refresh its local cache immediately. You don't want to call each service individually, and you don't want only one instance to get the update.
+Imagine a multi-service platform where an admin updates a feature flag. Every service (orders, payments, notifications, analytics) must refresh its local cache immediately. You don't want to call each service individually, and you don't want only one instance to get the update.
 
 Broadcast events solve this. When you publish a broadcast event, every service that has registered a handler receives the message independently.
 
@@ -28,12 +28,12 @@ Broadcast events solve this. When you publish a broadcast event, every service t
 
 The broadcast flow, step by step:
 
-1. **Publish** — a service calls `client.emit('broadcast:config.updated', data)`. The `broadcast:` prefix tells the transport this is a fan-out event.
-2. **Route** — the transport publishes to the subject `broadcast.config.updated` (a global subject, not scoped to any service).
-3. **Shared stream** — the message is persisted in a single **shared** `broadcast-stream` with **Limits** retention: messages stay in the stream until they exceed `max_age`, `max_msgs`, or `max_bytes`, even after every consumer acknowledges them. This is what lets new instances replay recent broadcasts on startup, unlike the Workqueue retention used for regular events.
-4. **Per-service consumers** — each service that registered a `{ broadcast: true }` handler has its own durable consumer on the shared stream. Every consumer independently receives the message.
-5. **Dispatch** — each service's `EventRouter` decodes the payload and invokes the matching handler.
-6. **Acknowledge** — each consumer acks or naks independently.
+1. **Publish**: a service calls `client.emit('broadcast:config.updated', data)`. The `broadcast:` prefix tells the transport this is a fan-out event.
+2. **Route**: the transport publishes to the subject `broadcast.config.updated` (a global subject, not scoped to any service).
+3. **Shared stream**: the message is persisted in a single **shared** `broadcast-stream` with **Limits** retention: messages stay in the stream until they exceed `max_age`, `max_msgs`, or `max_bytes`, even after every consumer acknowledges them. This is what lets new instances replay recent broadcasts on startup, unlike the Workqueue retention used for regular events.
+4. **Per-service consumers**: each service that registered a `{ broadcast: true }` handler has its own durable consumer on the shared stream. Every consumer independently receives the message.
+5. **Dispatch**: each service's `EventRouter` decodes the payload and invokes the matching handler.
+6. **Acknowledge**: each consumer acks or naks independently.
 
 ```mermaid
 flowchart TD
@@ -84,7 +84,7 @@ export class AdminService {
 
 ### Handling broadcast events
 
-Use `@EventPattern` with `{ broadcast: true }` in the extras object. The pattern itself does **not** include the `broadcast:` prefix — that's only for the sending side.
+Use `@EventPattern` with `{ broadcast: true }` in the extras object. The pattern itself does not include the `broadcast:` prefix: that's only for the sending side.
 
 ```typescript title="src/orders/orders.controller.ts"
 import { Controller, Logger } from '@nestjs/common';
@@ -125,31 +125,31 @@ export class PaymentsController {
 }
 ```
 
-Both `OrdersController` and `PaymentsController` receive the same `config.updated` message independently — each through their own durable consumer.
+Both `OrdersController` and `PaymentsController` receive the same `config.updated` message independently: each through their own durable consumer.
 
 :::warning Asymmetric prefixing
-The `broadcast:` prefix is used **only on the sending side** (`client.emit('broadcast:config.updated', ...)`). On the handler side, the pattern is just `'config.updated'` with `{ broadcast: true }` in extras. This asymmetry is intentional — the prefix controls routing, while the extras flag controls consumer registration.
+The `broadcast:` prefix is used **only on the sending side** (`client.emit('broadcast:config.updated', ...)`). On the handler side, the pattern is just `'config.updated'` with `{ broadcast: true }` in extras. This asymmetry is intentional: the prefix controls routing, while the extras flag controls consumer registration.
 :::
 
 ## Delivery semantics
 
 Each consumer processes broadcast messages with the same delivery guarantees as workqueue events:
 
-- **Handler succeeds** &mdash; `ack`. The consumer is marked as having processed the message.
-- **Handler throws an error** &mdash; `nak`. The message is redelivered to **that consumer only**.
-- **Payload cannot be decoded** &mdash; `term`. The message is terminated for that consumer.
-- **No handler for subject** &mdash; `term`. The message is terminated for that consumer.
-- **Max deliveries exhausted** &mdash; `term`. The dead letter callback is invoked for that consumer.
+- **Handler succeeds**, `ack`. The consumer is marked as having processed the message.
+- **Handler throws an error**, `nak`. The message is redelivered to **that consumer only**.
+- **Payload cannot be decoded**, `term`. The message is terminated for that consumer.
+- **No handler for subject**, `term`. The message is terminated for that consumer.
+- **Max deliveries exhausted**, `term`. The dead letter callback is invoked for that consumer.
 
 The key difference from workqueue events: broadcast delivery is **at-least-once per consumer**. Every subscribing service receives every message at least once.
 
 ## Per-service isolation
 
-This is the most important concept to understand about broadcast events: **each service's consumer is completely independent**.
+This is the most important concept to understand about broadcast events: **each service's consumer is independent**.
 
 If the orders service fails to process a broadcast message and the message is nak'd:
 - Only the orders service's consumer retries the message.
-- The payments service and analytics service are **completely unaffected**.
+- The payments service and analytics service are **unaffected**.
 - Each consumer tracks its own delivery count independently.
 
 ```mermaid
@@ -234,16 +234,16 @@ JetstreamModule.forRoot({
 Each consumer only subscribes to the broadcast subjects it has handlers for (via `filter_subject` or `filter_subjects`), so services only receive the broadcast events they care about.
 
 :::tip Broadcast scheduling
-To schedule delayed broadcasts, enable `broadcast.stream.allow_msg_schedules: true` — this is a separate opt-in from the event stream flag. See [Scheduling (Delayed Jobs)](/docs/guides/scheduling).
+To schedule delayed broadcasts, enable `broadcast.stream.allow_msg_schedules: true`: this is a separate opt-in from the event stream flag. See [Scheduling (Delayed Jobs)](/docs/guides/scheduling).
 :::
 
-### Default values — the ones you'll actually tune
+### Default values: the ones you'll actually tune
 
-- **`max_age`** (stream, shared) &mdash; 1 hour. New instances catch up on broadcasts within this window.
-- **`max_deliver`** (per-service) &mdash; `3`. Each service retries independently before dead letter.
-- **`ack_wait`** (per-service) &mdash; 10 seconds. Scoped to each service's broadcast consumer.
+- **`max_age`** (stream, shared), 1 hour. New instances catch up on broadcasts within this window.
+- **`max_deliver`** (per-service), `3`. Each service retries independently before dead letter.
+- **`ack_wait`** (per-service), 10 seconds. Scoped to each service's broadcast consumer.
 
-See [Default Configs — Broadcast Stream](/docs/reference/default-configs#broadcast-stream) and [Broadcast Consumer](/docs/reference/default-configs#broadcast-consumer) for the complete list.
+See [Default Configs, Broadcast Stream](/docs/reference/default-configs#broadcast-stream) and [Broadcast Consumer](/docs/reference/default-configs#broadcast-consumer) for the complete list.
 
 ## Common use cases
 
@@ -311,4 +311,4 @@ handleFeatureFlag(@Payload() data: FeatureFlagEvent): void {
 
 ## See also
 
-Broadcast consumers compete with regular event consumers for the same concurrency budget — tune both via [Performance Tuning](/docs/guides/performance#concurrency-control). If a broadcast handler keeps failing, only *that* service's consumer retries; see [Dead Letter Queue](/docs/guides/dead-letter-queue#scope) for per-consumer dead letter semantics.
+Broadcast consumers compete with regular event consumers for the same concurrency budget, tune both via [Performance Tuning](/docs/guides/performance#concurrency-control). If a broadcast handler keeps failing, only *that* service's consumer retries; see [Dead Letter Queue](/docs/guides/dead-letter-queue#scope) for per-consumer dead letter semantics.

--- a/website/docs/patterns/broadcast.md
+++ b/website/docs/patterns/broadcast.md
@@ -8,7 +8,7 @@ schema:
   headline: "Broadcast Events: NestJS JetStream Fan-Out Delivery"
   description: "Fan-out NATS JetStream events to every NestJS service instance via per-service durable consumers on a shared broadcast stream."
   datePublished: "2026-03-21"
-  dateModified: "2026-04-11"
+  dateModified: "2026-07-26"
 ---
 
 # Broadcast Events

--- a/website/docs/patterns/events.md
+++ b/website/docs/patterns/events.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 2
 sidebar_label: "Events (Workqueue)"
-title: "Workqueue Events — NestJS JetStream At-Least-Once Delivery"
+title: "Workqueue Events: NestJS JetStream At-Least-Once Delivery"
 description: "NestJS NATS JetStream workqueue events with at-least-once delivery, automatic retry, publish-side deduplication, and dead letter handling."
 schema:
   type: Article
-  headline: "Workqueue Events — NestJS JetStream At-Least-Once Delivery"
+  headline: "Workqueue Events: NestJS JetStream At-Least-Once Delivery"
   description: "NestJS NATS JetStream workqueue events with at-least-once delivery, automatic retry, publish-side deduplication, and dead letter handling."
   datePublished: "2026-03-21"
   dateModified: "2026-06-12"
@@ -20,7 +20,7 @@ Workqueue events are fire-and-forget messages where **exactly one** handler inst
 
 ## When to use
 
-Imagine an e-commerce system: an order is created, and you need to send a confirmation email, update inventory, and notify the warehouse. Each of these tasks should happen **once** — you don't want three instances of the email service each sending the same confirmation.
+Imagine an e-commerce system: an order is created, and you need to send a confirmation email, update inventory, and notify the warehouse. Each of these tasks should happen **once**: you don't want three instances of the email service each sending the same confirmation.
 
 Workqueue events solve this. When you publish an event, NATS JetStream delivers it to a single consumer in the group. If that consumer fails, the message is redelivered to another instance. If all retries are exhausted, the message is routed to a dead letter queue for investigation.
 
@@ -28,14 +28,14 @@ Workqueue events solve this. When you publish an event, NATS JetStream delivers 
 
 The workqueue flow, step by step:
 
-1. **Publish** — a service calls `client.emit('order.created', data)`.
-2. **Route** — the transport publishes to the JetStream subject `{service}__microservice.ev.order.created`.
-3. **Stream** — the message is persisted in the service's event stream (workqueue retention).
-4. **Consume** — one durable pull consumer picks up the message from the stream.
-5. **Dispatch** — the `EventRouter` decodes the payload and invokes the matching `@EventPattern` handler.
-6. **Acknowledge** — on success, the message is `ack`'d and removed from the stream. On failure, it is `nak`'d for redelivery.
+1. **Publish**: a service calls `client.emit('order.created', data)`.
+2. **Route**: the transport publishes to the JetStream subject `{service}__microservice.ev.order.created`.
+3. **Stream**: the message is persisted in the service's event stream (workqueue retention).
+4. **Consume**: one durable pull consumer picks up the message from the stream.
+5. **Dispatch**: the `EventRouter` decodes the payload and invokes the matching `@EventPattern` handler.
+6. **Acknowledge**: on success, the message is `ack`'d and removed from the stream. On failure, it is `nak`'d for redelivery.
 
-Because the stream uses **workqueue retention**, a message is automatically deleted once acknowledged — keeping the stream compact.
+Because the stream uses **workqueue retention**, a message is automatically deleted once acknowledged, keeping the stream compact.
 
 Handlers run concurrently via RxJS `mergeMap`, bounded by the consumer's `max_ack_pending` (default: 100). Multiple messages can be in-flight at once.
 
@@ -95,11 +95,11 @@ export class NotificationsController {
 }
 ```
 
-If `handleOrderCreated` throws, the message is automatically `nak`'d and redelivered. No try/catch needed — the transport handles retries.
+If `handleOrderCreated` throws, the message is automatically `nak`'d and redelivered. No try/catch needed: the transport handles retries.
 
 ## Consumer naming and `@EventPattern` extras
 
-At-least-once delivery is **on by default** — every event handler registered with `@EventPattern` is automatically backed by a **durable** JetStream pull consumer with explicit ack. You don't enable it; you configure it.
+At-least-once delivery is **on by default**: every event handler registered with `@EventPattern` is automatically backed by a **durable** JetStream pull consumer with explicit ack. You don't enable it; you configure it.
 
 ### Where the durable consumer name comes from
 
@@ -118,7 +118,7 @@ JetstreamModule.forRoot({
 | [Broadcast](/docs/patterns/broadcast) | `orders__microservice_broadcast-consumer` |
 | [Ordered](/docs/patterns/ordered-events) | `orders__microservice_ordered-consumer` |
 
-All `@EventPattern` handlers in the same `orders` service share the workqueue consumer above. JetStream load-balances across replicas of the same service via that single durable consumer, which is exactly what at-least-once delivery requires — multiple replicas, one cursor, ack semantics enforced server-side.
+All `@EventPattern` handlers in the same `orders` service share the workqueue consumer above. JetStream load-balances across replicas of the same service via that single durable consumer, which is exactly what at-least-once delivery requires, multiple replicas, one cursor, ack semantics enforced server-side.
 
 If you need a different consumer for a specific subject, that's done by **giving it its own service**, not by overriding the decorator.
 
@@ -137,23 +137,23 @@ async onOrderStatus(@Payload() data: OrderStatus) { /* ... */ }
 async onSettingsChanged(@Payload() s: Settings) { /* ... */ }
 ```
 
-**`broadcast: boolean`** &mdash; routes the handler to the shared broadcast stream so every replica processes every message. See [Broadcast](/docs/patterns/broadcast).
+**`broadcast: boolean`**, routes the handler to the shared broadcast stream so every replica processes every message. See [Broadcast](/docs/patterns/broadcast).
 
-**`ordered: boolean`** &mdash; backs the handler with an [ordered consumer](/docs/patterns/ordered-events) for strict per-key delivery.
+**`ordered: boolean`**, backs the handler with an [ordered consumer](/docs/patterns/ordered-events) for strict per-key delivery.
 
-**`meta: Record<string, unknown>`** &mdash; free-form metadata published to the [handler metadata registry](/docs/patterns/handler-metadata).
+**`meta: Record<string, unknown>`**, free-form metadata published to the [handler metadata registry](/docs/patterns/handler-metadata).
 
-There is no `durable`, `ackWait`, or `maxDeliver` on the decorator — those are stream-and-consumer-level concerns, configured once on the module under [Custom configuration](#custom-configuration) below.
+There is no `durable`, `ackWait`, or `maxDeliver` on the decorator: those are stream-and-consumer-level concerns, configured once on the module under [Custom configuration](#custom-configuration) below.
 
 ## Delivery semantics
 
 The transport uses explicit acknowledgement. The outcome depends on what happens during message processing:
 
-- **Handler succeeds** &mdash; `ack`. Message is removed from the stream.
-- **Handler throws an error** &mdash; `nak`. Message is redelivered after backoff.
-- **Payload cannot be decoded** &mdash; `term`. Message is terminated immediately; no retry.
-- **No handler registered for subject** &mdash; `term`. Message is terminated; no retry.
-- **Max deliveries exhausted** &mdash; `term`. Dead letter callback is invoked, then the message is terminated.
+- **Handler succeeds**, `ack`. Message is removed from the stream.
+- **Handler throws an error**, `nak`. Message is redelivered after backoff.
+- **Payload cannot be decoded**, `term`. Message is terminated immediately; no retry.
+- **No handler registered for subject**, `term`. Message is terminated; no retry.
+- **Max deliveries exhausted**, `term`. Dead letter callback is invoked, then the message is terminated.
 
 :::warning Decode errors are terminal
 If the codec cannot deserialize a message (e.g., corrupted data, schema mismatch), the message is immediately terminated with `term()`. Retrying would produce the same error, so the transport avoids wasting delivery attempts.
@@ -198,11 +198,11 @@ For full details on dead letter handling, see the [Dead Letter Queue](/docs/guid
 
 ## Idempotency
 
-Because the transport provides **at-least-once** delivery, a handler may receive the same message more than once — for example, if the service crashes after processing but before acknowledging. Your handlers must be **idempotent**: processing the same message twice should produce the same result.
+Because the transport provides **at-least-once** delivery, a handler may receive the same message more than once, for example, if the service crashes after processing but before acknowledging. Your handlers must be **idempotent**: processing the same message twice should produce the same result.
 
 ### Practical patterns
 
-**Database upsert** — use a unique constraint or `ON CONFLICT` clause so re-processing the same event doesn't create duplicates:
+**Database upsert**: use a unique constraint or `ON CONFLICT` clause so re-processing the same event doesn't create duplicates:
 
 ```typescript
 @EventPattern('order.created')
@@ -217,12 +217,12 @@ async handleOrderCreated(@Payload() data: OrderCreatedEvent): Promise<void> {
 }
 ```
 
-**Idempotency key** — track processed message IDs in a cache or database:
+**Idempotency key**: track processed message IDs in a cache or database:
 
 ```typescript
 @EventPattern('payment.completed')
 async handlePayment(@Payload() data: PaymentEvent, @Ctx() ctx: RpcContext): Promise<void> {
-  // Stream sequence is guaranteed unique within a stream — perfect dedup key
+  // Stream sequence is guaranteed unique within a stream, perfect dedup key
   const dedupKey = `payment:${ctx.getStream()}:${ctx.getSequence()}`;
 
   if (await this.cache.exists(dedupKey)) {
@@ -263,7 +263,7 @@ This prevents duplicate publishes in scenarios like:
 
 The default `duplicate_window` is **2 minutes**; messages with the same ID published within that window are deduplicated. To extend it, override `events.stream.duplicate_window` in `forRoot()` (e.g. `duplicate_window: toNanos(5, 'minutes')`). See [Custom configuration](#custom-configuration) for the full override pattern.
 
-When no message ID is set explicitly, the transport generates a random UUID for each publish — meaning no deduplication occurs by default. Always set a deterministic message ID when duplicate publishes are a concern.
+When no message ID is set explicitly, the transport generates a random UUID for each publish, meaning no deduplication occurs by default. Always set a deterministic message ID when duplicate publishes are a concern.
 
 ## Custom configuration
 
@@ -304,22 +304,22 @@ JetstreamModule.forRoot({
 ```
 
 :::tip When to increase ack_wait
-If your handler calls a slow external API (e.g., sending emails, processing payments), increase `ack_wait` so that NATS doesn't redeliver the message before your handler finishes. The default is 10 seconds — long-running handlers may need 30s or more. For unbounded processing, consider [ack extension](/docs/guides/performance#ack-extension) instead.
+If your handler calls a slow external API (e.g., sending emails, processing payments), increase `ack_wait` so that NATS doesn't redeliver the message before your handler finishes. The default is 10 seconds, long-running handlers may need 30s or more. For unbounded processing, consider [ack extension](/docs/guides/performance#ack-extension) instead.
 :::
 
 :::tip When to increase max_deliver
 The default of 3 delivery attempts works well for transient errors (network blips, temporary database unavailability). Increase it to 5 or higher if your handlers interact with unreliable external services where intermittent failures are common.
 :::
 
-### Default values — the ones you'll actually tune
+### Default values: the ones you'll actually tune
 
-- **`max_deliver`** &mdash; `3`. How many retry attempts before the message is marked dead.
-- **`ack_wait`** &mdash; 10 seconds. How long a handler has to ack before NATS redelivers.
-- **`max_ack_pending`** &mdash; `100`. In-flight cap; the primary backpressure control.
-- **`max_age`** &mdash; 7 days. How long events live in the stream before being purged.
-- **`duplicate_window`** &mdash; 2 minutes. Dedup window for [`setMessageId()`](/docs/guides/record-builder).
+- **`max_deliver`**, `3`. How many retry attempts before the message is marked dead.
+- **`ack_wait`**, 10 seconds. How long a handler has to ack before NATS redelivers.
+- **`max_ack_pending`**, `100`. In-flight cap; the primary backpressure control.
+- **`max_age`**, 7 days. How long events live in the stream before being purged.
+- **`duplicate_window`**, 2 minutes. Dedup window for [`setMessageId()`](/docs/guides/record-builder).
 
-See [Default Configs — Event Stream](/docs/reference/default-configs#event-stream) and [Event Consumer](/docs/reference/default-configs#event-consumer) for the complete list of stream and consumer defaults.
+See [Default Configs, Event Stream](/docs/reference/default-configs#event-stream) and [Event Consumer](/docs/reference/default-configs#event-consumer) for the complete list of stream and consumer defaults.
 
 ## Error handling
 
@@ -341,11 +341,11 @@ export class OrdersController {
   ): Promise<void> {
     try {
       await this.ordersService.process(data);
-      // Success — ack is called automatically by the transport
+      // Success, ack is called automatically by the transport
     } catch (error) {
       if (this.isNonRecoverable(error)) {
         // Non-recoverable: invalid payload, business rule violation, etc.
-        // ctx.terminate() prevents redelivery — the message is permanently discarded.
+        // ctx.terminate() prevents redelivery, the message is permanently discarded.
         const reason = error instanceof Error ? error.message : String(error);
         ctx.terminate('Non-recoverable: ' + reason);
         this.logger.error(`Permanently discarding order`, error);
@@ -353,7 +353,7 @@ export class OrdersController {
       }
 
       // Recoverable errors (DB timeout, external API down, etc.):
-      // Re-throw — the transport calls nak automatically,
+      // Re-throw, the transport calls nak automatically,
       // triggering redelivery after ack_wait.
       // After max_deliver attempts, onDeadLetter is invoked.
       throw error;
@@ -371,11 +371,11 @@ export class OrdersController {
 
 Every message ends in one of three states:
 
-**Auto-ack** (no action needed). The handler returns successfully. The transport calls `ack()` on the underlying message automatically — the message is removed from the stream.
+**Auto-ack** (no action needed). The handler returns successfully. The transport calls `ack()` on the underlying message automatically: the message is removed from the stream.
 
 **`ctx.retry()`**; for recoverable errors. The message is redelivered, optionally with a `{ delayMs }` delay. The transport applies the same retry semantics automatically when a handler throws, so you only need to call `ctx.retry()` manually when you want to return early without raising an exception.
 
-**`ctx.terminate(reason)`** — for non-recoverable errors. The message is permanently discarded. Must be called manually in the handler.
+**`ctx.terminate(reason)`**: for non-recoverable errors. The message is permanently discarded. Must be called manually in the handler.
 
 ### Relationship with dead letter handling
 
@@ -384,15 +384,15 @@ When a message is `nak`'d repeatedly and reaches the `max_deliver` limit (defaul
 1. The `onDeadLetter` callback is invoked (if configured) with full message context.
 2. The message is terminated with `term()`.
 
-This means `ctx.terminate()` is for errors you **know** will never succeed (validation failures, schema mismatches), while `throw` is for errors that **might** succeed on retry (timeouts, temporary unavailability). For messages that exhaust all retries, the dead letter mechanism provides a safety net.
+`ctx.terminate()` is so for errors you **know** will never succeed (validation failures, schema mismatches), while `throw` is for errors that **might** succeed on retry (timeouts, temporary unavailability). For messages that exhaust all retries, the dead letter mechanism provides a safety net.
 
 See the [Dead Letter Queue](/docs/guides/dead-letter-queue) guide for how to configure and handle dead letters.
 
 ## What's next?
 
-- [**Broadcast Events**](/docs/patterns/broadcast) — fan-out delivery to all service instances
-- [**Dead Letter Queue**](/docs/guides/dead-letter-queue) — handle messages that exhaust all retries
-- [**Record Builder**](/docs/guides/record-builder) — attach custom headers and message IDs
-- [**Lifecycle Hooks**](/docs/guides/lifecycle-hooks) — observe transport events like dead letters and message routing
-- [**Performance Tuning**](/docs/guides/performance) — concurrency, ack extension, and backpressure
-- [**Troubleshooting**](/docs/guides/troubleshooting#consumer-issues) — diagnosing delivery and redelivery issues
+- [**Broadcast Events**](/docs/patterns/broadcast): fan-out delivery to all service instances
+- [**Dead Letter Queue**](/docs/guides/dead-letter-queue): handle messages that exhaust all retries
+- [**Record Builder**](/docs/guides/record-builder): attach custom headers and message IDs
+- [**Lifecycle Hooks**](/docs/guides/lifecycle-hooks): observe transport events like dead letters and message routing
+- [**Performance Tuning**](/docs/guides/performance): concurrency, ack extension, and backpressure
+- [**Troubleshooting**](/docs/guides/troubleshooting#consumer-issues): diagnosing delivery and redelivery issues

--- a/website/docs/patterns/events.md
+++ b/website/docs/patterns/events.md
@@ -8,7 +8,7 @@ schema:
   headline: "Workqueue Events: NestJS JetStream At-Least-Once Delivery"
   description: "NestJS NATS JetStream workqueue events with at-least-once delivery, automatic retry, publish-side deduplication, and dead letter handling."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Events (Workqueue)

--- a/website/docs/patterns/handler-metadata.md
+++ b/website/docs/patterns/handler-metadata.md
@@ -8,7 +8,7 @@ schema:
   headline: "Handler Metadata Registry: NATS KV Service Discovery for NestJS"
   description: "Publish NestJS handler metadata to a NATS KV bucket for dynamic service discovery, API gateway routing, and automatic catalog generation."
   datePublished: "2026-04-02"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/patterns/handler-metadata.md
+++ b/website/docs/patterns/handler-metadata.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 5
 sidebar_label: "Handler Metadata"
-title: "Handler Metadata Registry — NATS KV Service Discovery for NestJS"
+title: "Handler Metadata Registry: NATS KV Service Discovery for NestJS"
 description: "Publish NestJS handler metadata to a NATS KV bucket for dynamic service discovery, API gateway routing, and automatic catalog generation."
 schema:
   type: Article
-  headline: "Handler Metadata Registry — NATS KV Service Discovery for NestJS"
+  headline: "Handler Metadata Registry: NATS KV Service Discovery for NestJS"
   description: "Publish NestJS handler metadata to a NATS KV bucket for dynamic service discovery, API gateway routing, and automatic catalog generation."
   datePublished: "2026-04-02"
   dateModified: "2026-06-12"
@@ -17,7 +17,7 @@ import Since from '@site/src/components/Since';
 
 <Since version="2.9.0" />
 
-Publish handler metadata to a NATS KV bucket at startup. External services — API gateways, dashboards, CLI tools — can read or watch the bucket for automatic service discovery.
+Publish handler metadata to a NATS KV bucket at startup. External services (API gateways, dashboards, CLI tools) can read or watch the bucket for automatic service discovery.
 
 **Requires:** NATS Server 2.10+ (KV support)
 
@@ -107,9 +107,9 @@ JetstreamModule.forRoot({
 })
 ```
 
-- **`bucket`** &mdash; `'handler_registry'`. KV bucket name.
-- **`replicas`** &mdash; `1`. Bucket replicas (1, 3, or 5).
-- **`ttl`** &mdash; `30_000`. Entry TTL in milliseconds; entries expire unless refreshed by heartbeat (minimum: `5_000` ms). Note: this field is in ms, not nanoseconds.
+- **`bucket`**, `'handler_registry'`. KV bucket name.
+- **`replicas`**, `1`. Bucket replicas (1, 3, or 5).
+- **`ttl`**, `30_000`. Entry TTL in milliseconds; entries expire unless refreshed by heartbeat (minimum: `5_000` ms). Note: this field is in ms, not nanoseconds.
 
 :::note Bucket configuration
 The KV bucket is created on first startup. Changing `ttl` or `replicas` after creation requires deleting the existing bucket; NATS KV does not update bucket config in place. Use the NATS CLI: `nats kv rm handler_registry`.
@@ -137,7 +137,7 @@ const key = metadataKey('orders', StreamKind.Event, 'order.created');
 
 ## Meta structure
 
-The `meta` field is `Record<string, unknown>` — the library serializes it as JSON and stores as-is with no schema enforcement. Values must be JSON-serializable. You decide the structure based on your use case.
+The `meta` field is `Record<string, unknown>`: the library serializes it as JSON and stores as-is with no schema enforcement. Values must be JSON-serializable. You decide the structure based on your use case.
 
 :::warning Security
 The `meta` object is stored in a shared NATS KV bucket readable by any connected service. Never include secrets, API keys, passwords, or personally identifiable information (PII) in handler metadata.
@@ -159,14 +159,14 @@ The `meta` object is stored in a shared NATS KV bucket readable by any connected
 
 ## Lifecycle
 
-Entries are managed via TTL + heartbeat — no explicit delete needed.
+Entries are managed via TTL + heartbeat: no explicit delete needed.
 
 - **Startup.** The transport writes all handler meta entries to KV and starts the heartbeat.
 - **Heartbeat.** Every `ttl / 2`, all entries are re-written to reset their TTL.
 - **Graceful shutdown.** Heartbeat stops; entries expire after TTL.
 - **Crash.** Heartbeat stops; entries expire after TTL (automatic cleanup).
 - **Rolling update.** The new pod writes entries immediately; old entries from removed handlers expire via TTL.
-- **Multi-pod.** All pods heartbeat the same keys — entries stay alive while any pod is running.
+- **Multi-pod.** All pods heartbeat the same keys: entries stay alive while any pod is running.
 
 ## Use cases
 
@@ -190,10 +190,10 @@ nats kv get handler_registry orders.ev.order.created
 nats kv watch handler_registry
 ```
 
-If entries are missing or the bucket fails to create, see [Troubleshooting — Handler metadata registry](/docs/guides/troubleshooting#handler-metadata-registry).
+If entries are missing or the bucket fails to create, see [Troubleshooting, Handler metadata registry](/docs/guides/troubleshooting#handler-metadata-registry).
 
 ## See also
 
-- [Naming Conventions — `metadataKey()`](/docs/reference/naming-conventions#metadatakeyservicename-kind-pattern) — programmatic key construction
-- [Module Configuration](/docs/reference/module-configuration) — the `metadata` option in the full options reference
-- [Events (Workqueue)](/docs/patterns/events), [RPC](/docs/patterns/rpc), [Broadcast](/docs/patterns/broadcast), [Ordered Events](/docs/patterns/ordered-events) — any handler type can attach `meta`
+- [Naming Conventions: `metadataKey()`](/docs/reference/naming-conventions#metadatakeyservicename-kind-pattern): programmatic key construction
+- [Module Configuration](/docs/reference/module-configuration): the `metadata` option in the full options reference
+- [Events (Workqueue)](/docs/patterns/events), [RPC](/docs/patterns/rpc), [Broadcast](/docs/patterns/broadcast), [Ordered Events](/docs/patterns/ordered-events): any handler type can attach `meta`

--- a/website/docs/patterns/ordered-events.md
+++ b/website/docs/patterns/ordered-events.md
@@ -8,7 +8,7 @@ schema:
   headline: "Ordered Events: Strict Sequential Delivery in NATS JetStream"
   description: "Strict sequential NestJS NATS JetStream event delivery with ephemeral ordered consumers, deliver policies, and CQRS replay patterns."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/patterns/ordered-events.md
+++ b/website/docs/patterns/ordered-events.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 2
 sidebar_label: "Ordered Events"
-title: "Ordered Events — Strict Sequential Delivery in NATS JetStream"
+title: "Ordered Events: Strict Sequential Delivery in NATS JetStream"
 description: "Strict sequential NestJS NATS JetStream event delivery with ephemeral ordered consumers, deliver policies, and CQRS replay patterns."
 schema:
   type: Article
-  headline: "Ordered Events — Strict Sequential Delivery in NATS JetStream"
+  headline: "Ordered Events: Strict Sequential Delivery in NATS JetStream"
   description: "Strict sequential NestJS NATS JetStream event delivery with ephemeral ordered consumers, deliver policies, and CQRS replay patterns."
   datePublished: "2026-03-21"
   dateModified: "2026-06-12"
@@ -18,29 +18,29 @@ import Since from '@site/src/components/Since';
 # Ordered Events
 
 > **Use when:** every replica needs to rebuild its own state from a strict, replayable event sequence (CQRS read models, in-memory caches, projections).
-> **You get:** ephemeral ordered consumers — each replica reads the full stream in order, independently.
+> **You get:** ephemeral ordered consumers: each replica reads the full stream in order, independently.
 
 ## The problem: rebuilding state from event history
 
-Imagine you're building an e-commerce platform. Every time an order changes status — created, paid, shipped, delivered — you publish an event. Downstream, a projections service rebuilds a read model (an Elasticsearch index, a Redis cache, a reporting database) from these events.
+Imagine you're building an e-commerce platform. Every time an order changes status (created, paid, shipped, delivered) you publish an event. Downstream, a projections service rebuilds a read model (an Elasticsearch index, a Redis cache, a reporting database) from these events.
 
-Here's the catch: **order matters**. If the projections service processes "delivered" before "shipped", your read model is wrong. If it processes "paid" before "created", you get a foreign key violation. And if a message is lost, your projection diverges silently from reality.
+**Order matters here.** If the projections service processes "delivered" before "shipped", your read model is wrong. If it processes "paid" before "created", you get a foreign key violation. And if a message is lost, your projection diverges silently from reality.
 
-Standard [workqueue events](/docs/patterns/events) don't help here — they're designed for parallel processing and load balancing, not for sequential replay. You need a messaging primitive that guarantees:
+Standard [workqueue events](/docs/patterns/events) don't help here: they're designed for parallel processing and load balancing, not for sequential replay. You need a messaging primitive that guarantees:
 
-1. **Strict ordering** — messages arrive in exactly the sequence they were published
-2. **Full replay** — new instances can catch up from the beginning of the stream
-3. **Per-instance delivery** — each service instance gets its own independent view of the stream
+1. **Strict ordering**: messages arrive in exactly the sequence they were published
+2. **Full replay**: new instances can catch up from the beginning of the stream
+3. **Per-instance delivery**: each service instance gets its own independent view of the stream
 
 This is what ordered events provide.
 
 ## How ordered consumers work
 
-Under the hood, ordered events use a fundamentally different NATS JetStream primitive than workqueue or broadcast events. Understanding these differences is key to using them correctly.
+Under the hood, ordered events use a different NATS JetStream primitive than workqueue or broadcast events. Understanding these differences is key to using them correctly.
 
-### Ephemeral, not durable
+### Ephemeral consumers
 
-Workqueue and broadcast events use **durable consumers** — server-side state that tracks which messages have been acknowledged. Ordered events use **ordered consumers**, which are ephemeral. There is no server-side consumer state. The `@nats-io/jetstream` client creates a new consumer on each connection and manages its lifecycle internally.
+Workqueue and broadcast events use **durable consumers**: server-side state that tracks which messages have been acknowledged. Ordered events use **ordered consumers**, which are ephemeral. The server keeps no consumer state. The `@nats-io/jetstream` client creates a new consumer on each connection and manages its lifecycle internally.
 
 This means:
 - No consumer name appears in `nats consumer ls`
@@ -58,11 +58,11 @@ The ordered stream uses **Limits retention** (`RetentionPolicy.Limits`), not Wor
 | Replay possible | No (messages are gone after ack) | Yes (messages persist) |
 | Default `max_age` | 7 days | **1 day** |
 
-With Limits retention, messages stay in the stream until they expire (default: 1 day, configurable via `max_age`). Every consumer — and every service instance — can read the full history independently.
+With Limits retention, messages stay in the stream until they expire (default: 1 day, configurable via `max_age`). Every consumer, and every service instance, can read the full history independently.
 
 ### Auto-acknowledgment
 
-The `@nats-io/jetstream` client automatically acknowledges messages from ordered consumers. Your handler code never calls `msg.ack()` or `msg.nak()`. This is not optional — it's baked into the ordered consumer protocol.
+The `@nats-io/jetstream` client automatically acknowledges messages from ordered consumers. Your handler code never calls `msg.ack()` or `msg.nak()`. This is not optional: it's baked into the ordered consumer protocol.
 
 ### Self-healing
 
@@ -74,19 +74,19 @@ Ordered consumers provide **at-most-once** delivery. This is the fundamental tra
 
 ### What happens when things go wrong
 
-For ordered consumers, **no scenario triggers a retry** — the consumer always advances to the next message. This is the fundamental trade-off for strict ordering.
+For ordered consumers, **no scenario triggers a retry**: the consumer always advances to the next message. This is the fundamental trade-off for strict ordering.
 
-- **Handler succeeds** &mdash; auto-acked by the client.
-- **Handler throws an error** &mdash; error is logged; the consumer moves to the next message.
-- **Decode error (malformed payload)** &mdash; error is logged; the message is skipped.
-- **No handler registered for subject** &mdash; error is logged; the message is skipped.
+- **Handler succeeds**, auto-acked by the client.
+- **Handler throws an error**, error is logged; the consumer moves to the next message.
+- **Decode error (malformed payload)**, error is logged; the message is skipped.
+- **No handler registered for subject**, error is logged; the message is skipped.
 
 ### Why no retries?
 
-Retrying a failed message would block all subsequent messages (since ordering must be preserved), creating a head-of-line blocking problem. A single poison message could halt your entire pipeline. Instead, the transport logs the error and moves on.
+Retrying a failed message would block all later messages (since ordering must be preserved), creating a head-of-line blocking problem. A single poison message could halt your entire pipeline. Instead, the transport logs the error and moves on.
 
 :::warning Handler errors are silent from a delivery perspective
-If your handler throws, the message is gone. The ordered consumer does not support `nak()`, `term()`, or any form of negative acknowledgment. Design your handlers to be defensive — catch errors internally if you need to persist failures to a dead letter table or retry queue.
+If your handler throws, the message is gone. The ordered consumer does not support `nak()`, `term()`, or any form of negative acknowledgment. Design your handlers to be defensive, catch errors internally if you need to persist failures to a dead letter table or retry queue.
 :::
 
 ### Sequential processing with concatMap
@@ -231,17 +231,17 @@ export class ProjectionsController {
 
 The deliver policy controls **where the ordered consumer starts reading** when it is created (or recreated after a restart). This is the most important configuration decision for ordered events.
 
-A one-liner per policy — open the matching `<details>` block below for the full discussion:
+A one-liner per policy, open the matching `<details>` block below for the full discussion:
 
-- **`All`** (default) — replays the full stream on every restart. No external state needed. Best for read-model rebuilds and event sourcing.
-- **`New`** — starts from messages published after the consumer is created. Skips history; misses messages emitted while the consumer is down. Best for real-time dashboards and live feeds.
-- **`Last`** — delivers only the most recent message in the stream. Best for config initialization.
-- **`LastPerSubject`** — delivers the most recent message per subject. Best for per-entity state maps.
-- **`StartSequence`** — resumes from a tracked offset stored in your application (e.g., in a database). Best for resumable projections.
-- **`StartTime`** — resumes from an ISO timestamp. Best for debugging and time-based recovery.
+- **`All`** (default): replays the full stream on every restart. No external state needed. Best for read-model rebuilds and event sourcing.
+- **`New`**: starts from messages published after the consumer is created. Skips history; misses messages emitted while the consumer is down. Best for real-time dashboards and live feeds.
+- **`Last`**: delivers only the most recent message in the stream. Best for config initialization.
+- **`LastPerSubject`**: delivers the most recent message per subject. Best for per-entity state maps.
+- **`StartSequence`**: resumes from a tracked offset stored in your application (e.g., in a database). Best for resumable projections.
+- **`StartTime`**: resumes from an ISO timestamp. Best for debugging and time-based recovery.
 
 <details>
-<summary><b>All</b> — full replay on every start <i>(default)</i></summary>
+<summary><b>All</b>: full replay on every start <i>(default)</i></summary>
 
 **Scenario:** You're building a CQRS read model that must reflect the complete event history. An Elasticsearch index, a materialized view in PostgreSQL, or a Redis cache that's fully derived from events.
 
@@ -260,9 +260,9 @@ JetstreamModule.forRoot({
 
 **How it works:** On every startup (or reconnection), the consumer replays **all messages** currently in the stream, bounded by `max_age`. If your stream has 7 days of history, every restart replays 7 days of events.
 
-**Restart behavior:** Full replay from the beginning of the stream. Your handlers must be **idempotent** — processing the same event twice must produce the same result.
+**Restart behavior:** Full replay from the beginning of the stream. Your handlers must be **idempotent**: processing the same event twice must produce the same result.
 
-**When to use:** services that build state entirely from events and can afford to replay on startup. The simplest model — no external offset tracking needed.
+**When to use:** services that build state entirely from events and can afford to replay on startup. The simplest model: no external offset tracking needed.
 
 :::caution Replay volume
 With `All` policy, a service that restarts after running for 7 days will replay 7 days of events before it's caught up. Consider the time and resource cost of this replay. If it's too expensive, look at `StartSequence` with external offset tracking, or reduce `max_age`.
@@ -271,9 +271,9 @@ With `All` policy, a service that restarts after running for 7 days will replay 
 </details>
 
 <details>
-<summary><b>New</b> — start from "now", skip backlog</summary>
+<summary><b>New</b>: start from "now", skip backlog</summary>
 
-**Scenario:** A real-time dashboard that shows live order activity. Historical data is loaded from a database on startup — you only need events published *after* the service starts.
+**Scenario:** A real-time dashboard that shows live order activity. Historical data is loaded from a database on startup: you only need events published *after* the service starts.
 
 ```typescript
 import { DeliverPolicy } from '@nats-io/jetstream';
@@ -289,7 +289,7 @@ JetstreamModule.forRoot({
 
 **How it works:** The consumer starts from the **current stream position** at creation time. Only messages published after the consumer connects are delivered.
 
-**Restart behavior:** Messages published **while the service was down are skipped**. After a restart, the consumer starts fresh from the new "now" position. There is no catch-up.
+**Restart behavior:** Messages published **while the service was down are skipped**. After a restart, the consumer starts fresh from the new "now" position. Nothing catches up.
 
 :::warning Gap on restart
 If your service restarts and messages were published during downtime, those messages are lost from this consumer's perspective. Use `New` only when missing messages during downtime is acceptable (dashboards, metrics, monitoring).
@@ -298,9 +298,9 @@ If your service restarts and messages were published during downtime, those mess
 </details>
 
 <details>
-<summary><b>Last</b> — only the most recent message, then live</summary>
+<summary><b>Last</b>: only the most recent message, then live</summary>
 
-**Scenario:** A configuration cache service that needs the latest config value on startup, then listens for updates. The stream contains configuration snapshots — you only need the most recent one to initialize, then you track changes going forward.
+**Scenario:** A configuration cache service that needs the latest config value on startup, then listens for updates. The stream contains configuration snapshots: you only need the most recent one to initialize, then you track changes going forward.
 
 ```typescript
 import { DeliverPolicy } from '@nats-io/jetstream';
@@ -323,7 +323,7 @@ JetstreamModule.forRoot({
 </details>
 
 <details>
-<summary><b>LastPerSubject</b> — latest per entity, then live</summary>
+<summary><b>LastPerSubject</b>: latest per entity, then live</summary>
 
 **Scenario:** An in-memory status map that tracks the latest state of every entity. The stream contains per-entity subjects like `order.status.123`, `order.status.456`. On startup, you need the latest status for *each* order, then you track updates in real time.
 
@@ -341,16 +341,16 @@ JetstreamModule.forRoot({
 
 **How it works:** On startup, delivers the **last message for each unique subject** in the stream. If the stream has 10,000 subjects, you get 10,000 messages (one per subject). Then continues with new messages.
 
-**Restart behavior:** Same as initial startup — delivers the latest per subject, then live messages.
+**Restart behavior:** Same as initial startup, delivers the latest per subject, then live messages.
 
 The "per subject" grouping is based on the full NATS subject. If you publish to `ordered:order.status` (a single subject), `LastPerSubject` behaves like `Last`. To get per-entity delivery, publish to `ordered:order.status.{orderId}` and register your handler with a wildcard or specific patterns.
 
 </details>
 
 <details>
-<summary><b>StartSequence</b> — resume from a tracked offset</summary>
+<summary><b>StartSequence</b>: resume from a tracked offset</summary>
 
-**Scenario:** A resumable projection that stores its last-processed sequence number in an external database. On restart, it reads the stored offset and resumes from exactly that point — no re-processing, no gaps.
+**Scenario:** A resumable projection that stores its last-processed sequence number in an external database. On restart, it reads the stored offset and resumes from exactly that point: no re-processing, no gaps.
 
 ```typescript
 import { DeliverPolicy } from '@nats-io/jetstream';
@@ -400,7 +400,7 @@ async handleOrderStatus(
 </details>
 
 <details>
-<summary><b>StartTime</b> — replay from a wall-clock timestamp</summary>
+<summary><b>StartTime</b>: replay from a wall-clock timestamp</summary>
 
 **Scenario:** Debugging a production issue. You know the bug was introduced around 14:00 UTC and you want to replay the last 2 hours of events against a fixed handler to verify the fix.
 
@@ -486,11 +486,11 @@ ordered: {
 
 ## Scaling behavior
 
-Ordered consumers behave fundamentally differently from workqueue consumers when it comes to scaling.
+Ordered consumers scale differently from workqueue consumers.
 
 ### Every instance gets every message
 
-Unlike workqueue events (where messages are load-balanced across instances), **every instance with an ordered consumer receives all messages independently**. There is no competition, no message distribution, no consumer groups.
+Unlike workqueue events (where messages are load-balanced across instances), **every instance with an ordered consumer receives all messages independently**. Every replica reads the whole stream on its own, with no distribution or consumer groups involved.
 
 ```mermaid
 flowchart LR
@@ -501,7 +501,7 @@ flowchart LR
 
 Each instance receives **all** messages independently.
 
-This is by design — ordered consumers are meant for per-instance state building (caches, projections, in-memory indexes).
+This is by design, ordered consumers are meant for per-instance state building (caches, projections, in-memory indexes).
 
 ### Single-instance for exclusive processing
 
@@ -546,7 +546,7 @@ async handleOrderStatus(@Payload() data: OrderStatusDto) {
 |---|---|---|
 | **Delivery guarantee** | At-least-once | At-most-once |
 | **Message ordering** | Not guaranteed (parallel) | Strict sequential |
-| **Handler parallelism** | `mergeMap`; concurrent | `concatMap` — one at a time |
+| **Handler parallelism** | `mergeMap`; concurrent | `concatMap`: one at a time |
 | **Retry on failure** | Yes (`nak` triggers redeliver) | No (error logged, continues) |
 | **Dead letter queue** | Yes (after `max_deliver` attempts) | No |
 | **Acknowledgment** | Explicit (`msg.ack()`) | Automatic by the client |
@@ -577,7 +577,7 @@ See [Events (Workqueue)](/docs/patterns/events) for workqueue event documentatio
 
 In the NATS JavaScript SDK (originally observed in `nats` v2.29.x, workaround retained for `@nats-io/jetstream` v3.x), explicitly passing `DeliverPolicy.All` to an ordered consumer causes `consume()` to hang indefinitely. The root cause: when `deliver_policy` is set to `All`, the SDK internally leaves a residual `opt_start_seq` field in the consumer configuration, which conflicts with the ordered consumer protocol.
 
-**The transport works around this automatically.** When the configured deliver policy is `All` (or unset), the transport omits the `deliver_policy` field entirely. The SDK default behavior is identical to `All`, so the result is the same — without the bug.
+**The transport works around this automatically.** When the configured deliver policy is `All` (or unset), the transport omits the `deliver_policy` field entirely. The SDK default behavior is identical to `All`, so the result is the same, without the bug.
 
 ```typescript
 // This works correctly (transport omits deliver_policy internally):
@@ -597,7 +597,7 @@ This workaround is invisible to your application code. It's documented here for 
 
 ### No partial replay
 
-Ordered consumers do not support "resume from where I left off" natively. If the consumer disconnects and reconnects, the client recreates it — but the starting position depends on the configured deliver policy, not on the last message processed. For resumable processing, use `DeliverPolicy.StartSequence` with external offset tracking (see the **StartSequence** entry in [Deliver policy deep dive](#deliver-policy-deep-dive)).
+Ordered consumers do not support "resume from where I left off" natively. If the consumer disconnects and reconnects, the client recreates it, but the starting position depends on the configured deliver policy, not on the last message processed. For resumable processing, use `DeliverPolicy.StartSequence` with external offset tracking (see the **StartSequence** entry in [Deliver policy deep dive](#deliver-policy-deep-dive)).
 
 ### Stream name is derived automatically
 
@@ -605,8 +605,8 @@ The ordered stream name follows the library's [naming conventions](/docs/referen
 
 ## What's next?
 
-- [Events (Workqueue)](/docs/patterns/events) — at-least-once delivery with load balancing
-- [Module Configuration](/docs/reference/module-configuration) — full options reference including `ordered`
-- [Default Configs](/docs/reference/default-configs) — stream and consumer defaults for all stream types
-- [Lifecycle Hooks](/docs/guides/lifecycle-hooks) — monitor errors, reconnections, and transport events
-- [Troubleshooting](/docs/guides/troubleshooting) — common issues and debugging
+- [Events (Workqueue)](/docs/patterns/events): at-least-once delivery with load balancing
+- [Module Configuration](/docs/reference/module-configuration): full options reference including `ordered`
+- [Default Configs](/docs/reference/default-configs): stream and consumer defaults for all stream types
+- [Lifecycle Hooks](/docs/guides/lifecycle-hooks): monitor errors, reconnections, and transport events
+- [Troubleshooting](/docs/guides/troubleshooting): common issues and debugging

--- a/website/docs/patterns/rpc.md
+++ b/website/docs/patterns/rpc.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
 sidebar_label: "RPC (Request/Reply)"
-title: "NestJS NATS RPC — Core vs JetStream Request/Reply"
+title: "NestJS NATS RPC: Core vs JetStream Request/Reply"
 description: "Synchronous NestJS NATS request-reply in Core NATS or JetStream mode, with timeout handling, error serialization, and per-request overrides."
 schema:
   type: Article
-  headline: "NestJS NATS RPC — Core vs JetStream Request/Reply"
+  headline: "NestJS NATS RPC: Core vs JetStream Request/Reply"
   description: "Synchronous NestJS NATS request-reply in Core NATS or JetStream mode, with timeout handling, error serialization, and per-request overrides."
   datePublished: "2026-03-21"
   dateModified: "2026-04-11"
@@ -20,7 +20,7 @@ Your API gateway needs to fetch an order from the orders microservice. The clien
 
 ## Core Mode (Default)
 
-Core mode uses NATS native request/reply — the fastest path with no persistence overhead. It is the default when you do not configure `rpc` or set `rpc.mode` to `'core'`.
+Core mode uses NATS native request/reply: the fastest path with no persistence overhead. It is the default when you do not configure `rpc` or set `rpc.mode` to `'core'`.
 
 ### How it works
 
@@ -93,7 +93,7 @@ Handlers can return a plain value, a `Promise`, or an `Observable`. For an Obser
 
 **Decode failure.** An error response is returned to the caller; the handler is not invoked.
 
-**Timeout exceeded.** NATS returns a timeout error to the client — no response was produced in time.
+**Timeout exceeded.** NATS returns a timeout error to the client: no response was produced in time.
 
 ## JetStream Mode
 
@@ -129,10 +129,10 @@ sequenceDiagram
 
 ### Code example
 
-The application code is **identical** to Core mode — the transport handles the plumbing:
+The application code is **identical** to Core mode: the transport handles the plumbing:
 
 ```typescript
-// Same client code — mode is configured at module level, not per call
+// Same client code, mode is configured at module level, not per call
 const order = await firstValueFrom(
   this.ordersClient.send<Order>('get.order', { id }),
 );
@@ -140,7 +140,7 @@ const order = await firstValueFrom(
 
 ### Error behavior
 
-**Handler throws `RpcException`.** The error is published to the caller's inbox with the `x-error` header. The message is `term()`'d — no redelivery.
+**Handler throws `RpcException`.** The error is published to the caller's inbox with the `x-error` header. The message is `term()`'d: no redelivery.
 
 **Handler throws a generic `Error`.** `{ message }` is published to the inbox; the message is `term()`'d.
 
@@ -165,7 +165,7 @@ RPC commands are **never** redelivered via `nak()`. Retrying a command could cau
 | Aspect | Core Mode | JetStream Mode |
 |---|---|---|
 | **Latency** | Lowest (direct request/reply) | Slightly higher (stream persistence + inbox routing) |
-| **Persistence** | None — fire and forget | Commands persisted in stream before delivery |
+| **Persistence** | None: fire and forget | Commands persisted in stream before delivery |
 | **If server is offline** | Client gets timeout error immediately | Message queued in stream, delivered when server starts |
 | **Retry on failure** | No built-in retry | No retry (`max_deliver: 1`), error returned to caller |
 | **Default timeout** | 30 seconds | 3 minutes |
@@ -181,15 +181,15 @@ RPC commands are **never** redelivered via `nak()`. Retrying a command could cau
 The transport serializes errors differently based on their type:
 
 ```typescript
-// 1. RpcException — full payload preserved
+// 1. RpcException, full payload preserved
 throw new RpcException({ code: 'NOT_FOUND', message: 'Order not found' });
 // Client receives: { code: 'NOT_FOUND', message: 'Order not found' }
 
-// 2. Generic Error — only message extracted
+// 2. Generic Error, only message extracted
 throw new Error('Something went wrong');
 // Client receives: { message: 'Something went wrong' }
 
-// 3. Plain object — passed through as-is
+// 3. Plain object, passed through as-is
 throw { code: 'VALIDATION_ERROR', fields: ['email'] };
 // Client receives: { code: 'VALIDATION_ERROR', fields: ['email'] }
 ```
@@ -219,10 +219,10 @@ export class CustomRpcFilter implements RpcExceptionFilter<RpcException> {
 
 A single `timeout` value in `RpcConfig` controls **both sides** of the RPC call:
 
-- **Client side** — how long the client waits for a response before rejecting with `"RPC timeout"`.
-- **Server side (JetStream mode only)** — how long the handler has to complete before the message is `term()`'d.
+- **Client side**: how long the client waits for a response before rejecting with `"RPC timeout"`.
+- **Server side (JetStream mode only)**: how long the handler has to complete before the message is `term()`'d.
 
-Defaults: **Core** &mdash; 30,000 ms (30 s). **JetStream** &mdash; 180,000 ms (3 min). Both modes accept the value under `rpc.timeout`.
+Defaults: **Core**, 30,000 ms (30 s). **JetStream**, 180,000 ms (3 min). Both modes accept the value under `rpc.timeout`.
 
 ```typescript
 JetstreamModule.forRoot({
@@ -261,7 +261,7 @@ See [Module Configuration](/docs/reference/module-configuration) for all `RpcCon
 
 ### Server not running
 
-**Core mode.** The client receives a timeout error — no subscriber exists to handle the request, so NATS gives up after the deadline.
+**Core mode.** The client receives a timeout error: no subscriber exists to handle the request, so NATS gives up after the deadline.
 
 **JetStream mode.** The command is persisted in the stream. When the server comes online, the consumer delivers it. If the client's timeout expires before the response arrives, the client receives a timeout error but the handler may still execute later.
 
@@ -271,7 +271,7 @@ If the client times out but the server processes the message later, the response
 
 ### Observable returns
 
-When a handler returns an `Observable`, the transport subscribes and takes the **first emitted value** as the RPC response. Subsequent emissions are ignored, and the subscription is cleaned up immediately.
+When a handler returns an `Observable`, the transport subscribes and takes the **first emitted value** as the RPC response. Later emissions are ignored, and the subscription is cleaned up immediately.
 
 ```typescript
 @MessagePattern('stream.first')
@@ -283,7 +283,7 @@ handleStream(): Observable<string> {
 
 ### Double-settlement protection (JetStream mode)
 
-The JetStream RPC router uses a `settled` flag to prevent race conditions between the handler completing and the timeout firing. Once the message is settled (ack'd, term'd, or timed out), any subsequent settlement attempt is a no-op. This means:
+The JetStream RPC router uses a `settled` flag to prevent race conditions between the handler completing and the timeout firing. Once the message is settled (ack'd, term'd, or timed out), any later settlement attempt is a no-op. This means:
 
 - If the handler completes just as the timeout fires, only one path executes.
 - No duplicate responses are published to the client's inbox.
@@ -305,7 +305,7 @@ In Core mode, NATS handles disconnect behavior natively. Pending `nc.request()` 
 
 ## See Also
 
-- [Record Builder](/docs/guides/record-builder) — custom headers, message IDs, per-request timeouts
-- [Module Configuration](/docs/reference/module-configuration) — RPC mode selection and timeout config
-- [Performance Tuning](/docs/guides/performance) — concurrency and ack extension for JetStream RPC
-- [Troubleshooting](/docs/guides/troubleshooting#rpc-issues) — diagnosing timeout and routing errors
+- [Record Builder](/docs/guides/record-builder): custom headers, message IDs, per-request timeouts
+- [Module Configuration](/docs/reference/module-configuration): RPC mode selection and timeout config
+- [Performance Tuning](/docs/guides/performance): concurrency and ack extension for JetStream RPC
+- [Troubleshooting](/docs/guides/troubleshooting#rpc-issues): diagnosing timeout and routing errors

--- a/website/docs/patterns/rpc.md
+++ b/website/docs/patterns/rpc.md
@@ -8,7 +8,7 @@ schema:
   headline: "NestJS NATS RPC: Core vs JetStream Request/Reply"
   description: "Synchronous NestJS NATS request-reply in Core NATS or JetStream mode, with timeout handling, error serialization, and per-request overrides."
   datePublished: "2026-03-21"
-  dateModified: "2026-04-11"
+  dateModified: "2026-07-26"
 ---
 
 # RPC (Request/Reply)

--- a/website/docs/reference/default-configs.md
+++ b/website/docs/reference/default-configs.md
@@ -8,7 +8,7 @@ schema:
   headline: "Default Stream & Consumer Configs for NATS JetStream"
   description: "Production-ready default stream, consumer, and connection settings for every NestJS JetStream StreamKind (event, broadcast, ordered, command, DLQ)."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Default Configs

--- a/website/docs/reference/default-configs.md
+++ b/website/docs/reference/default-configs.md
@@ -43,7 +43,7 @@ events: {
 
 ### Event Stream
 
-Workqueue retention — each message is removed after being acknowledged by a consumer.
+Workqueue retention: each message is removed after being acknowledged by a consumer.
 
 | Property | Value | Notes |
 |----------|-------|-------|
@@ -83,7 +83,7 @@ Short-lived RPC commands (JetStream RPC mode only).
 
 ### Broadcast Stream
 
-Limits retention — messages persist until the configured limits are reached. Shared across all services.
+Limits retention, messages persist until the configured limits are reached. Shared across all services.
 
 | Property | Value | Notes |
 |----------|-------|-------|
@@ -100,7 +100,7 @@ Limits retention — messages persist until the configured limits are reached. S
 | `duplicate_window` | `2 minutes` | `toNanos(2, 'minutes')` |
 
 :::info Changed in v2.9.0
-`max_age` reduced from 1 day to 1 hour. Broadcast messages (config propagation, cache invalidation, feature flags) are relevant for minutes, not days. 1 hour provides sufficient catch-up window for new instances while reducing unnecessary storage. This is a mutable property — existing streams update automatically on next startup.
+`max_age` reduced from 1 day to 1 hour. Broadcast messages (config propagation, cache invalidation, feature flags) are relevant for minutes, not days. 1 hour provides enough catch-up window for new instances while reducing unnecessary storage. This is a mutable property, existing streams update automatically on next startup.
 :::
 
 ### Ordered Stream
@@ -123,7 +123,7 @@ Limits retention for strict sequential delivery. Ordered consumers are ephemeral
 
 ### DLQ Stream
 
-Workqueue retention — dead letters are removed when a DLQ consumer acks them. Created on demand when `dlq: { stream }` is set in `forRoot()`. See [Dead Letter Queue — Built-in DLQ stream](/docs/guides/dead-letter-queue#built-in-dlq-stream).
+Workqueue retention, dead letters are removed when a DLQ consumer acks them. Created on demand when `dlq: { stream }` is set in `forRoot()`. See [Dead Letter Queue, Built-in DLQ stream](/docs/guides/dead-letter-queue#built-in-dlq-stream).
 
 | Property | Value | Notes |
 |----------|-------|-------|
@@ -157,7 +157,7 @@ Workqueue retention — dead letters are removed when a DLQ consumer acks them. 
 | Property | Value | Notes |
 |----------|-------|-------|
 | `ack_wait` | `5 minutes` | `toNanos(5, 'minutes')` |
-| `max_deliver` | `1` | No retries — RPC failures propagate immediately |
+| `max_deliver` | `1` | No retries: RPC failures propagate immediately |
 | `max_ack_pending` | `100` | |
 | `ack_policy` | `Explicit` | |
 | `deliver_policy` | `All` | |
@@ -233,7 +233,7 @@ JetstreamModule.forRoot({
 ```
 
 :::tip
-`num_replicas` can be changed on an existing stream — NATS will add or remove replicas automatically. No downtime or stream recreation required.
+`num_replicas` can be changed on an existing stream, NATS will add or remove replicas automatically. No downtime or stream recreation required.
 :::
 
 ## Immutable vs mutable stream properties
@@ -244,7 +244,7 @@ NATS JetStream divides stream configuration into properties that can be updated 
 
 `num_replicas`, `max_age`, `max_bytes`, `max_msgs`, `max_msg_size`, `max_msgs_per_subject`, `discard`, `duplicate_window`, `subjects`, `compression`, `description`, `allow_rollup_hdrs`, `allow_direct`
 
-The transport applies mutable changes automatically on startup — just update the value in `forRoot()` and restart the service.
+The transport applies mutable changes automatically on startup, just update the value in `forRoot()` and restart the service.
 
 ### Enable-only (can be turned on, but never off)
 
@@ -252,7 +252,7 @@ These properties can be **enabled** on an existing stream via a normal update, b
 
 | Property | Default | Notes |
 |----------|---------|-------|
-| `allow_msg_schedules` | `false` | Enable [message scheduling](/docs/guides/scheduling) — safe to add to existing streams |
+| `allow_msg_schedules` | `false` | Enable [message scheduling](/docs/guides/scheduling): safe to add to existing streams |
 | `allow_msg_ttl` | `false` | Enable per-message TTL |
 | `deny_delete` | `false` | Prevent message deletion via API |
 | `deny_purge` | `false` | Prevent stream purging via API |
@@ -266,7 +266,7 @@ You can safely add `allow_msg_schedules: true` to an existing stream config; NAT
 | Property | Default | Migratable | Notes |
 |----------|---------|-----------|-------|
 | `name` | derived from service name | No | Cannot be renamed |
-| `retention` | `Workqueue` or `Limits` | **No** | Controlled by the transport — a mismatch is always an error |
+| `retention` | `Workqueue` or `Limits` | **No** | Controlled by the transport: a mismatch is always an error |
 | `storage` | `File` | **Yes** | Can be migrated with `allowDestructiveMigration: true` |
 
 The transport can automatically migrate `storage` via blue-green stream recreation. See the full **[Stream Migration guide](/docs/guides/stream-migration)** for how it works, rolling update behavior, performance benchmarks, and limitations.
@@ -277,7 +277,7 @@ The transport can automatically migrate `storage` via blue-green stream recreati
 
 ## Overriding Defaults
 
-All stream and consumer defaults can be overridden in `forRoot()` options. User-provided values are merged on top of the defaults — you only need to specify the properties you want to change.
+All stream and consumer defaults can be overridden in `forRoot()` options. User-provided values are merged on top of the defaults: you only need to specify the properties you want to change.
 
 ```typescript
 import { RetentionPolicy, StorageType } from '@nats-io/jetstream';

--- a/website/docs/reference/edge-cases.md
+++ b/website/docs/reference/edge-cases.md
@@ -8,7 +8,7 @@ schema:
   headline: "Edge Cases & FAQ: NestJS JetStream Transport"
   description: "NestJS JetStream transport FAQ: publisher-only mode, consumer self-healing, NATS header limits, fire-and-forget messaging, and DeliverPolicy edge cases."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Edge Cases & FAQ

--- a/website/docs/reference/edge-cases.md
+++ b/website/docs/reference/edge-cases.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 3
 sidebar_label: "Edge Cases & FAQ"
-title: "Edge Cases & FAQ — NestJS JetStream Transport"
+title: "Edge Cases & FAQ: NestJS JetStream Transport"
 description: "NestJS JetStream transport FAQ: publisher-only mode, consumer self-healing, NATS header limits, fire-and-forget messaging, and DeliverPolicy edge cases."
 schema:
   type: Article
-  headline: "Edge Cases & FAQ — NestJS JetStream Transport"
+  headline: "Edge Cases & FAQ: NestJS JetStream Transport"
   description: "NestJS JetStream transport FAQ: publisher-only mode, consumer self-healing, NATS header limits, fire-and-forget messaging, and DeliverPolicy edge cases."
   datePublished: "2026-03-21"
   dateModified: "2026-06-12"
@@ -25,7 +25,7 @@ Use `client.emit()`. This publishes an event to the event stream (JetStream-back
 await lastValueFrom(this.client.emit('order.created', { orderId: '123' }));
 ```
 
-If you specifically need non-durable Core NATS `publish()` (truly ephemeral pub/sub), use the standard `@nestjs/microservices` NATS transport alongside this library — both can share the same NATS cluster.
+If you specifically need non-durable Core NATS `publish()` (truly ephemeral pub/sub), use the standard `@nestjs/microservices` NATS transport alongside this library, both can share the same NATS cluster.
 
 ## Publisher-Only Mode
 
@@ -60,7 +60,7 @@ See [Broadcast Events](/docs/patterns/broadcast) for usage details.
 
 **Q: What happens if NATS is unreachable at startup?**
 
-The transport **throws immediately** on startup if the initial connection fails. This is intentional — your NestJS application will fail to bootstrap, which lets orchestrators (Kubernetes, Docker Compose) detect and restart the service.
+The transport **throws immediately** on startup if the initial connection fails. This is intentional: your NestJS application will fail to bootstrap, which lets orchestrators (Kubernetes, Docker Compose) detect and restart the service.
 
 **After a successful initial connection**, the NATS client handles automatic reconnection transparently. The transport monitors connection status events and emits lifecycle hooks (`Disconnect`, `Reconnect`) so your application can react. See [Lifecycle Hooks](/docs/guides/lifecycle-hooks) for details.
 
@@ -95,11 +95,11 @@ Specifically:
 Each consumer runs a self-healing loop with **exponential backoff**. When the pull-based message iterator ends unexpectedly (stream deletion, NATS restart, network partition), the consumer automatically re-establishes:
 
 1. First retry: **200ms** delay (counter increments to 1 before the delay is computed)
-2. Each subsequent failure doubles the delay: 400ms, 800ms, 1.6s, 3.2s, ...
+2. Each later failure doubles the delay: 400ms, 800ms, 1.6s, 3.2s, ...
 3. Maximum delay is capped at **30 seconds**
 4. After a successful consumption cycle, the failure counter resets to zero
 
-The backoff formula is: `min(100ms * 2^failures, 30_000ms)` — so with 1 failure the delay is 200ms, with 2 failures it is 400ms, and so on.
+The backoff formula is: `min(100ms * 2^failures, 30_000ms)`: so with 1 failure the delay is 200ms, with 2 failures it is 400ms, and so on.
 
 This applies to all consumer types: event, command, broadcast, and ordered. The transport emits a `TransportEvent.Error` hook on each failure so you can monitor consumer health. See [Lifecycle Hooks](/docs/guides/lifecycle-hooks).
 
@@ -111,9 +111,9 @@ This applies to all consumer types: event, command, broadcast, and ordered. The 
 
 The recovery is **migration-aware**: if a migration backup stream exists (another pod is mid-migration), the consumer is NOT recreated. Instead, self-healing waits with exponential backoff until migration completes and the backup is cleaned up. This prevents consumers from interfering with message restoration on workqueue streams.
 
-During rolling updates, recovery never recreates a consumer that already exists — if another pod has recreated it, self-healing uses the existing consumer as-is rather than issuing its own create/update call.
+During rolling updates, recovery never recreates a consumer that already exists, if another pod has recreated it, self-healing uses the existing consumer as-is rather than issuing its own create/update call.
 
-Ordered consumers are excluded from auto-recreation — they are ephemeral and managed internally by the nats.js client.
+Ordered consumers are excluded from auto-recreation: they are ephemeral and managed internally by the nats.js client.
 
 ## NATS Header Size Limits
 
@@ -121,12 +121,12 @@ Ordered consumers are excluded from auto-recreation — they are ephemeral and m
 
 NATS imposes a total header size limit (default 4 KB per message in most server configurations). The transport uses five [transport-managed headers](/docs/reference/api/enumerations/JetstreamHeader) that count toward this limit:
 
-- **Reserved** — `x-correlation-id`, `x-reply-to`, `x-error`. Setting these via `JetstreamRecordBuilder.setHeader()` throws immediately at the call site.
-- **Auto-set** — `x-subject`, `x-caller-name`. The transport populates these on every outbound message; any value you pass via the builder is silently replaced at publish time.
+- **Reserved**: `x-correlation-id`, `x-reply-to`, `x-error`. Setting these via `JetstreamRecordBuilder.setHeader()` throws immediately at the call site.
+- **Auto-set**: `x-subject`, `x-caller-name`. The transport populates these on every outbound message; any value you pass via the builder is silently replaced at publish time.
 
 When using `JetstreamRecordBuilder.setHeader()`, keep in mind:
 - None of the five transport-managed headers above can be overwritten from user code
-- Custom headers are additive — they are included alongside transport-managed headers
+- Custom headers are additive: they are included alongside transport-managed headers
 - If the total header size exceeds the NATS server limit, the publish will fail
 
 See [Record Builder](/docs/guides/record-builder) for custom header usage.
@@ -135,9 +135,9 @@ See [Record Builder](/docs/guides/record-builder) for custom header usage.
 
 **Q: Why does the ordered consumer not pass `DeliverPolicy.All` explicitly?**
 
-There is a known issue in the NATS JavaScript SDK where explicitly passing `DeliverPolicy.All` to an ordered consumer leaves `opt_start_seq` in the consumer configuration, which causes `consume()` to hang indefinitely. This was originally observed in the `nats` package v2.29.x and the workaround is retained for safety in `@nats-io/jetstream` v3.x.
+The NATS JavaScript SDK has a known issue where explicitly passing `DeliverPolicy.All` to an ordered consumer leaves `opt_start_seq` in the consumer configuration, which causes `consume()` to hang indefinitely. This was originally observed in the `nats` package v2.29.x and the workaround is retained for safety in `@nats-io/jetstream` v3.x.
 
-The transport works around this by **omitting** the `deliver_policy` field when it would be `DeliverPolicy.All` (the default). Since the SDK uses `All` as its internal default anyway, the behavior is identical — but the workaround avoids the hanging bug.
+The transport works around this by **omitting** the `deliver_policy` field when it would be `DeliverPolicy.All` (the default). Since the SDK uses `All` as its internal default anyway, the behavior is identical, but the workaround avoids the hanging bug.
 
 If you configure a custom `deliverPolicy` on the ordered consumer (e.g., `DeliverPolicy.Last` or `DeliverPolicy.New`), it will be passed through explicitly:
 
@@ -159,7 +159,7 @@ NATS JetStream uses nanosecond timestamps internally (`int64` in Go), but the `@
 
 This affects:
 - `ctx.getTimestamp()`; returns `Date` (millisecond precision), accurate to +/-1ms
-- `toNanos()` helper — output is accurate for typical config values (seconds, minutes), but sub-millisecond precision is not guaranteed
-- `msg.info.timestampNanos` — raw value from the SDK, already truncated before reaching this library
+- `toNanos()` helper: output is accurate for typical config values (seconds, minutes), but sub-millisecond precision is not guaranteed
+- `msg.info.timestampNanos`: raw value from the SDK, already truncated before reaching this library
 
 This is a fundamental limitation of the NATS JavaScript SDK, not this library. Using `BigInt` internally would not help; the SDK converts to/from `number` at the boundary. For ordering and deduplication, NATS uses stream sequence numbers (integers, always safe) rather than timestamps.

--- a/website/docs/reference/header-contract.md
+++ b/website/docs/reference/header-contract.md
@@ -8,7 +8,7 @@ schema:
   headline: "Header Contract: NATS Message Headers Used by the Transport"
   description: "Stable contract for NATS message headers the transport reads and writes."
   datePublished: "2026-04-24"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Header Contract

--- a/website/docs/reference/header-contract.md
+++ b/website/docs/reference/header-contract.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 5
 sidebar_label: "Header Contract"
-title: "Header Contract — NATS Message Headers Used by the Transport"
-description: "Stable contract for NATS message headers the transport reads and writes — W3C Trace Context, JetStream metadata, and library-internal markers."
+title: "Header Contract: NATS Message Headers Used by the Transport"
+description: "Stable contract for NATS message headers the transport reads and writes: W3C Trace Context, JetStream metadata, and library-internal markers."
 schema:
   type: Article
-  headline: "Header Contract — NATS Message Headers Used by the Transport"
+  headline: "Header Contract: NATS Message Headers Used by the Transport"
   description: "Stable contract for NATS message headers the transport reads and writes."
   datePublished: "2026-04-24"
   dateModified: "2026-06-12"
@@ -13,7 +13,7 @@ schema:
 
 # Header Contract
 
-Every NATS message header the transport touches — in one place. The contract is **stable across minor versions**; header names change only on major bumps. External publishers (Go, Python, Rust, …) only need to honour this page to interoperate with NestJS services using the library.
+Every NATS message header the transport touches, in one place. The contract is **stable across minor versions**; header names change only on major bumps. External publishers (Go, Python, Rust, …) only need to honour this page to interoperate with NestJS services using the library.
 
 ## At a glance
 
@@ -26,19 +26,19 @@ Every NATS message header the transport touches — in one place. The contract i
 | `x-correlation-id` | RPC | RPC | Library | Identifies the matching RPC reply. |
 | `x-reply-to` | RPC | RPC | Library | Inbox subject for the RPC reply. |
 | `x-error` | RPC reply | RPC reply | Library | Marks the reply payload as an error envelope. |
-| `x-subject` | — | ✓ | Library | Original subject the message was published to. |
-| `x-caller-name` | — | ✓ | Library | Internal name of the sending service. |
-| `x-dead-letter-reason` | — | DLQ | Library | DLQ tracking — exhausted-retry reason. |
-| `x-original-subject` | — | DLQ | Library | DLQ tracking — original target subject. |
-| `x-original-stream` | — | DLQ | Library | DLQ tracking — original stream name. |
-| `x-failed-at` | — | DLQ | Library | DLQ tracking — ISO 8601 failure timestamp. |
-| `x-delivery-count` | — | DLQ | Library | DLQ tracking — delivery attempt counter. |
+| `x-subject` | - | ✓ | Library | Original subject the message was published to. |
+| `x-caller-name` | - | ✓ | Library | Internal name of the sending service. |
+| `x-dead-letter-reason` | - | DLQ | Library | DLQ tracking: exhausted-retry reason. |
+| `x-original-subject` | - | DLQ | Library | DLQ tracking: original target subject. |
+| `x-original-stream` | - | DLQ | Library | DLQ tracking: original stream name. |
+| `x-failed-at` | - | DLQ | Library | DLQ tracking: ISO 8601 failure timestamp. |
+| `x-delivery-count` | - | DLQ | Library | DLQ tracking: delivery attempt counter. |
 
 Header names are matched **case-insensitively** per the W3C Trace Context specification.
 
 ## Reserved (you can't set these)
 
-Calling `JetstreamRecordBuilder.setHeader()` with any of these throws a reserved-header error — they are populated by the library at publish time:
+Calling `JetstreamRecordBuilder.setHeader()` with any of these throws a reserved-header error: they are populated by the library at publish time:
 
 - `x-correlation-id` · `x-reply-to` · `x-error`
 
@@ -53,7 +53,7 @@ User-defined headers should use a distinct prefix or name (`x-tenant-id`, `x-req
 These are interpreted by the NATS server itself, not by this library:
 
 - **`Nats-Msg-Id`**; publisher-supplied deduplication key. Set via `JetstreamRecordBuilder.setMessageId()` (from this library) or directly on the headers map (external publishers). Do not set it both ways on the same publish.
-- **`Nats-TTL`, `Nats-Schedule`, `Nats-Expected-*`, `Nats-Rollup`, …** — set them per the [NATS docs](https://docs.nats.io/) when you need their semantics; otherwise leave them alone.
+- **`Nats-TTL`, `Nats-Schedule`, `Nats-Expected-*`, `Nats-Rollup`, …**: set them per the [NATS docs](https://docs.nats.io/) when you need their semantics; otherwise leave them alone.
 
 ## Cross-language examples
 
@@ -121,7 +121,7 @@ Per the [W3C Trace Context specification](https://www.w3.org/TR/trace-context/),
 ## Compatibility
 
 - **NATS server:** `>= 2.11` (preserves W3C Trace Context headers across publish and consume per ADR-41).
-- **`@nats-io/nats-core`:** inherited transitively via `@nats-io/jetstream` and `@nats-io/transport-node` (both pinned to `^3.3.1`). You do not install `nats-core` directly — the resolved version is whatever those two pull in.
+- **`@nats-io/nats-core`:** inherited transitively via `@nats-io/jetstream` and `@nats-io/transport-node` (both pinned to `^3.3.1`). You do not install `nats-core` directly: the resolved version is whatever those two pull in.
 - **External publishers:** any NATS client capable of attaching headers.
 
-The library does **not** require a NestJS or TypeScript service on the other side of the wire. The header contract is the only coupling point.
+The library does not require a NestJS or TypeScript service on the other side of the wire. The header contract is the only coupling point.

--- a/website/docs/reference/module-configuration.md
+++ b/website/docs/reference/module-configuration.md
@@ -8,7 +8,7 @@ schema:
   headline: "Module Configuration Reference"
   description: "Reference for forRoot(), forRootAsync(), and forFeature() registration methods with stream, consumer, and connection options."
   datePublished: "2026-03-21"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 import Since from '@site/src/components/Since';

--- a/website/docs/reference/module-configuration.md
+++ b/website/docs/reference/module-configuration.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: "Module Configuration"
-title: "Module Configuration — NestJS JetStream Transport"
+title: "Module Configuration: NestJS JetStream Transport"
 description: "Reference for forRoot(), forRootAsync(), and forFeature() registration methods, plus stream, consumer, RPC, and connection options."
 schema:
   type: Article
@@ -100,7 +100,7 @@ export class AppModule {}
 ```
 
 :::info The `name` lives outside the factory
-The `name` property is defined at the top level of `forRootAsync()`, not inside the factory return value. This is by design — the name is needed upfront for DI token generation before the factory runs.
+The `name` property is defined at the top level of `forRootAsync()`, not inside the factory return value. This is by design: the name is needed upfront for DI token generation before the factory runs.
 :::
 
 ### useExisting
@@ -115,11 +115,11 @@ JetstreamModule.forRootAsync({
 })
 ```
 
-The `NatsConfigService` must be a class-based provider that directly implements `Omit<JetstreamModuleOptions, 'name'>` — the instance itself is used as the options object (NestJS does not call a factory method on it).
+The `NatsConfigService` must be a class-based provider that directly implements `Omit<JetstreamModuleOptions, 'name'>`: the instance itself is used as the options object (NestJS does not call a factory method on it).
 
 ### useClass
 
-Similar to `useExisting`, but the class is instantiated by the module:
+Like `useExisting`, but the class is instantiated by the module:
 
 ```typescript
 JetstreamModule.forRootAsync({
@@ -130,7 +130,7 @@ JetstreamModule.forRootAsync({
 
 ## forFeature()
 
-`forFeature()` creates a lightweight `JetstreamClient` proxy for a target service. It reuses the shared NATS connection from `forRoot()` — no new connections are created.
+`forFeature()` creates a lightweight `JetstreamClient` proxy for a target service. It reuses the shared NATS connection from `forRoot()`: no new connections are created.
 
 Import it in each feature module that needs to communicate with a specific service:
 
@@ -215,53 +215,53 @@ Every field in `JetstreamModuleOptions` with its type, default, and guidance on 
 
 ### Required options
 
-#### `name` &mdash; `string`
+#### `name`, `string`
 
 Service name. Used for stream, consumer, and subject naming. Must be unique per service in your system.
 
-#### `servers` &mdash; `string[]`
+#### `servers`, `string[]`
 
 NATS server URLs (e.g., `['nats://localhost:4222']`).
 
 ### Optional options
 
-#### `codec` &mdash; `Codec`
+#### `codec`, `Codec`
 
 Default: `JsonCodec`. Global message serializer/deserializer. Swap for MessagePack, Protobuf, or any custom binary format. See [Custom Codec](/docs/guides/custom-codec).
 
-#### `rpc` &mdash; `RpcConfig`
+#### `rpc`, `RpcConfig`
 
 Default: `{ mode: 'core' }`. RPC transport mode and configuration. See [RpcConfig](#rpcconfig) below.
 
-#### `consumer` &mdash; `boolean`
+#### `consumer`, `boolean`
 
 Default: `true`. Enable consumer infrastructure. Set to `false` for publisher-only services (e.g., API gateways).
 
-#### `events` &mdash; `StreamConsumerOverrides`
+#### `events`, `StreamConsumerOverrides`
 
 Default: production defaults (see [Default Configs](/docs/reference/default-configs#stream-defaults)). Overrides for workqueue event stream and consumer config. To enable [message scheduling](/docs/guides/scheduling), set `events.stream.allow_msg_schedules: true` (requires NATS >= 2.12). <Since version="2.8.0" />
 
-#### `broadcast` &mdash; `StreamConsumerOverrides`
+#### `broadcast`, `StreamConsumerOverrides`
 
 Default: production defaults. Overrides for broadcast event stream and consumer config.
 
-#### `ordered` &mdash; `OrderedEventOverrides`
+#### `ordered`, `OrderedEventOverrides`
 
 Default: production defaults. Configuration for ordered event consumers. See [OrderedEventOverrides](#orderedeventoverrides) below. <Since version="2.4.0" />
 
-#### `hooks` &mdash; `Partial<TransportHooks>`
+#### `hooks`, `Partial<TransportHooks>`
 
 Default: none. Transport lifecycle hook handlers. Unset hooks are silently ignored. See [Lifecycle Hooks](/docs/guides/lifecycle-hooks).
 
-#### `onDeadLetter` &mdash; `(info: DeadLetterInfo) => Promise<void>`
+#### `onDeadLetter`, `(info: DeadLetterInfo) => Promise<void>`
 
 Default: none. Async callback for dead letter handling. Called and awaited when a message exhausts all delivery attempts. See [Dead Letter Queue](/docs/guides/dead-letter-queue). <Since version="2.2.0" />
 
-#### `dlq` &mdash; `{ stream?: StreamConfigOverrides; management?: EntityManagement }`
+#### `dlq`, `{ stream?: StreamConfigOverrides; management?: EntityManagement }`
 
 Default: none. Built-in Dead Letter Queue stream. When set, exhausted messages are automatically republished to a dedicated DLQ stream with tracking headers. The optional `management` field controls whether the DLQ stream is auto-provisioned (`Auto`, default) or externally managed (`Manual`). See [Built-in DLQ stream](/docs/guides/dead-letter-queue#built-in-dlq-stream) and [External DLQ](/docs/guides/external-infrastructure#external-dlq). <Since version="2.9.0" />
 
-#### `provisioning` &mdash; `ProvisioningOptions`
+#### `provisioning`, `ProvisioningOptions`
 
 Default: `{ management: ManagementMode.Auto }`. Controls global provisioning behavior. <Since version="2.10.0" />
 
@@ -286,27 +286,27 @@ JetstreamModule.forRoot({
 
 The global value can be overridden per entity via `events.management`, `broadcast.management`, etc. Resolution order: per-entity -> global -> `Auto`. See [Bring Your Own Infrastructure](/docs/guides/external-infrastructure) for a complete guide.
 
-#### `metadata` &mdash; `MetadataRegistryOptions`
+#### `metadata`, `MetadataRegistryOptions`
 
 Default: auto-enabled if any handler has `meta`. Handler metadata registry; publishes `@EventPattern` / `@MessagePattern` handler metadata to a NATS KV bucket for cross-service discovery. No-op when `consumer: false`. See [Handler Metadata](/docs/patterns/handler-metadata). <Since version="2.9.0" />
 
-#### `metrics` &mdash; `MetricsOption`
+#### `metrics`, `MetricsOption`
 
 Default: none. Built-in Prometheus metrics. Pass `true` for defaults or a `MetricsConfig` object for full control (custom registry, prefix, labels, polling interval, histogram buckets). Requires the optional `prom-client` peer dependency when enabled. See [Prometheus Metrics](/docs/observability/metrics). <Since version="2.11.0" />
 
-#### `allowDestructiveMigration` &mdash; `boolean`
+#### `allowDestructiveMigration`, `boolean`
 
 Default: `false`. Allow automatic blue-green stream recreation for immutable property changes (e.g., `storage`). Without this flag, the transport logs a warning and keeps the existing stream config. See [Stream Migration](/docs/guides/stream-migration). <Since version="2.9.0" />
 
-#### `shutdownTimeout` &mdash; `number`
+#### `shutdownTimeout`, `number`
 
 Default: `10_000` (10 s). Graceful shutdown timeout in milliseconds. Handlers exceeding this are abandoned.
 
-#### `connectionOptions` &mdash; `Partial<ConnectionOptions>`
+#### `connectionOptions`, `Partial<ConnectionOptions>`
 
 Default: none. Raw NATS `ConnectionOptions` pass-through for TLS, auth, reconnection, etc. See [connectionOptions](#connectionoptions) below.
 
-#### `otel` &mdash; `OtelOptions`
+#### `otel`, `OtelOptions`
 
 Default: enabled with sensible defaults. OpenTelemetry tracing configuration. See [Distributed Tracing](/docs/observability/tracing).
 
@@ -314,12 +314,12 @@ Default: enabled with sensible defaults. OpenTelemetry tracing configuration. Se
 
 RPC configuration is a discriminated union on `mode`. Pick the mode based on whether commands must survive handler downtime:
 
-**`mode: 'core'`** &mdash; default. NATS native request/reply, no persistence. Lowest latency. Default timeout `30_000` ms (30 s). Best for low-latency queries and lookups where in-flight requests can simply error on failure.
+**`mode: 'core'`**, default. NATS native request/reply, no persistence. Lowest latency. Default timeout `30_000` ms (30 s). Best for low-latency queries and lookups where in-flight requests can simply error on failure.
 
-**`mode: 'jetstream'`** &mdash; commands persisted in a JetStream stream before delivery. Default timeout `180_000` ms (3 min). Best for commands that must survive a handler restart (payments, state changes).
+**`mode: 'jetstream'`**, commands persisted in a JetStream stream before delivery. Default timeout `180_000` ms (3 min). Best for commands that must survive a handler restart (payments, state changes).
 
 :::note Timeout unit
-The `timeout` field is specified in **milliseconds**, not seconds. Writing `timeout: 30` means 30 ms; almost certainly a bug. Use `timeout: 30_000` for 30 seconds.
+The `timeout` field is specified in **milliseconds**, not seconds. Writing `timeout: 30` means 30 ms, which is a bug in almost every case. Use `timeout: 30_000` for 30 seconds.
 :::
 
 ```typescript
@@ -372,7 +372,7 @@ These overrides are merged with the [production defaults](/docs/reference/defaul
 NATS JetStream uses nanoseconds for all time-based configuration. The library exports a `toNanos(value, unit)` helper that converts human-readable durations to nanoseconds. Supported units: `'ms'`, `'seconds'`, `'minutes'`, `'hours'`, `'days'`.
 :::
 
-#### `stream.name` &mdash; `string`
+#### `stream.name`, `string`
 
 Default: derived from `name` + kind convention (e.g., `orders__microservice_ev-stream`). Set an explicit stream name to bind to an externally provisioned stream with a custom name. <Since version="2.10.0" />
 
@@ -382,7 +382,7 @@ events: {
 }
 ```
 
-#### `consumer.durable_name` &mdash; `string`
+#### `consumer.durable_name`, `string`
 
 Default: derived from `name` + kind convention (e.g., `orders__microservice_ev-consumer`). Set an explicit durable name to bind to an externally provisioned consumer. <Since version="2.10.0" />
 
@@ -392,7 +392,7 @@ events: {
 }
 ```
 
-#### `management` &mdash; `EntityManagement`
+#### `management`, `EntityManagement`
 
 Default: falls back to `provisioning.management`, then `ManagementMode.Auto`. Per-kind provisioning control with separate overrides for the stream and consumer: <Since version="2.10.0" />
 
@@ -407,7 +407,7 @@ events: {
 }
 ```
 
-#### `subjectPrefix` &mdash; `string`
+#### `subjectPrefix`, `string`
 
 Default: library convention (e.g., `orders__microservice.ev.`). Override the subject prefix for all subjects in this kind. The trailing dot is normalized automatically. When a custom prefix is set, subjects become `{prefix}{pattern}` and consumers use exact `filter_subjects` entries instead of a single wildcard filter. <Since version="2.10.0" />
 
@@ -440,31 +440,31 @@ JetstreamModule.forRoot({
 })
 ```
 
-#### `stream` &mdash; `Partial<StreamConfig>`
+#### `stream`, `Partial<StreamConfig>`
 
 Default: production defaults. Stream overrides (e.g., `max_age`, `max_bytes`).
 
-#### `deliverPolicy` &mdash; `DeliverPolicy`
+#### `deliverPolicy`, `DeliverPolicy`
 
 Default: `DeliverPolicy.All`. Where to start reading when the consumer is created.
 
-#### `optStartSeq` &mdash; `number`
+#### `optStartSeq`, `number`
 
 Default: none. Start sequence number. Only used with `DeliverPolicy.StartSequence`.
 
-#### `optStartTime` &mdash; `string`
+#### `optStartTime`, `string`
 
 Default: none. Start time as an ISO string. Only used with `DeliverPolicy.StartTime`.
 
-#### `replayPolicy` &mdash; `ReplayPolicy`
+#### `replayPolicy`, `ReplayPolicy`
 
 Default: `ReplayPolicy.Instant`. Replay policy for historical messages.
 
-#### `management` &mdash; `EntityManagement`
+#### `management`, `EntityManagement`
 
 Default: falls back to `provisioning.management`, then `ManagementMode.Auto`. Per-kind provisioning control for the ordered stream. Same semantics as `StreamConsumerOverrides.management`. <Since version="2.10.0" />
 
-#### `subjectPrefix` &mdash; `string`
+#### `subjectPrefix`, `string`
 
 Default: library convention. Custom subject prefix for ordered-event subjects. Same semantics as `StreamConsumerOverrides.subjectPrefix`. <Since version="2.10.0" />
 
@@ -497,7 +497,7 @@ JetstreamModule.forRoot({
 })
 ```
 
-For server-only TLS (no client certificate) against a publicly-trusted broker, `tls: {}` is enough — it tells the client to upgrade the connection without sending a client identity.
+For server-only TLS (no client certificate) against a publicly-trusted broker, `tls: {}` is enough: it tells the client to upgrade the connection without sending a client identity.
 
 ### Authentication
 
@@ -536,7 +536,7 @@ JetstreamModule.forRoot({
 })
 ```
 
-In publisher-only mode, the `JetstreamStrategy` provider resolves to `null`. Do **not** call `app.connectMicroservice()` or `app.get(JetstreamStrategy)`.
+In publisher-only mode, the `JetstreamStrategy` provider resolves to `null`. Do not call `app.connectMicroservice()` or `app.get(JetstreamStrategy)`.
 
 ```typescript title="src/main.ts"
 const bootstrap = async () => {
@@ -551,8 +551,8 @@ void bootstrap();
 
 ## What's next?
 
-- [**RPC Patterns**](/docs/patterns/rpc) — Core vs JetStream mode, error handling, and timeouts
-- [**Events & Broadcast**](/docs/patterns/events) — workqueue events and fan-out delivery
-- [**Scheduling (Delayed Jobs)**](/docs/guides/scheduling) — one-shot delayed delivery via NATS 2.12
-- [**Lifecycle Hooks**](/docs/guides/lifecycle-hooks) — monitor connection state and transport events
-- [**Default Configs**](/docs/reference/default-configs) — full list of production-ready stream and consumer defaults
+- [**RPC Patterns**](/docs/patterns/rpc): Core vs JetStream mode, error handling, and timeouts
+- [**Events & Broadcast**](/docs/patterns/events): workqueue events and fan-out delivery
+- [**Scheduling (Delayed Jobs)**](/docs/guides/scheduling): one-shot delayed delivery via NATS 2.12
+- [**Lifecycle Hooks**](/docs/guides/lifecycle-hooks): monitor connection state and transport events
+- [**Default Configs**](/docs/reference/default-configs): full list of production-ready stream and consumer defaults

--- a/website/docs/reference/naming-conventions.md
+++ b/website/docs/reference/naming-conventions.md
@@ -6,7 +6,7 @@ schema:
   headline: Naming Conventions
   description: "Stream, consumer, and subject naming patterns derived from the service name."
   datePublished: "2026-03-21"
-  dateModified: "2026-04-11"
+  dateModified: "2026-07-26"
 ---
 
 # Naming Conventions

--- a/website/docs/reference/naming-conventions.md
+++ b/website/docs/reference/naming-conventions.md
@@ -15,7 +15,7 @@ The transport derives all NATS subject names, stream names, and consumer names f
 
 ## The `__microservice` Suffix
 
-Every service name is suffixed with `__microservice` to create an **internal name**. This suffix provides namespace isolation — it ensures your application subjects never collide with other NATS clients sharing the same cluster that might use bare service names.
+Every service name is suffixed with `__microservice` to create an **internal name**. The suffix isolates the namespace, so your application subjects never collide with other NATS clients sharing the same cluster that might use bare service names.
 
 ```typescript
 JetstreamModule.forRoot({
@@ -57,7 +57,7 @@ Given `name: 'orders'`, the transport generates the following names:
 | Broadcast consumer | `{name}__microservice_broadcast-consumer` | `orders__microservice_broadcast-consumer` |
 
 :::note
-Ordered consumers are **ephemeral** — they are created and managed by the `@nats-io/jetstream` client at consumption time and do not have a durable consumer name.
+Ordered consumers are **ephemeral**: they are created and managed by the `@nats-io/jetstream` client at consumption time and do not have a durable consumer name.
 :::
 
 :::info
@@ -108,7 +108,7 @@ buildBroadcastSubject('config.updated');
 
 ### `streamName(serviceName, kind)`
 
-Builds the JetStream stream name for a given service and stream kind.
+Builds the JetStream stream name for one service and stream kind.
 
 ```typescript
 import { streamName, StreamKind } from '@horizon-republic/nestjs-jetstream';
@@ -121,7 +121,7 @@ streamName('orders', StreamKind.Broadcast); // 'broadcast-stream'
 
 ### `consumerName(serviceName, kind)`
 
-Builds the JetStream consumer name for a given service and stream kind.
+Builds the JetStream consumer name for one service and stream kind.
 
 ```typescript
 import { consumerName, StreamKind } from '@horizon-republic/nestjs-jetstream';
@@ -133,7 +133,7 @@ consumerName('orders', StreamKind.Broadcast); // 'orders__microservice_broadcast
 
 ### `dlqStreamName(serviceName)`
 
-Builds the [Dead Letter Queue stream](/docs/guides/dead-letter-queue#built-in-dlq-stream) name for a given service. Use it to subscribe to the DLQ stream from an external consumer without hardcoding the naming pattern.
+Builds the [Dead Letter Queue stream](/docs/guides/dead-letter-queue#built-in-dlq-stream) name for one service. Use it to subscribe to the DLQ stream from an external consumer without hardcoding the naming pattern.
 
 ```typescript
 import { dlqStreamName } from '@horizon-republic/nestjs-jetstream';
@@ -167,11 +167,11 @@ The `>` wildcard matches one or more tokens, so `orders__microservice.ev.>` will
 
 ### Scheduling subjects
 
-When [message scheduling](/docs/guides/scheduling) is enabled (`allow_msg_schedules: true`), the transport adds additional subject filters to capture scheduled messages:
+When [message scheduling](/docs/guides/scheduling) is enabled (`allow_msg_schedules: true`), the transport adds extra subject filters to capture scheduled messages:
 
-| Stream Kind | Additional Subject Filter |
+| Stream Kind | Extra Subject Filter |
 |------------|--------------------------|
 | Event | `{name}__microservice._sch.>` |
 | Broadcast | `broadcast._sch.>` |
 
-The `_sch` subjects are a library convention to separate scheduled messages from regular events within the same stream. NATS scheduling itself works via headers (`Nats-Schedule`, `Nats-Schedule-Target` per [ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md)), not special subjects. You don't interact with `_sch` subjects directly — the library manages them automatically.
+The `_sch` subjects are a library convention to separate scheduled messages from regular events within the same stream. NATS scheduling itself works via headers (`Nats-Schedule`, `Nats-Schedule-Target` per [ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md)), not special subjects. You don't interact with `_sch` subjects directly: the library manages them automatically.

--- a/website/docs/reference/release-notes.md
+++ b/website/docs/reference/release-notes.md
@@ -8,7 +8,7 @@ schema:
   headline: "Release Notes: NestJS JetStream Transport"
   description: "Version-by-version changelog covering new features, behavior changes, and breaking changes."
   datePublished: "2026-03-26"
-  dateModified: "2026-06-12"
+  dateModified: "2026-07-26"
 ---
 
 # Release Notes

--- a/website/docs/reference/release-notes.md
+++ b/website/docs/reference/release-notes.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 6
 sidebar_label: "Release Notes"
-title: "Release Notes — NestJS JetStream Transport"
+title: "Release Notes: NestJS JetStream Transport"
 description: "Version-by-version changelog: new features, behavior changes, peer dependencies, and breaking changes between releases of @horizon-republic/nestjs-jetstream."
 schema:
   type: Article
-  headline: "Release Notes — NestJS JetStream Transport"
+  headline: "Release Notes: NestJS JetStream Transport"
   description: "Version-by-version changelog covering new features, behavior changes, and breaking changes."
   datePublished: "2026-03-26"
   dateModified: "2026-06-12"
@@ -19,11 +19,11 @@ Version-by-version changelog. New features, peer-dependency requirements, behavi
 
 **New features**
 
-- [**Prometheus metrics**](/docs/observability/metrics) — built-in `prom-client`-based metrics covering throughput (`jetstream_messages_received_total`, `jetstream_publish_total`, `jetstream_messages_dead_letter_total`), latency histograms (`jetstream_handler_duration_seconds`, `jetstream_publish_duration_seconds`, `jetstream_rpc_duration_seconds`), and consumer lag gauges (`jetstream_consumer_num_pending`, `jetstream_stream_messages`, etc.). Enable via `forRoot({ metrics: true })`. Writes to `prom-client`'s global `register` by default, so pairing with `@willsoto/nestjs-prometheus` is zero-config. Adds `TransportEvent.HandlerCompleted`, `TransportEvent.Published`, and `TransportEvent.RpcCompleted` to the public `TransportHooks` surface for users who want to subscribe directly.
+- [**Prometheus metrics**](/docs/observability/metrics): built-in `prom-client`-based metrics covering throughput (`jetstream_messages_received_total`, `jetstream_publish_total`, `jetstream_messages_dead_letter_total`), latency histograms (`jetstream_handler_duration_seconds`, `jetstream_publish_duration_seconds`, `jetstream_rpc_duration_seconds`), and consumer lag gauges (`jetstream_consumer_num_pending`, `jetstream_stream_messages`, etc.). Enable via `forRoot({ metrics: true })`. Writes to `prom-client`'s global `register` by default, so pairing with `@willsoto/nestjs-prometheus` is zero-config. Adds `TransportEvent.HandlerCompleted`, `TransportEvent.Published`, and `TransportEvent.RpcCompleted` to the public `TransportHooks` surface for users who want to subscribe directly.
 
 **Peer dependency (optional)**
 
-- **`prom-client`** is now declared as an **optional peer dependency** (`^15.0.0`). Required only when `metrics` is enabled. The transport never imports it when `metrics` is omitted or `false`, so applications that do not use the metrics feature pay nothing — no bundle weight, no runtime cost.
+- **`prom-client`** is now declared as an **optional peer dependency** (`^15.0.0`). Required only when `metrics` is enabled. The transport never imports it when `metrics` is omitted or `false`, so applications that do not use the metrics feature pay nothing: no bundle weight, no runtime cost.
 
 **Documentation reorganization**
 
@@ -35,16 +35,16 @@ No breaking API changes. Existing applications upgrade by bumping the dependency
 
 **New features**
 
-- [**Distributed tracing with OpenTelemetry**](/docs/observability/tracing) — every publish, consume, and RPC round-trip now produces an OpenTelemetry span. W3C Trace Context propagates through NATS message headers, so a single trace flows end-to-end across services. Activates automatically the moment your application registers an OpenTelemetry SDK (Sentry, Datadog, NodeSDK, etc.); zero runtime cost when no SDK is registered. Configurable through `forRoot({ otel: ... })`.
-- [**Header contract**](/docs/reference/header-contract) — formal documentation of the NATS message headers the transport reads and writes. Use this as the integration spec when publishing to (or consuming from) the transport from other languages (Go, Python, etc.).
+- [**Distributed tracing with OpenTelemetry**](/docs/observability/tracing): every publish, consume, and RPC round-trip now produces an OpenTelemetry span. W3C Trace Context propagates through NATS message headers, so a single trace flows end-to-end across services. Activates automatically the moment your application registers an OpenTelemetry SDK (Sentry, Datadog, NodeSDK, etc.); zero runtime cost when no SDK is registered. Configurable through `forRoot({ otel: ... })`.
+- [**Header contract**](/docs/reference/header-contract): formal documentation of the NATS message headers the transport reads and writes. Use this as the integration spec when publishing to (or consuming from) the transport from other languages (Go, Python, etc.).
 
 **Peer dependency (optional)**
 
-- **`@opentelemetry/api`** is now declared as an **optional peer dependency**. Applications that already register an OpenTelemetry SDK (`@sentry/node`, `@datadog/tracer`, `@opentelemetry/sdk-node`, etc.) bring it in transitively; no action needed. Applications that want to use the library's distributed-tracing feature **and** do not already have an OTel SDK must install `@opentelemetry/api` at the same major version (`^1.9.0`). This avoids the silent "no-op tracer" trap where two copies of the API live in `node_modules` and the global tracer singleton refuses the mismatched version.
+- **`@opentelemetry/api`** is now declared as an **optional peer dependency**. Applications that already register an OpenTelemetry SDK (`@sentry/node`, `@datadog/tracer`, `@opentelemetry/sdk-node`, etc.) bring it in transitively; no action needed. Applications that want to use the library's distributed-tracing feature and do not already have an OTel SDK must install `@opentelemetry/api` at the same major version (`^1.9.0`). This avoids the silent "no-op tracer" trap where two copies of the API live in `node_modules` and the global tracer singleton refuses the mismatched version.
 
 **Behavior changes (non-breaking API, observable in logs/APM)**
 
-- **Reduced internal logging.** Several `logger.error` sites that duplicated existing `TransportHooks` events have been removed. The hook is now the single observability channel for those events. If you relied on those log lines for monitoring, register the relevant hook (`error`, `rpcTimeout`, `deadLetter`).
+- **Reduced internal logging.** The `logger.error` sites that duplicated existing `TransportHooks` events have been removed. The hook is now the single observability channel for those events. If you relied on those log lines for monitoring, register the relevant hook (`error`, `rpcTimeout`, `deadLetter`).
 - **Error classification on OTel spans.** When OpenTelemetry is enabled, handler throws of `RpcException` and `HttpException` produce `OK` spans with `jetstream.rpc.reply.has_error` and `jetstream.rpc.reply.error.code` attributes; they are treated as expected business outcomes per the RPC contract. Bare `Error` throws produce `ERROR` spans with `recordException`. This keeps APM error rates clean for known business denials while loud-failing on real bugs.
 - **TransportEvent.Error now fires on every handler throw**, both event and RPC paths. Previously only some paths emitted it. If you have an `error` hook registered, it will now receive these (which is what most users want).
 - **`RpcConfig.timeout` in JetStream mode now bounds `connect + RPC`.** Previously the JetStream-mode per-request deadline only started after `await connect()` resolved, which meant a permanent NATS outage could accumulate pending RPCs indefinitely. The deadline is now armed immediately so callers always see a timeout. Core-mode RPC still relies on `nats.js`'s own `nc.request({ timeout })`, which starts after `connect()` resolves; operators running permanent-outage scenarios against Core mode should configure `maxReconnectAttempts` to stop the retry loop at the protocol layer.
@@ -56,7 +56,7 @@ No breaking API changes. Existing applications upgrade by bumping the dependency
 **Notable change**
 
 :::caution Broadcast `max_age` reduced: 1 day → 1 hour
-Broadcast messages (config propagation, cache invalidation, feature flags) are relevant for minutes, not days. The new default provides a sufficient catch-up window while reducing storage. This is a mutable property — **existing streams update automatically on next application startup**. If you need a longer retention window, override it explicitly:
+Broadcast messages (config propagation, cache invalidation, feature flags) are relevant for minutes, not days. The new default provides a enough catch-up window while reducing storage. This is a mutable property, **existing streams update automatically on next application startup**. If you need a longer retention window, override it explicitly:
 ```typescript
 broadcast: { stream: { max_age: toNanos(1, 'days') } }
 ```
@@ -64,11 +64,11 @@ broadcast: { stream: { max_age: toNanos(1, 'days') } }
 
 **New features**
 
-- [**Built-in Dead Letter Queue stream**](/docs/guides/dead-letter-queue#built-in-dlq-stream) — add the `dlq: { stream }` option to `forRoot()` and the library provisions a dedicated DLQ stream on startup. Exhausted messages are automatically republished with tracking headers (`x-dead-letter-reason`, `x-original-subject`, `x-original-stream`, `x-failed-at`, `x-delivery-count`). The `onDeadLetter` callback remains available as a standalone option or as a notification/safety-net hook when combined with the DLQ stream.
-- [**Per-message TTL**](/docs/guides/per-message-ttl) — `JetstreamRecordBuilder.ttl(duration)` sets the `Nats-TTL` header (NATS 2.11+), allowing individual messages to expire independently of the stream's `max_age`. Requires `allow_msg_ttl: true` on the target stream.
-- [**Handler metadata registry (NATS KV)**](/docs/patterns/handler-metadata) — when enabled via the `metadata` option, the library publishes all registered `@EventPattern` / `@MessagePattern` handlers to a NATS KV bucket at startup, enabling cross-service discovery without a separate service registry.
-- [**Stream migration**](/docs/guides/stream-migration) — automatic blue-green stream recreation for immutable property changes (`storage`, `retention`, etc.). Enable with `allowDestructiveMigration: true` on a per-stream basis.
-- **Consumer self-healing auto-recreation** — consumers deleted externally (via NATS CLI, cluster issues) are automatically recreated on the next poll. Migration-aware: waits during active stream migrations.
+- [**Built-in Dead Letter Queue stream**](/docs/guides/dead-letter-queue#built-in-dlq-stream): add the `dlq: { stream }` option to `forRoot()` and the library provisions a dedicated DLQ stream on startup. Exhausted messages are automatically republished with tracking headers (`x-dead-letter-reason`, `x-original-subject`, `x-original-stream`, `x-failed-at`, `x-delivery-count`). The `onDeadLetter` callback remains available as a standalone option or as a notification/safety-net hook when combined with the DLQ stream.
+- [**Per-message TTL**](/docs/guides/per-message-ttl): `JetstreamRecordBuilder.ttl(duration)` sets the `Nats-TTL` header (NATS 2.11+), allowing individual messages to expire independently of the stream's `max_age`. Requires `allow_msg_ttl: true` on the target stream.
+- [**Handler metadata registry (NATS KV)**](/docs/patterns/handler-metadata): when enabled via the `metadata` option, the library publishes all registered `@EventPattern` / `@MessagePattern` handlers to a NATS KV bucket at startup, enabling cross-service discovery without a separate service registry.
+- [**Stream migration**](/docs/guides/stream-migration): automatic blue-green stream recreation for immutable property changes (`storage`, `retention`, etc.). Enable with `allowDestructiveMigration: true` on a per-stream basis.
+- **Consumer self-healing auto-recreation**: consumers deleted externally (via NATS CLI, cluster issues) are automatically recreated on the next poll. Migration-aware: waits during active stream migrations.
 - **`StreamConfigOverrides` type**; prevents users from overriding `retention` (transport-controlled).
 - **`NatsErrorCode` enum** for NATS JetStream API error codes, so error handling code can switch on typed constants instead of magic strings.
 
@@ -78,7 +78,7 @@ No breaking changes.
 
 **Breaking change:** migrated from `nats` package to `@nats-io/*` scoped packages (v3.x).
 
-This is an internal change — the library re-exports everything users need. If you import types directly from `nats` in your own code, update them:
+This is an internal change: the library re-exports everything users need. If you import types directly from `nats` in your own code, update them:
 
 ```diff
 - import { JsMsg, NatsConnection } from 'nats';
@@ -88,23 +88,23 @@ This is an internal change — the library re-exports everything users need. If 
 
 **New features**
 
-- [Message scheduling](/docs/guides/scheduling) — one-shot delayed delivery via `scheduleAt()` (requires NATS >= 2.12)
+- [Message scheduling](/docs/guides/scheduling): one-shot delayed delivery via `scheduleAt()` (requires NATS >= 2.12)
 - `allow_msg_schedules` stream config option
 
 ## v2.6 → v2.7
 
-v2.7 shipped handler-controlled settlement — a way to ack, nak, or terminate a message without throwing.
+v2.7 shipped handler-controlled settlement, a way to ack, nak, or terminate a message without throwing.
 
 **New features**
 
-- Handler-controlled settlement via [`ctx.retry()` and `ctx.terminate()`](/docs/guides/handler-context#controlling-message-settlement) — control message acknowledgment without throwing errors
+- Handler-controlled settlement via [`ctx.retry()` and `ctx.terminate()`](/docs/guides/handler-context#controlling-message-settlement): control message acknowledgment without throwing errors
 - Metadata getters on [`RpcContext`](/docs/guides/handler-context#jetstream-message-info): `getDeliveryCount()`, `getStream()`, `getSequence()`, `getTimestamp()`, `getCallerName()`
 
 No breaking changes.
 
 ## v2.5 → v2.6
 
-v2.6 was the performance release — concurrency control, ack extension, and production-ready defaults for reconnection and compression.
+v2.6 was the performance release, concurrency control, ack extension, and production-ready defaults for reconnection and compression.
 
 **New features**
 
@@ -152,5 +152,5 @@ No breaking changes.
 
 ## See also
 
-- [Migration Guide](/docs/guides/migration) — switching from `@nestjs/microservices` NATS to this library
-- [GitHub Releases](https://github.com/HorizonRepublic/nestjs-jetstream/releases) — full change history with commit-level detail
+- [Migration Guide](/docs/guides/migration): switching from `@nestjs/microservices` NATS to this library
+- [GitHub Releases](https://github.com/HorizonRepublic/nestjs-jetstream/releases): full change history with commit-level detail

--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -36,7 +36,7 @@ export default function Root({ children }) {
   "headline": "Contributing",
   "description": "How to contribute to the project.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-04-11"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/development/testing/': {
@@ -44,7 +44,7 @@ export default function Root({ children }) {
   "headline": "Testing",
   "description": "Running unit and integration tests with Vitest and Testcontainers.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/getting-started/installation/': {
@@ -60,7 +60,7 @@ export default function Root({ children }) {
   "headline": "Quick Start",
   "description": "Complete working example in four steps: register the module, connect the transport, define handlers, and send messages.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/getting-started/why-jetstream/': {
@@ -68,7 +68,7 @@ export default function Root({ children }) {
   "headline": "Why JetStream? NestJS NATS Transport Comparison",
   "description": "When the built-in NestJS NATS transport is enough, and when your system outgrows Core NATS and needs JetStream for durable messaging.",
   "datePublished": "2026-04-11",
-  "dateModified": "2026-04-11"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/custom-codec/': {
@@ -76,7 +76,7 @@ export default function Root({ children }) {
   "headline": "How to use a custom codec with NestJS JetStream",
   "description": "Replace JSON with MessagePack, Protobuf, or a custom binary codec for NATS message serialization.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/dead-letter-queue/': {
@@ -84,7 +84,7 @@ export default function Root({ children }) {
   "headline": "How to configure a Dead Letter Queue",
   "description": "Capture NestJS NATS JetStream messages that exhaust all delivery attempts via a DLQ stream or onDeadLetter callback.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/external-infrastructure/': {
@@ -92,7 +92,7 @@ export default function Root({ children }) {
   "headline": "Bring Your Own Infrastructure (bind-only mode)",
   "description": "Bind NestJS JetStream to externally managed NATS streams and consumers provisioned by Terraform, ArgoCD, or a platform team.",
   "datePublished": "2026-06-12",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/graceful-shutdown/': {
@@ -100,15 +100,15 @@ export default function Root({ children }) {
   "headline": "Graceful Shutdown",
   "description": "Automatic shutdown handling with in-flight message completion and NATS connection drain.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/handler-context/': {
   "@type": "Article",
-  "headline": "RpcContext — Handler Context & Message Settlement",
+  "headline": "RpcContext: Handler Context & Message Settlement",
   "description": "Access JetStream metadata and control ack, retry, and terminate actions in NestJS message handlers via RpcContext.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/health-checks/': {
@@ -116,7 +116,7 @@ export default function Root({ children }) {
   "headline": "How to expose health checks for NATS JetStream",
   "description": "Expose NATS connection status and RTT latency as a Kubernetes readiness/liveness probe using JetstreamHealthIndicator.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/lifecycle-hooks/': {
@@ -124,7 +124,7 @@ export default function Root({ children }) {
   "headline": "How to register lifecycle hooks for NestJS JetStream",
   "description": "Subscribe to transport events for monitoring, alerting, and logging integration.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/migration/': {
@@ -132,7 +132,7 @@ export default function Root({ children }) {
   "headline": "How to migrate from @nestjs/microservices NATS to JetStream",
   "description": "Step-by-step migration from the built-in NestJS NATS transport to durable JetStream-backed delivery.",
   "datePublished": "2026-03-26",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/per-message-ttl/': {
@@ -140,7 +140,7 @@ export default function Root({ children }) {
   "headline": "How to set per-message TTL on NATS JetStream messages",
   "description": "Set individual message expiration via the Nats-TTL header (NATS 2.11, ADR-43).",
   "datePublished": "2026-04-02",
-  "dateModified": "2026-05-27"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/performance/': {
@@ -148,15 +148,15 @@ export default function Root({ children }) {
   "headline": "Performance Tuning",
   "description": "Tune ackWait, maxAckPending, batch sizes, and ack extension for high-throughput workloads.",
   "datePublished": "2026-03-26",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/record-builder/': {
   "@type": "Article",
-  "headline": "JetstreamRecordBuilder — Headers, Message IDs & Deduplication",
+  "headline": "JetstreamRecordBuilder: Headers, Message IDs & Deduplication",
   "description": "Build NestJS NATS messages with custom headers, deterministic message IDs for publish-side deduplication, and per-request RPC timeouts.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/scheduling/': {
@@ -164,7 +164,7 @@ export default function Root({ children }) {
   "headline": "How to schedule delayed messages with NestJS JetStream",
   "description": "One-shot delayed message delivery via the Nats-Schedule header (NATS 2.12, ADR-51).",
   "datePublished": "2026-04-01",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/storage-budgeting/': {
@@ -172,7 +172,7 @@ export default function Root({ children }) {
   "headline": "Storage budgeting & provisioning",
   "description": "How JetStream stream reservations relate to the server max_file_store, and how to read the boot-time provisioning summary.",
   "datePublished": "2026-06-02",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/stream-migration/': {
@@ -180,87 +180,87 @@ export default function Root({ children }) {
   "headline": "How to migrate immutable stream properties",
   "description": "Safely change immutable stream properties without losing messages via blue-green sourcing.",
   "datePublished": "2026-04-02",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/guides/troubleshooting/': {
   "@type": "Article",
-  "headline": "Troubleshooting — NestJS JetStream Transport",
+  "headline": "Troubleshooting: NestJS JetStream Transport",
   "description": "Fix common NestJS JetStream issues: NATS connection errors, consumer lag, RPC timeouts, DLQ publish failures, and stream migration recovery.",
   "datePublished": "2026-03-26",
-  "dateModified": "2026-04-11"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/': {
   "@type": "Article",
-  "headline": "NestJS NATS Transport with JetStream — Introduction",
+  "headline": "NestJS NATS Transport with JetStream: Introduction",
   "description": "A NestJS NATS microservice transport backed by JetStream: durable events, broadcast, ordered delivery, RPC, and dead letter queues.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-04-11"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/observability/index/': {
   "@type": "Article",
-  "headline": "Observability — NestJS JetStream Transport",
+  "headline": "Observability: NestJS JetStream Transport",
   "description": "Distributed tracing and Prometheus metrics built into the transport. Zero-config integration with OpenTelemetry SDKs and prom-client-based exporters.",
   "datePublished": "2026-05-27",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/observability/metrics/': {
   "@type": "Article",
-  "headline": "Prometheus Metrics — NestJS JetStream Transport",
+  "headline": "Prometheus Metrics: NestJS JetStream Transport",
   "description": "Production-ready Prometheus metrics for NATS JetStream transport: throughput, handler latency, consumer lag, dead letters, and publish errors.",
   "datePublished": "2026-05-27",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/observability/tracing/': {
   "@type": "Article",
-  "headline": "Distributed Tracing — NestJS JetStream Transport",
+  "headline": "Distributed Tracing: NestJS JetStream Transport",
   "description": "Built-in W3C Trace Context propagation and OpenTelemetry spans for every publish, consume, and RPC round-trip.",
   "datePublished": "2026-04-24",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/patterns/broadcast/': {
   "@type": "Article",
-  "headline": "Broadcast Events — NestJS JetStream Fan-Out Delivery",
+  "headline": "Broadcast Events: NestJS JetStream Fan-Out Delivery",
   "description": "Fan-out NATS JetStream events to every NestJS service instance via per-service durable consumers on a shared broadcast stream.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-04-11"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/patterns/events/': {
   "@type": "Article",
-  "headline": "Workqueue Events — NestJS JetStream At-Least-Once Delivery",
+  "headline": "Workqueue Events: NestJS JetStream At-Least-Once Delivery",
   "description": "NestJS NATS JetStream workqueue events with at-least-once delivery, automatic retry, publish-side deduplication, and dead letter handling.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/patterns/handler-metadata/': {
   "@type": "Article",
-  "headline": "Handler Metadata Registry — NATS KV Service Discovery for NestJS",
+  "headline": "Handler Metadata Registry: NATS KV Service Discovery for NestJS",
   "description": "Publish NestJS handler metadata to a NATS KV bucket for dynamic service discovery, API gateway routing, and automatic catalog generation.",
   "datePublished": "2026-04-02",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/patterns/ordered-events/': {
   "@type": "Article",
-  "headline": "Ordered Events — Strict Sequential Delivery in NATS JetStream",
+  "headline": "Ordered Events: Strict Sequential Delivery in NATS JetStream",
   "description": "Strict sequential NestJS NATS JetStream event delivery with ephemeral ordered consumers, deliver policies, and CQRS replay patterns.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/patterns/rpc/': {
   "@type": "Article",
-  "headline": "NestJS NATS RPC — Core vs JetStream Request/Reply",
+  "headline": "NestJS NATS RPC: Core vs JetStream Request/Reply",
   "description": "Synchronous NestJS NATS request-reply in Core NATS or JetStream mode, with timeout handling, error serialization, and per-request overrides.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-04-11"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/reference/default-configs/': {
@@ -268,23 +268,23 @@ export default function Root({ children }) {
   "headline": "Default Stream & Consumer Configs for NATS JetStream",
   "description": "Production-ready default stream, consumer, and connection settings for every NestJS JetStream StreamKind (event, broadcast, ordered, command, DLQ).",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/reference/edge-cases/': {
   "@type": "Article",
-  "headline": "Edge Cases & FAQ — NestJS JetStream Transport",
+  "headline": "Edge Cases & FAQ: NestJS JetStream Transport",
   "description": "NestJS JetStream transport FAQ: publisher-only mode, consumer self-healing, NATS header limits, fire-and-forget messaging, and DeliverPolicy edge cases.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/reference/header-contract/': {
   "@type": "Article",
-  "headline": "Header Contract — NATS Message Headers Used by the Transport",
+  "headline": "Header Contract: NATS Message Headers Used by the Transport",
   "description": "Stable contract for NATS message headers the transport reads and writes.",
   "datePublished": "2026-04-24",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/reference/module-configuration/': {
@@ -292,7 +292,7 @@ export default function Root({ children }) {
   "headline": "Module Configuration Reference",
   "description": "Reference for forRoot(), forRootAsync(), and forFeature() registration methods with stream, consumer, and connection options.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/reference/naming-conventions/': {
@@ -300,15 +300,15 @@ export default function Root({ children }) {
   "headline": "Naming Conventions",
   "description": "Stream, consumer, and subject naming patterns derived from the service name.",
   "datePublished": "2026-03-21",
-  "dateModified": "2026-04-11"
+  "dateModified": "2026-07-26"
 },
       
     '/docs/reference/release-notes/': {
   "@type": "Article",
-  "headline": "Release Notes — NestJS JetStream Transport",
+  "headline": "Release Notes: NestJS JetStream Transport",
   "description": "Version-by-version changelog covering new features, behavior changes, and breaking changes.",
   "datePublished": "2026-03-26",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-26"
 },
       
 


### PR DESCRIPTION
## What's new

**Docs**

- Documentation, readme, examples and code comments read in one plain voice, with the em dash gone from prose and replaced by the punctuation the sentence actually needs.
- Explanations state what happens instead of announcing themselves: "this ensures", "this means", "this page provides" and similar filler are gone.
- Weak quantifiers give way to figures or to nothing at all, and emphasis markup no longer stands in for a clear sentence.

## Why

Groundwork for the next major. The prose had drifted into a register that reads as machine-written, which undercuts a library whose selling point is that a person thought about the failure modes.

## Watch out for

- 1106 of 1299 flagged patterns are resolved. The rest sit on our own vocabulary, where a linter cannot tell a technical term from corporate register: `terminate` is an API call, `multiple` describes consumers, `expiration` describes TTL. Rewriting those would cost accuracy.
- `dateModified` is refreshed on every touched page and the structured data is regenerated, so the schema output matches the front matter.

<details>
<summary>Testing</summary>

Lint, format, type check and all 990 tests pass. The documentation site builds, including the TypeDoc reference and the llms.txt output.

</details>

<details>
<summary>Changelog</summary>

BEGIN_COMMIT_OVERRIDE
docs: tighten prose across the site, readme, examples and code comments
END_COMMIT_OVERRIDE

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Refined the README and example guides with clearer messaging, formatting, and setup descriptions.
  - Clarified publisher-only mode, dead-letter handling, retries, tracing, message expiry, RPC behavior, service discovery, and observability settings.
  - Improved explanations for timeout handling, stream migration, ordered processing, acknowledgements, and error classification.
  - Updated example listings and trace output formatting for easier navigation.

- **Tests**
  - Improved descriptive comments throughout integration and unit tests without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->