### PR TITLE
chore: drop the local scratch file from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,4 +160,3 @@ benchmarks/
 benchmarks/results/
 benchmarks/baseline.json
 benchmarks/baseline.md
-SEO-INDEXING-TASKS.md


### PR DESCRIPTION
## What's new

**Chore**

- `.gitignore` no longer names a local scratch file; that entry belongs in a personal ignore list, not in the shared one.

## Why

The previous change added it to `.gitignore` to stop it being committed. Ignoring a private working file is a per-checkout concern, so it moves to `.git/info/exclude` and the shared list stays about build output and tooling.

<details>
<summary>Changelog</summary>

BEGIN_COMMIT_OVERRIDE
chore: drop the local scratch file from gitignore
END_COMMIT_OVERRIDE

</details>