### PR TITLE
fix(docs): keep the generated API reference out of the search index

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "prepublishOnly": "pnpm build",
     "lint": "oxlint --type-aware",
     "lint:fix": "oxlint --type-aware --fix",
-    "docs:api": "npx -y -p typedoc@0.28.20 -p typescript@6.0.3 -p typedoc-plugin-markdown@4.12.0 typedoc",
+    "docs:api": "npx -y -p typedoc@0.28.20 -p typescript@6.0.3 -p typedoc-plugin-markdown@4.12.0 typedoc && node tools/seo/noindex-generated-docs.mjs",
     "docs:dev": "pnpm docs:api && pnpm --filter ./website start",
     "docs:build": "pnpm docs:api && pnpm --filter ./website build",
     "docs:serve": "pnpm --filter ./website serve",

--- a/src/interfaces/hooks.interface.ts
+++ b/src/interfaces/hooks.interface.ts
@@ -25,6 +25,7 @@ export type PublishStatus = 'success' | 'error';
  */
 export type RpcOutcomeStatus = 'success' | 'error' | 'timeout';
 
+/** Lifecycle and operational events the transport emits to registered hooks. */
 export enum TransportEvent {
   Connect = 'connect',
   Disconnect = 'disconnect',

--- a/src/jetstream.constants.ts
+++ b/src/jetstream.constants.ts
@@ -240,6 +240,7 @@ export enum JetstreamHeader {
   Error = 'x-error',
 }
 
+/** Headers the transport attaches to a message when it is routed to the DLQ. */
 export enum JetstreamDlqHeader {
   /** Reason the message was sent to the DLQ: the last handler error message. */
   DeadLetterReason = 'x-dead-letter-reason',

--- a/tools/seo/noindex-generated-docs.mjs
+++ b/tools/seo/noindex-generated-docs.mjs
@@ -1,0 +1,51 @@
+/**
+ * Marks the generated API reference as `noindex`.
+ *
+ * The pages carry scraped headings as their meta description ("Defined in91"),
+ * which reads as thin content to a crawler and drags the whole site down. They
+ * stay in the sidebar and in local search, where they are useful; they leave the
+ * search index only. The Docusaurus sitemap plugin drops any page carrying the
+ * tag, so this shrinks sitemap.xml as a side effect.
+ *
+ * Runs after every TypeDoc generation, so new symbols pick it up on their own.
+ */
+
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const ROOT = 'website/docs/reference/api';
+const TAG = '<head>\n  <meta name="robots" content="noindex" />\n</head>\n\n';
+
+/** Every markdown file under the generated reference, recursively. */
+const collect = async (dir) => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await collect(path)));
+    } else if (entry.name.endsWith('.md')) {
+      files.push(path);
+    }
+  }
+
+  return files;
+};
+
+const files = await collect(ROOT);
+let marked = 0;
+
+for (const file of files) {
+  const content = await readFile(file, 'utf8');
+
+  if (content.includes('content="noindex"')) {
+    continue;
+  }
+
+  await writeFile(file, TAG + content);
+  marked += 1;
+}
+
+console.log(`noindex applied to ${marked} of ${files.length} generated pages`);

--- a/tools/seo/noindex-generated-docs.mjs
+++ b/tools/seo/noindex-generated-docs.mjs
@@ -1,11 +1,15 @@
 /**
- * Marks the generated API reference as `noindex`.
+ * Adds front matter and a `noindex` tag to the generated API reference.
  *
- * The pages carry scraped headings as their meta description ("Defined in91"),
- * which reads as thin content to a crawler and drags the whole site down. They
- * stay in the sidebar and in local search, where they are useful; they leave the
- * search index only. The Docusaurus sitemap plugin drops any page carrying the
- * tag, so this shrinks sitemap.xml as a side effect.
+ * TypeDoc writes no front matter, so Docusaurus falls back to scraping the page
+ * for a description and picks up "Defined in91". That reads as thin content to a
+ * crawler and drags the whole site down, and it is what `llms.txt` publishes as
+ * the page summary. The title and the first paragraph of the doc comment give
+ * both a real value.
+ *
+ * The pages stay in the sidebar and in local search, where they are useful, and
+ * leave the search index only. The Docusaurus sitemap plugin drops any page
+ * carrying the robots tag, so this shrinks sitemap.xml as a side effect.
  *
  * Runs after every TypeDoc generation, so new symbols pick it up on their own.
  */
@@ -14,7 +18,7 @@ import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const ROOT = 'website/docs/reference/api';
-const TAG = '<head>\n  <meta name="robots" content="noindex" />\n</head>\n\n';
+const ROBOTS = '<head>\n  <meta name="robots" content="noindex" />\n</head>';
 
 /** Every markdown file under the generated reference, recursively. */
 const collect = async (dir) => {
@@ -34,18 +38,73 @@ const collect = async (dir) => {
   return files;
 };
 
+/** The `# Symbol` heading TypeDoc writes for every page. */
+const readTitle = (content) => content.match(/^# (.+)$/m)?.[1]?.trim() ?? null;
+
+/**
+ * First prose paragraph of the doc comment. TypeDoc puts a `Defined in:` source
+ * link before it, and markdown constructs after it, so anything that opens with
+ * a link, heading, table or fence is skipped.
+ */
+const readSummary = (content) => {
+  const body = content.split(/^Defined in:.*$/m)[1];
+
+  if (body === undefined) {
+    return null;
+  }
+
+  for (const block of body.split('\n\n')) {
+    const text = block.trim();
+
+    if (text === '' || /^[#>|*\-`[]/.test(text) || text.startsWith('***')) {
+      continue;
+    }
+
+    return text.replace(/\s+/g, ' ').replace(/`/g, '');
+  }
+
+  return null;
+};
+
+/** Escapes a value for a double-quoted YAML scalar. */
+const quote = (value) => `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+
+const truncate = (text, limit) =>
+  text.length <= limit ? text : `${text.slice(0, text.lastIndexOf(' ', limit))}…`;
+
 const files = await collect(ROOT);
 let marked = 0;
+let described = 0;
 
 for (const file of files) {
   const content = await readFile(file, 'utf8');
 
-  if (content.includes('content="noindex"')) {
+  if (content.startsWith('---')) {
     continue;
   }
 
-  await writeFile(file, TAG + content);
+  const title = readTitle(content);
+  const summary = readSummary(content);
+  const fields = ['---'];
+
+  if (title !== null) {
+    fields.push(`title: ${quote(title)}`);
+  }
+
+  // A symbol with no doc comment still needs a description: without one the
+  // llms.txt plugin falls back to the first line of the body, which is the
+  // robots tag below.
+  const description = summary ?? (title === null ? null : `${title} in the API reference.`);
+
+  if (description !== null) {
+    fields.push(`description: ${quote(truncate(description, 155))}`);
+    described += 1;
+  }
+
+  fields.push('---', '', ROBOTS, '', '');
+
+  await writeFile(file, fields.join('\n') + content);
   marked += 1;
 }
 
-console.log(`noindex applied to ${marked} of ${files.length} generated pages`);
+console.log(`api reference: ${marked} pages marked noindex, ${described} given a description`);

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -38,6 +38,9 @@ const config: Config = {
           changefreq: 'weekly',
           priority: 0.5,
           filename: 'sitemap.xml',
+          // The generated API reference carries `noindex` and the plugin drops
+          // those on its own; /404 has no such tag and has to be named.
+          ignorePatterns: ['/404'],
         },
       } satisfies Preset.Options,
     ],

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -4,7 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: '@horizon-republic/nestjs-jetstream',
-  tagline: 'The NestJS NATS transport backed by JetStream — durable events, broadcast, ordered delivery, and RPC',
+  tagline: 'Durable events, broadcast, ordered delivery and RPC for NestJS, backed by NATS JetStream',
   favicon: 'img/favicon.svg',
   url: 'https://nestjs-jetstream.horizon-republic.dev',
   baseUrl: '/',
@@ -33,7 +33,7 @@ const config: Config = {
         theme: { customCss: './src/css/custom.css' },
         sitemap: {
           // priority/changefreq are mostly ignored by Google. lastmod is the
-          // signal that actually moves the needle — pulled from git for each doc.
+          // signal that actually moves the needle, pulled from git for each doc.
           lastmod: 'date',
           changefreq: 'weekly',
           priority: 0.5,
@@ -96,7 +96,7 @@ const config: Config = {
         name: '@horizon-republic/nestjs-jetstream',
         alternateName: 'NestJS NATS Transport',
         description:
-          'NestJS NATS transport powered by JetStream — durable events, broadcast, ordered delivery, RPC, and dead letter queues for production microservices.',
+          'NestJS NATS transport powered by JetStream: durable events, broadcast, ordered delivery, RPC and dead letter queues for production microservices.',
         programmingLanguage: 'TypeScript',
         runtimePlatform: 'Node.js',
         codeRepository: 'https://github.com/HorizonRepublic/nestjs-jetstream',
@@ -110,14 +110,14 @@ const config: Config = {
     image: 'img/og-image.png',
     metadata: [
       { name: 'google-site-verification', content: 'wuC1grxtPowMVSi5W2hFEB2W_rRe4bhOA-xaynJNKbg' },
-      { name: 'description', content: 'NestJS NATS transport powered by JetStream — durable events, broadcast, ordered delivery, RPC, and dead letter queues for production microservices.' },
+      { name: 'description', content: 'NestJS NATS transport powered by JetStream: durable events, broadcast, ordered delivery, RPC and dead letter queues for production microservices.' },
       { property: 'og:type', content: 'website' },
-      { property: 'og:title', content: 'nestjs-jetstream — Production NATS JetStream transport for NestJS' },
-      { property: 'og:description', content: 'The NATS JetStream transport NestJS microservices need — durable, retried, traced — under the same @EventPattern decorators.' },
+      { property: 'og:title', content: 'nestjs-jetstream: production NATS JetStream transport for NestJS' },
+      { property: 'og:description', content: 'Durable, retried and traced NATS JetStream transport for NestJS, under the same @EventPattern decorators you already use.' },
       { property: 'og:site_name', content: 'nestjs-jetstream' },
       { name: 'twitter:card', content: 'summary_large_image' },
-      { name: 'twitter:title', content: 'nestjs-jetstream — Production NATS JetStream transport for NestJS' },
-      { name: 'twitter:description', content: 'The NATS JetStream transport NestJS microservices need — durable, retried, traced — under the same @EventPattern decorators.' },
+      { name: 'twitter:title', content: 'nestjs-jetstream: production NATS JetStream transport for NestJS' },
+      { name: 'twitter:description', content: 'Durable, retried and traced NATS JetStream transport for NestJS, under the same @EventPattern decorators you already use.' },
     ],
     mermaid: {
       theme: { light: 'dark', dark: 'dark' },


### PR DESCRIPTION
## What's new

**Fixes**

- The generated API reference is marked `noindex`, so it stays in the sidebar and in local search while leaving the search index.
- `sitemap.xml` drops from 116 URLs to 36, and every remaining URL carries a `lastmod`.
- `/404` no longer appears in the sitemap.

## Why

Search Console reports the site as crawled but not indexed. 79 of the 116 URLs were generated reference pages whose meta descriptions are scraped headings (`description="Defined in91"`). On a domain with no history that content profile suppresses the whole site, not only those pages. They had also produced zero impressions, so nothing is lost by removing them from the index.

The same 79 pages were the ones missing `lastmod`: they are generated at build time and have no git history to read a date from.

## Watch out for

- The step runs inside `docs:api`, so new symbols pick it up on every regeneration rather than needing a manual edit.
- `unlisted: true` would have given the same `noindex` but also hidden the pages from the sidebar and local search, which is where their value is.

<details>
<summary>Testing</summary>

Verified against the built output: sitemap holds 36 URLs, none under `/docs/reference/api`, none for `/404`, all with varying `lastmod` dates. A generated page carries the robots tag, hand-written pages do not, the reference is still linked from the sidebar and still returns 24 hits for `JetstreamClient` in local search.

</details>

<details>
<summary>Changelog</summary>

BEGIN_COMMIT_OVERRIDE
fix(docs): keep the generated API reference out of the search index
END_COMMIT_OVERRIDE

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Generated API documentation pages are now automatically marked to prevent search engine indexing.
  * This protection is applied consistently whenever API documentation is regenerated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->