### PR TITLE
feat(defaults)!: pace retries, enable the dead-letter stream and right-size stream reservations

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ queue with the original headers intact. A `traceparent` header rides through eve
 npm i @horizon-republic/nestjs-jetstream
 ```
 
-Requires Node >= 20, NestJS 10 to 12, and NATS Server >= 2.10 with JetStream
+Requires Node >= 22, NestJS 10 to 12, and NATS Server >= 2.10 with JetStream
 enabled.
 
 ## Where to go next

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">= 20.0.0",
+    "node": ">= 22.0.0",
     "pnpm": ">= 11.17.0"
   },
   "scripts": {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -17,7 +17,9 @@ export { ManagementMode } from './options.interface';
 
 export type {
   AckExtensionConfig,
+  DlqOptions,
   EntityManagement,
+  RetryConfig,
   JetstreamFeatureOptions,
   JetstreamModuleAsyncOptions,
   JetstreamModuleOptions,
@@ -43,6 +45,7 @@ export type {
 export type {
   DeadLetterConfig,
   EventProcessingConfig,
+  KindProcessingConfig,
   PatternsByKind,
   RegisteredHandler,
   RpcRouterOptions,

--- a/src/interfaces/options.interface.ts
+++ b/src/interfaces/options.interface.ts
@@ -88,6 +88,25 @@ export type RpcConfig =
 /** The JetStream variant of {@link RpcConfig}. */
 export type JetStreamRpcConfig = Extract<RpcConfig, { mode: 'jetstream' }>;
 
+/**
+ * Redelivery pacing for a stream kind.
+ *
+ * An array sets the delay in milliseconds before each retry, index 0 being the
+ * first one, and the last entry repeats once the curve runs out. `false` naks
+ * immediately, which burns every attempt as fast as the handler can fail.
+ *
+ * @default [2000, 10000]
+ */
+export type RetryConfig = readonly number[] | false;
+
+/** Built-in dead-letter stream, or `false` to leave exhausted messages in place. */
+export interface DlqOptions {
+  /** Raw NATS StreamConfig overrides for the DLQ stream. `name` is ignored. */
+  stream?: StreamConfigOverrides;
+  /** Provisioning control for the DLQ stream. Falls back to provisioning.management. */
+  management?: EntityManagement;
+}
+
 /** Overrides for JetStream stream and consumer configuration. */
 export interface StreamConsumerOverrides {
   stream?: StreamConfigOverrides;
@@ -126,6 +145,12 @@ export interface StreamConsumerOverrides {
    * - `number`: explicit extension interval in milliseconds.
    */
   ackExtension?: AckExtensionConfig;
+
+  /**
+   * Delay before each redelivery after a handler throws or calls `ctx.retry()`.
+   * See {@link RetryConfig}.
+   */
+  retry?: RetryConfig;
 
   /** Provisioning control for this kind's stream/consumer. Falls back to provisioning.management. */
   management?: EntityManagement;
@@ -317,11 +342,7 @@ export interface JetstreamModuleOptions {
    * })
    * ```
    */
-  dlq?: {
-    stream?: StreamConfigOverrides;
-    /** Provisioning control for the DLQ stream. Falls back to provisioning.management. */
-    management?: EntityManagement;
-  };
+  dlq?: DlqOptions | false;
 
   /**
    * Graceful shutdown timeout in ms.

--- a/src/interfaces/routing.interface.ts
+++ b/src/interfaces/routing.interface.ts
@@ -1,6 +1,7 @@
 import type { MessageHandler } from '@nestjs/microservices';
 
 import type { DeadLetterInfo } from './hooks.interface';
+import type { AckExtensionConfig, RetryConfig } from './options.interface';
 
 /** @internal Entry stored in the pattern registry after handler registration. */
 export interface RegisteredHandler {
@@ -31,9 +32,15 @@ export interface PatternsByKind {
 }
 
 /** Options for configuring event/broadcast processing behavior. */
+export interface KindProcessingConfig {
+  concurrency?: number;
+  ackExtension?: AckExtensionConfig;
+  retry?: RetryConfig;
+}
+
 export interface EventProcessingConfig {
-  events?: { concurrency?: number; ackExtension?: boolean | number };
-  broadcast?: { concurrency?: number; ackExtension?: boolean | number };
+  events?: KindProcessingConfig;
+  broadcast?: KindProcessingConfig;
 }
 
 /** Options for dead letter queue handling. */

--- a/src/jetstream.constants.ts
+++ b/src/jetstream.constants.ts
@@ -92,10 +92,10 @@ export const DEFAULT_EVENT_STREAM_CONFIG: Partial<StreamConfig> = {
   ...baseStreamConfig,
   allow_rollup_hdrs: true,
   max_consumers: 100,
-  max_msg_size: 10 * MB,
-  max_msgs_per_subject: 5_000_000,
-  max_msgs: 50_000_000,
-  max_bytes: 5 * GB,
+  max_msg_size: MB,
+  max_msgs_per_subject: 100_000,
+  max_msgs: 1_000_000,
+  max_bytes: 512 * MB,
   max_age: toNanos(7, 'days'),
   duplicate_window: toNanos(2, 'minutes'),
 };
@@ -105,10 +105,10 @@ export const DEFAULT_COMMAND_STREAM_CONFIG: Partial<StreamConfig> = {
   ...baseStreamConfig,
   allow_rollup_hdrs: false,
   max_consumers: 50,
-  max_msg_size: 5 * MB,
-  max_msgs_per_subject: 100_000,
-  max_msgs: 1_000_000,
-  max_bytes: 100 * MB,
+  max_msg_size: MB,
+  max_msgs_per_subject: 10_000,
+  max_msgs: 100_000,
+  max_bytes: 64 * MB,
   max_age: toNanos(3, 'minutes'),
   duplicate_window: toNanos(30, 'seconds'),
 };
@@ -119,10 +119,10 @@ export const DEFAULT_BROADCAST_STREAM_CONFIG: Partial<StreamConfig> = {
   retention: RetentionPolicy.Limits,
   allow_rollup_hdrs: true,
   max_consumers: 200,
-  max_msg_size: 10 * MB,
-  max_msgs_per_subject: 1_000_000,
-  max_msgs: 10_000_000,
-  max_bytes: 2 * GB,
+  max_msg_size: MB,
+  max_msgs_per_subject: 50_000,
+  max_msgs: 500_000,
+  max_bytes: 256 * MB,
   max_age: toNanos(1, 'hours'),
   duplicate_window: toNanos(2, 'minutes'),
 };
@@ -133,10 +133,10 @@ export const DEFAULT_ORDERED_STREAM_CONFIG: Partial<StreamConfig> = {
   retention: RetentionPolicy.Limits,
   allow_rollup_hdrs: false,
   max_consumers: 100,
-  max_msg_size: 10 * MB,
-  max_msgs_per_subject: 5_000_000,
-  max_msgs: 50_000_000,
-  max_bytes: 5 * GB,
+  max_msg_size: MB,
+  max_msgs_per_subject: 500_000,
+  max_msgs: 5_000_000,
+  max_bytes: GB,
   max_age: toNanos(1, 'days'),
   duplicate_window: toNanos(2, 'minutes'),
 };
@@ -147,18 +147,29 @@ export const DEFAULT_DLQ_STREAM_CONFIG: Partial<StreamConfig> = {
   retention: RetentionPolicy.Limits,
   allow_rollup_hdrs: false,
   max_consumers: 100,
-  max_msg_size: 10 * MB,
-  max_msgs_per_subject: 5_000_000,
-  max_msgs: 50_000_000,
-  max_bytes: 5 * GB,
+  max_msg_size: MB,
+  max_msgs_per_subject: 50_000,
+  max_msgs: 500_000,
+  max_bytes: 256 * MB,
   max_age: toNanos(30, 'days'),
   duplicate_window: toNanos(2, 'minutes'),
 };
+
+/**
+ * Delay before each redelivery, in milliseconds. Index 0 is the first retry.
+ * A failing handler used to nak without a delay, which burned every attempt
+ * within milliseconds and dead-lettered before a transient fault could clear.
+ */
+export const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [2_000, 10_000];
+
+/** {@link DEFAULT_RETRY_DELAYS_MS} as the nanosecond array a consumer's `backoff` takes. */
+const defaultBackoff: number[] = DEFAULT_RETRY_DELAYS_MS.map((ms) => toNanos(ms, 'ms'));
 
 /** Default config for workqueue event consumers. */
 export const DEFAULT_EVENT_CONSUMER_CONFIG: Partial<ConsumerConfig> = {
   ack_wait: toNanos(10, 'seconds'),
   max_deliver: 3,
+  backoff: defaultBackoff,
   max_ack_pending: 100,
   ack_policy: AckPolicy.Explicit,
   deliver_policy: DeliverPolicy.All,
@@ -179,6 +190,7 @@ export const DEFAULT_COMMAND_CONSUMER_CONFIG: Partial<ConsumerConfig> = {
 export const DEFAULT_BROADCAST_CONSUMER_CONFIG: Partial<ConsumerConfig> = {
   ack_wait: toNanos(10, 'seconds'),
   max_deliver: 3,
+  backoff: defaultBackoff,
   max_ack_pending: 100,
   ack_policy: AckPolicy.Explicit,
   deliver_policy: DeliverPolicy.All,

--- a/src/jetstream.constants.ts
+++ b/src/jetstream.constants.ts
@@ -159,17 +159,17 @@ export const DEFAULT_DLQ_STREAM_CONFIG: Partial<StreamConfig> = {
  * Delay before each redelivery, in milliseconds. Index 0 is the first retry.
  * A failing handler used to nak without a delay, which burned every attempt
  * within milliseconds and dead-lettered before a transient fault could clear.
+ *
+ * Applied client-side through `nak(delay)`. Never mirror this into a consumer's
+ * `backoff`: JetStream overwrites `ack_wait` with the first backoff entry, which
+ * would cut the ack deadline to 2s and redeliver while the handler still runs.
  */
 export const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [2_000, 10_000];
-
-/** {@link DEFAULT_RETRY_DELAYS_MS} as the nanosecond array a consumer's `backoff` takes. */
-const defaultBackoff: number[] = DEFAULT_RETRY_DELAYS_MS.map((ms) => toNanos(ms, 'ms'));
 
 /** Default config for workqueue event consumers. */
 export const DEFAULT_EVENT_CONSUMER_CONFIG: Partial<ConsumerConfig> = {
   ack_wait: toNanos(10, 'seconds'),
   max_deliver: 3,
-  backoff: defaultBackoff,
   max_ack_pending: 100,
   ack_policy: AckPolicy.Explicit,
   deliver_policy: DeliverPolicy.All,
@@ -190,7 +190,6 @@ export const DEFAULT_COMMAND_CONSUMER_CONFIG: Partial<ConsumerConfig> = {
 export const DEFAULT_BROADCAST_CONSUMER_CONFIG: Partial<ConsumerConfig> = {
   ack_wait: toNanos(10, 'seconds'),
   max_deliver: 3,
-  backoff: defaultBackoff,
   max_ack_pending: 100,
   ack_policy: AckPolicy.Explicit,
   deliver_policy: DeliverPolicy.All,

--- a/src/jetstream.module.ts
+++ b/src/jetstream.module.ts
@@ -47,6 +47,7 @@ import {
   StreamProvider,
   type ConsumerRecoveryFn,
 } from './server';
+import { isDlqEnabled } from './server/infrastructure/dlq-options';
 import { InfrastructureBinder } from './server/infrastructure/infrastructure-binder';
 import { NameResolver } from './server/infrastructure/name-resolver';
 import { ShutdownManager } from './shutdown';
@@ -463,7 +464,7 @@ export class JetstreamModule implements OnApplicationShutdown {
           // Dead-letter detection is needed for both capture mechanisms:
           // the DLQ stream (options.dlq) and the onDeadLetter callback.
           const deadLetterConfig: DeadLetterConfig | undefined =
-            options.onDeadLetter || options.dlq
+            options.onDeadLetter || isDlqEnabled(options)
               ? {
                   maxDeliverByStream: new Map(),
                   onDeadLetter: options.onDeadLetter,
@@ -474,10 +475,12 @@ export class JetstreamModule implements OnApplicationShutdown {
             events: {
               concurrency: options.events?.concurrency,
               ackExtension: options.events?.ackExtension,
+              retry: options.events?.retry,
             },
             broadcast: {
               concurrency: options.broadcast?.concurrency,
               ackExtension: options.broadcast?.ackExtension,
+              retry: options.broadcast?.retry,
             },
           };
 

--- a/src/server/infrastructure/__tests__/infrastructure-binder.spec.ts
+++ b/src/server/infrastructure/__tests__/infrastructure-binder.spec.ts
@@ -589,8 +589,11 @@ describe(InfrastructureBinder.name, () => {
         const ackExtensionMs = 10_000;
         const ackWaitNanos = 5_000_000_000;
 
+        // dlq is on by default, and this mock consumer has unlimited
+        // max_deliver, which would add a second unrelated warning.
         const options: JetstreamModuleOptions = {
           ...baseOptions,
+          dlq: false,
           events: { ackExtension: ackExtensionMs },
         };
 

--- a/src/server/infrastructure/__tests__/stream.provider.spec.ts
+++ b/src/server/infrastructure/__tests__/stream.provider.spec.ts
@@ -44,7 +44,9 @@ describe(StreamProvider, () => {
   };
 
   beforeEach(() => {
-    options = { name: faker.lorem.word(), servers: ['nats://localhost:4222'] };
+    // The DLQ stream is provisioned by default; these cases assert on the
+    // event and broadcast streams, so it is switched off unless a case wants it.
+    options = { name: faker.lorem.word(), servers: ['nats://localhost:4222'], dlq: false };
 
     mockJsm = {
       streams: {

--- a/src/server/infrastructure/dlq-options.ts
+++ b/src/server/infrastructure/dlq-options.ts
@@ -1,0 +1,27 @@
+import { ManagementMode } from '../../interfaces';
+import type { DlqOptions, JetstreamModuleOptions, StreamConfigOverrides } from '../../interfaces';
+
+/**
+ * The dead-letter stream is provisioned unless it is explicitly turned off.
+ * Leaving it off by default meant a handler that exhausted its attempts
+ * dropped the message with nothing to inspect afterwards.
+ *
+ * The one exception is bind-only mode: a service that provisions nothing
+ * cannot be made to fail boot over a stream its operator never asked for, so
+ * the implicit default stands down under global Manual management. Configure
+ * `dlq` explicitly to bind to an externally provisioned one.
+ */
+export const isDlqEnabled = (options: JetstreamModuleOptions): boolean => {
+  if (options.dlq === false) return false;
+  if (options.dlq !== undefined) return true;
+
+  return options.provisioning?.management !== ManagementMode.Manual;
+};
+
+/** User overrides for the DLQ stream, empty when the defaults apply. */
+export const dlqStreamOverrides = (options: JetstreamModuleOptions): StreamConfigOverrides =>
+  (options.dlq === false ? undefined : options.dlq?.stream) ?? {};
+
+/** DLQ provisioning options, or `undefined` when the DLQ is off. */
+export const dlqOptions = (options: JetstreamModuleOptions): DlqOptions | undefined =>
+  options.dlq === false ? undefined : options.dlq;

--- a/src/server/infrastructure/infrastructure-binder.ts
+++ b/src/server/infrastructure/infrastructure-binder.ts
@@ -8,6 +8,7 @@ import type { AckExtensionConfig, JetstreamModuleOptions } from '../../interface
 import type { ProvisioningEntity } from '../../otel';
 import { resolveAckExtensionInterval } from '../../utils/ack-extension';
 import { PatternRegistry } from '../routing';
+import { isDlqEnabled } from './dlq-options';
 import { kindOptionsBlock, type ManagedKind } from './management';
 import { NameResolver } from './name-resolver';
 import { NatsErrorCode } from './nats-error-codes';
@@ -255,7 +256,7 @@ export class InfrastructureBinder {
   }
 
   private warnOnUnlimitedDelivery(info: ConsumerInfo, kind: StreamKind): void {
-    if (!this.options.dlq) return;
+    if (!isDlqEnabled(this.options)) return;
 
     const maxDeliver = info.config.max_deliver;
 

--- a/src/server/infrastructure/infrastructure-binder.ts
+++ b/src/server/infrastructure/infrastructure-binder.ts
@@ -263,7 +263,7 @@ export class InfrastructureBinder {
     if (maxDeliver === undefined || maxDeliver <= 0) {
       this.logger.warn(
         `Consumer "${this.names.consumerName(kind)}" (kind=${String(kind)}) has unlimited ` +
-          `max_deliver but options.dlq is enabled; messages will never be dead-lettered. ` +
+          `max_deliver but the DLQ is enabled; messages will never be dead-lettered. ` +
           `Set max_deliver > 0 on the consumer.`,
       );
     }

--- a/src/server/infrastructure/management.ts
+++ b/src/server/infrastructure/management.ts
@@ -8,6 +8,7 @@ import type {
   StreamConfigOverrides,
 } from '../../interfaces';
 import { isJetStreamRpcMode } from '../../jetstream.constants';
+import { dlqOptions } from './dlq-options';
 
 /** Entity slot within a kind. */
 export type ManagedEntity = 'stream' | 'consumer';
@@ -51,7 +52,7 @@ const entityManagementFor = (
   options: JetstreamModuleOptions,
   kind: ManagedKind,
 ): EntityManagement | undefined => {
-  if (kind === 'dlq') return options.dlq?.management;
+  if (kind === 'dlq') return dlqOptions(options)?.management;
 
   return kindOptionsBlock(options, kind)?.management;
 };

--- a/src/server/infrastructure/name-resolver.ts
+++ b/src/server/infrastructure/name-resolver.ts
@@ -9,6 +9,7 @@ import {
   streamName,
   subjectPrefix,
 } from '../../jetstream.constants';
+import { dlqStreamOverrides } from './dlq-options';
 import { kindOptionsBlock } from './management';
 
 interface KindNames {
@@ -25,7 +26,7 @@ export class NameResolver {
   private readonly dlq: string;
 
   public constructor(private readonly options: JetstreamModuleOptions) {
-    this.dlq = options.dlq?.stream?.name ?? dlqStreamName(options.name);
+    this.dlq = dlqStreamOverrides(options).name ?? dlqStreamName(options.name);
     this.kinds = this.buildKindMap();
   }
 

--- a/src/server/infrastructure/stream.provider.ts
+++ b/src/server/infrastructure/stream.provider.ts
@@ -25,6 +25,7 @@ import {
   type ResolvedOtelOptions,
   type ServerEndpoint,
 } from '../../otel';
+import { isDlqEnabled, dlqStreamOverrides } from './dlq-options';
 import { InfrastructureBinder } from './infrastructure-binder';
 import { kindOptionsBlock, resolveManagementMode } from './management';
 import { NameResolver } from './name-resolver';
@@ -92,11 +93,11 @@ export class StreamProvider {
       name: this.names.streamName(kind),
     }));
 
+    const dlqEnabled = isDlqEnabled(this.options);
     const dlqIsManual =
-      !!this.options.dlq &&
-      resolveManagementMode(this.options, 'dlq', 'stream') === ManagementMode.Manual;
+      dlqEnabled && resolveManagementMode(this.options, 'dlq', 'stream') === ManagementMode.Manual;
 
-    if (this.options.dlq) {
+    if (dlqEnabled) {
       if (dlqIsManual) {
         external.push({ kind: 'dlq', name: this.names.dlqStreamName() });
       } else {
@@ -115,7 +116,7 @@ export class StreamProvider {
       ...externalKinds.map((kind) => this.bindStream(jsm, kind)),
     ]);
 
-    if (this.options.dlq) {
+    if (dlqEnabled) {
       if (dlqIsManual) {
         await this.bindDlqStream(jsm);
       } else {
@@ -493,7 +494,7 @@ export class StreamProvider {
     const name = this.names.dlqStreamName();
     const subjects = [name];
     const description = `JetStream DLQ stream for ${this.options.name}`;
-    const overrides = this.options.dlq?.stream ?? {};
+    const overrides = dlqStreamOverrides(this.options);
     const safeOverrides = this.stripTransportControlled(overrides);
 
     return {

--- a/src/server/routing/concurrency-gate.ts
+++ b/src/server/routing/concurrency-gate.ts
@@ -61,10 +61,21 @@ export class ConcurrencyGate {
     }
   }
 
-  /** Stop parked timers and drop the backlog. */
+  /**
+   * Stop parked timers and hand the backlog back to the server. Dropping it
+   * silently left every parked message waiting out ack_wait before another
+   * pod could pick it up, which is the whole cost of a rolling deploy.
+   */
   public dispose(): void {
     for (const queued of this.backlog) {
       queued.stopAckExtension?.();
+
+      try {
+        queued.msg.nak();
+      } catch {
+        // A closing connection cannot carry the nak; the server redelivers
+        // once ack_wait expires either way.
+      }
     }
 
     this.backlog.length = 0;

--- a/src/server/routing/dead-letter-capture.ts
+++ b/src/server/routing/dead-letter-capture.ts
@@ -14,6 +14,7 @@ import {
 } from '../../jetstream.constants';
 import { withDeadLetterSpan, type ResolvedOtelOptions, type ServerEndpoint } from '../../otel';
 import { settleQuietly } from '../../utils';
+import { dlqStreamOverrides, isDlqEnabled } from '../infrastructure/dlq-options';
 import { NameResolver } from '../infrastructure/name-resolver';
 import { PatternRegistry } from './pattern-registry';
 
@@ -81,7 +82,7 @@ export class DeadLetterCapture {
       async () => {
         this.eventBus.emit(TransportEvent.DeadLetter, info);
 
-        if (!this.options?.dlq) {
+        if (!this.options || !isDlqEnabled(this.options)) {
           await this.fallbackToOnDeadLetterCallback(info, msg);
         } else {
           await this.publishToDlq(msg, info, error);
@@ -107,7 +108,7 @@ export class DeadLetterCapture {
       return;
     }
 
-    const dlqStreamOverride = this.options.dlq?.stream?.name;
+    const dlqStreamOverride = dlqStreamOverrides(this.options).name;
     const destinationSubject = this.names
       ? this.names.dlqStreamName()
       : (dlqStreamOverride ?? dlqStreamName(serviceName));

--- a/src/server/routing/event-pipeline.ts
+++ b/src/server/routing/event-pipeline.ts
@@ -142,7 +142,7 @@ export const createWorkqueuePipeline = (
 
   const reportHandlerCompleted = createHandlerReporter(rctx);
   const resolveEvent = createEventResolver(rctx);
-  const { settleSuccess, settleFailure } = createSettlement(logger, rctx.capture);
+  const { settleSuccess, settleFailure } = createSettlement(logger, rctx.capture, rctx.retryDelays);
 
   return (msg) => {
     const resolved = resolveEvent(msg);

--- a/src/server/routing/event.router.ts
+++ b/src/server/routing/event.router.ts
@@ -8,6 +8,7 @@ import { ConnectionProvider } from '../../connection';
 import { EventBus } from '../../hooks';
 import { StreamKind } from '../../interfaces';
 import type {
+  RetryConfig,
   AckExtensionConfig,
   Codec,
   DeadLetterConfig,
@@ -21,7 +22,11 @@ import {
   type ResolvedOtelOptions,
   type ServerEndpoint,
 } from '../../otel';
-import { resolveAckExtensionInterval, startAckExtensionTimer } from '../../utils';
+import {
+  resolveAckExtensionInterval,
+  resolveRetryDelays,
+  startAckExtensionTimer,
+} from '../../utils';
 import { MessageProvider } from '../infrastructure';
 import { NameResolver } from '../infrastructure/name-resolver';
 import { ConcurrencyGate } from './concurrency-gate';
@@ -140,6 +145,7 @@ export class EventRouter {
       serviceName: this.serviceName,
       serverEndpoint: this.serverEndpoint,
       ackExtensionInterval,
+      retryDelays: resolveRetryDelays(this.getRetryConfig(kind)),
       capture: this.capture,
     };
 
@@ -166,6 +172,14 @@ export class EventRouter {
     });
 
     this.subscriptions.push(subscription);
+  }
+
+  private getRetryConfig(kind: StreamKind): RetryConfig | undefined {
+    if (kind === StreamKind.Event) return this.processingConfig?.events?.retry;
+    if (kind === StreamKind.Broadcast) return this.processingConfig?.broadcast?.retry;
+
+    // Ordered consumers never redeliver, so a curve would have nothing to pace.
+    return false;
   }
 
   private getConcurrency(kind: StreamKind): number | undefined {

--- a/src/server/routing/routing.types.ts
+++ b/src/server/routing/routing.types.ts
@@ -50,5 +50,7 @@ export interface RoutePipelineContext {
   readonly serverEndpoint: ServerEndpoint | null;
   /** Resolved ack-extension interval in ms, or null when disabled. */
   readonly ackExtensionInterval: number | null;
+  /** Delay before each redelivery, in ms; empty means nak immediately. */
+  readonly retryDelays: readonly number[];
   readonly capture: DeadLetterCapture | null;
 }

--- a/src/server/routing/rpc.router.ts
+++ b/src/server/routing/rpc.router.ts
@@ -151,14 +151,22 @@ export class RpcRouter {
       );
     };
 
-    const publishReply = (replyTo: string, correlationId: string, payload: unknown): void => {
+    const publishReply = (
+      replyTo: string,
+      correlationId: string,
+      payload: unknown,
+      subject: string,
+    ): void => {
       try {
         const hdrs = headers();
 
         hdrs.set(JetstreamHeader.CorrelationId, correlationId);
         nc.publish(replyTo, codec.encode(payload), { headers: hdrs });
       } catch (publishErr) {
+        // Staying silent here left the caller waiting out its full timeout for
+        // a reply that was never going to be sent.
         logger.error(`Failed to publish RPC response`, publishErr);
+        publishErrorReply(replyTo, correlationId, subject, publishErr);
       }
     };
 
@@ -303,7 +311,7 @@ export class RpcRouter {
         settleQuietly(logger, `Failed to ack ${subject}:`, () => {
           msg.ack();
         });
-        publishReply(replyTo, correlationId, pending);
+        publishReply(replyTo, correlationId, pending, subject);
         reportHandlerCompleted(msg, startedAt, 'success');
 
         return undefined;
@@ -337,7 +345,7 @@ export class RpcRouter {
           settleQuietly(logger, `Failed to ack ${subject}:`, () => {
             msg.ack();
           });
-          publishReply(replyTo, correlationId, result);
+          publishReply(replyTo, correlationId, result, subject);
           reportHandlerCompleted(msg, startedAt, 'success');
         },
         (err: unknown) => {

--- a/src/server/routing/settlement.ts
+++ b/src/server/routing/settlement.ts
@@ -4,7 +4,7 @@ import type { JsMsg } from '@nats-io/jetstream';
 
 import type { RpcContext } from '../../context';
 import type { HandlerStatus } from '../../interfaces';
-import { settleQuietly } from '../../utils';
+import { retryDelayFor, settleQuietly } from '../../utils';
 import type { DeadLetterCapture } from './dead-letter-capture';
 import type { Settlement } from './routing.types';
 
@@ -16,7 +16,11 @@ export const statusForContext = (ctx: RpcContext): HandlerStatus => {
   return 'success';
 };
 
-export const createSettlement = (logger: Logger, capture: DeadLetterCapture | null): Settlement => {
+export const createSettlement = (
+  logger: Logger,
+  capture: DeadLetterCapture | null,
+  retryDelays: readonly number[] = [],
+): Settlement => {
   const settleSuccess = (msg: JsMsg, ctx: RpcContext, data: unknown): Promise<void> | undefined => {
     if (ctx.shouldTerminate) {
       settleQuietly(logger, `Failed to term ${msg.subject}:`, () => {
@@ -36,7 +40,7 @@ export const createSettlement = (logger: Logger, capture: DeadLetterCapture | nu
       }
 
       settleQuietly(logger, `Failed to nak ${msg.subject}:`, () => {
-        msg.nak(ctx.retryDelay);
+        msg.nak(ctx.retryDelay ?? retryDelayFor(retryDelays, msg));
       });
 
       return undefined;
@@ -57,7 +61,7 @@ export const createSettlement = (logger: Logger, capture: DeadLetterCapture | nu
     }
 
     settleQuietly(logger, `Failed to nak ${msg.subject}:`, () => {
-      msg.nak();
+      msg.nak(retryDelayFor(retryDelays, msg));
     });
   };
 

--- a/src/utils/__tests__/retry-delay.spec.ts
+++ b/src/utils/__tests__/retry-delay.spec.ts
@@ -1,0 +1,69 @@
+import type { JsMsg } from '@nats-io/jetstream';
+
+import { createMock } from '@golevelup/ts-vitest';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_RETRY_DELAYS_MS } from '../../jetstream.constants';
+import { resolveRetryDelays, retryDelayFor } from '../retry-delay';
+
+const msgWithDeliveryCount = (deliveryCount: number): JsMsg =>
+  createMock<JsMsg>({ info: { deliveryCount } } as Partial<JsMsg>);
+
+describe('resolveRetryDelays', () => {
+  it('should fall back to the defaults when unset', () => {
+    // Given no configuration / When resolved / Then the shipped curve applies
+    expect(resolveRetryDelays(undefined)).toEqual(DEFAULT_RETRY_DELAYS_MS);
+  });
+
+  it('should use the configured curve as given', () => {
+    // Given an explicit curve
+    const delays = [100, 250, 500];
+
+    // When / Then
+    expect(resolveRetryDelays(delays)).toEqual(delays);
+  });
+
+  it('should return an empty curve for false', () => {
+    // Given redelivery pacing turned off
+    expect(resolveRetryDelays(false)).toEqual([]);
+  });
+
+  it('should drop entries that are not positive finite numbers', () => {
+    // Given a curve with junk in it
+    expect(resolveRetryDelays([100, 0, -5, Number.NaN, Infinity, 200])).toEqual([100, 200]);
+  });
+});
+
+describe('retryDelayFor', () => {
+  it('should pick the first delay for the first delivery', () => {
+    // Given the first attempt
+    const msg = msgWithDeliveryCount(1);
+
+    // When / Then
+    expect(retryDelayFor([2_000, 10_000], msg)).toBe(2_000);
+  });
+
+  it('should advance through the curve with the delivery count', () => {
+    // Given the second attempt
+    const msg = msgWithDeliveryCount(2);
+
+    // When / Then
+    expect(retryDelayFor([2_000, 10_000], msg)).toBe(10_000);
+  });
+
+  it('should repeat the last delay once the curve runs out', () => {
+    // Given more attempts than the curve has entries
+    const msg = msgWithDeliveryCount(9);
+
+    // When / Then
+    expect(retryDelayFor([2_000, 10_000], msg)).toBe(10_000);
+  });
+
+  it('should request immediate redelivery for an empty curve', () => {
+    // Given pacing turned off
+    const msg = msgWithDeliveryCount(1);
+
+    // When / Then
+    expect(retryDelayFor([], msg)).toBeUndefined();
+  });
+});

--- a/src/utils/ack-extension.ts
+++ b/src/utils/ack-extension.ts
@@ -76,7 +76,9 @@ class AckExtensionPool {
     };
 
     this.entries.add(entry);
-    this.ensureWake(entry.nextFireAt);
+    // Wake at the deadline too: with `interval` longer than `maxTotalMs` an
+    // expired entry would otherwise linger until the next interval.
+    this.ensureWake(Math.min(entry.nextFireAt, entry.expiresAt));
 
     return entry;
   }
@@ -136,7 +138,9 @@ class AckExtensionPool {
         entry.nextFireAt = now + entry.interval;
       }
 
-      if (entry.nextFireAt < earliest) earliest = entry.nextFireAt;
+      const dueAt = Math.min(entry.nextFireAt, entry.expiresAt);
+
+      if (dueAt < earliest) earliest = dueAt;
     }
 
     if (earliest !== Infinity) this.ensureWake(earliest);

--- a/src/utils/ack-extension.ts
+++ b/src/utils/ack-extension.ts
@@ -7,6 +7,13 @@ const DEFAULT_ACK_EXTENSION_INTERVAL = 5_000;
 const MIN_ACK_EXTENSION_INTERVAL = 500;
 
 /**
+ * How long a single message may be kept alive by extension. A handler that
+ * hangs used to hold its message and its concurrency slot for the life of the
+ * process; past this point the extension stops and the server redelivers.
+ */
+export const DEFAULT_MAX_ACK_EXTENSION_MS = 300_000;
+
+/**
  * Resolve the ack extension interval from user config and NATS ack_wait.
  *
  * @param config  - `false`/`undefined` -> disabled, `number` -> explicit ms, `true` -> auto from ack_wait.
@@ -36,6 +43,7 @@ interface AckEntry {
   msg: { working(): void };
   interval: number;
   nextFireAt: number;
+  expiresAt: number;
   active: boolean;
 }
 
@@ -57,11 +65,13 @@ class AckExtensionPool {
   private handle: ReturnType<typeof setTimeout> | null = null;
   private handleFireAt = 0;
 
-  public schedule(msg: { working(): void }, interval: number): AckEntry {
+  public schedule(msg: { working(): void }, interval: number, maxTotalMs: number): AckEntry {
+    const now = Date.now();
     const entry: AckEntry = {
       msg,
       interval,
-      nextFireAt: Date.now() + interval,
+      nextFireAt: now + interval,
+      expiresAt: now + maxTotalMs,
       active: true,
     };
 
@@ -109,6 +119,12 @@ class AckExtensionPool {
 
     for (const entry of this.entries) {
       if (!entry.active) continue;
+
+      if (entry.expiresAt <= now) {
+        this.cancel(entry);
+        continue;
+      }
+
       if (entry.nextFireAt <= now) {
         try {
           entry.msg.working();
@@ -140,9 +156,10 @@ const pool = new AckExtensionPool();
 export const startAckExtensionTimer = (
   msg: { working(): void },
   interval: number | null,
+  maxTotalMs: number = DEFAULT_MAX_ACK_EXTENSION_MS,
 ): (() => void) | null => {
   if (interval === null || interval <= 0) return null;
-  const entry = pool.schedule(msg, interval);
+  const entry = pool.schedule(msg, interval, maxTotalMs);
 
   return () => {
     pool.cancel(entry);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,7 @@
 export { resolveAckExtensionInterval, startAckExtensionTimer } from './ack-extension';
 
+export { resolveRetryDelays, retryDelayFor } from './retry-delay';
+
 export { serializeError } from './serialize-error';
 
 export { settleQuietly, type SettleLogger } from './settle-quietly';

--- a/src/utils/retry-delay.ts
+++ b/src/utils/retry-delay.ts
@@ -1,0 +1,36 @@
+import type { JsMsg } from '@nats-io/jetstream';
+
+import type { RetryConfig } from '../interfaces';
+import { DEFAULT_RETRY_DELAYS_MS } from '../jetstream.constants';
+
+/**
+ * Resolve the redelivery delay curve for one stream kind.
+ *
+ * @param config - `false` -> nak immediately, an array -> use it, otherwise the defaults.
+ * @returns Delays in milliseconds, empty when redelivery should be immediate.
+ */
+export const resolveRetryDelays = (config: RetryConfig | undefined): readonly number[] => {
+  if (config === false) return [];
+  if (config === undefined) return DEFAULT_RETRY_DELAYS_MS;
+
+  return config.filter((ms) => Number.isFinite(ms) && ms > 0);
+};
+
+/**
+ * Pick the delay for the redelivery that follows this attempt. The last entry
+ * repeats once the curve is exhausted, so a longer `max_deliver` keeps the
+ * final spacing instead of falling back to an immediate nak.
+ *
+ * @param delays - Curve from {@link resolveRetryDelays}.
+ * @param msg - The message being naked; its delivery count picks the entry.
+ * @returns Delay in milliseconds, or `undefined` for immediate redelivery.
+ */
+export const retryDelayFor = (delays: readonly number[], msg: JsMsg): number | undefined => {
+  if (delays.length === 0) return undefined;
+
+  // deliveryCount is 1 on the first attempt, so it doubles as the 1-based
+  // index of the retry this nak is scheduling.
+  const index = Math.max(0, msg.info.deliveryCount - 1);
+
+  return delays[Math.min(index, delays.length - 1)];
+};

--- a/test/integration/otel-retry-dead-letter.spec.ts
+++ b/test/integration/otel-retry-dead-letter.spec.ts
@@ -101,7 +101,9 @@ describe('OTel retry + dead letter integration', () => {
         {
           name: serviceName,
           port,
-          events: { consumer: { max_deliver: 5, ack_wait: 2_000_000_000 } },
+          // These cases assert span shape, not pacing; the default curve
+          // would push the third attempt past the wait budget.
+          events: { consumer: { max_deliver: 5, ack_wait: 2_000_000_000 }, retry: [50, 50] },
         },
         [FlakyController],
         [serviceName],
@@ -191,7 +193,7 @@ describe('OTel retry + dead letter integration', () => {
         {
           name: serviceName,
           port,
-          events: { consumer: { max_deliver: 2, ack_wait: 2_000_000_000 } },
+          events: { consumer: { max_deliver: 2, ack_wait: 2_000_000_000 }, retry: [50] },
           onDeadLetter: async () => {
             controller.deadLetterSeen = true;
             await Promise.resolve();

--- a/test/integration/retry-and-dlq-defaults.spec.ts
+++ b/test/integration/retry-and-dlq-defaults.spec.ts
@@ -1,0 +1,136 @@
+import { Controller, INestApplication } from '@nestjs/common';
+import { ClientProxy, EventPattern, Payload } from '@nestjs/microservices';
+
+import { jetstreamManager } from '@nats-io/jetstream';
+import type { NatsConnection } from '@nats-io/transport-node';
+
+import { firstValueFrom } from 'rxjs';
+import type { StartedTestContainer } from 'testcontainers';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { dlqStreamName, getClientToken } from '../../src';
+import {
+  cleanupStreams,
+  createNatsConnection,
+  createTestApp,
+  uniqueServiceName,
+  waitForCondition,
+} from './helpers';
+import { startNatsContainer } from './nats-container';
+
+/** A service with no handlers provisions nothing, so the DLQ cases need one. */
+@Controller()
+class QuietController {
+  @EventPattern('order.quiet')
+  public handle(@Payload() _data: unknown): void {
+    // nothing to do; the handler exists so the service provisions its streams
+  }
+}
+
+/** Records when each delivery landed so the gap between them can be measured. */
+@Controller()
+class AlwaysFailingController {
+  public readonly attemptsAt: number[] = [];
+
+  @EventPattern('order.failing')
+  public handle(@Payload() _data: unknown): void {
+    this.attemptsAt.push(Date.now());
+    throw new Error('always fails');
+  }
+}
+
+describe('Retry pacing and DLQ defaults', () => {
+  let nc: NatsConnection;
+  let container: StartedTestContainer;
+  let port: number;
+  let app: INestApplication | undefined;
+  let serviceName: string;
+
+  beforeAll(async () => {
+    ({ container, port } = await startNatsContainer());
+    nc = await createNatsConnection(port);
+  });
+
+  afterAll(async () => {
+    try {
+      await nc.drain();
+    } finally {
+      await container.stop();
+    }
+  });
+
+  afterEach(async () => {
+    await app?.close();
+    app = undefined;
+    await cleanupStreams(nc, serviceName);
+  });
+
+  it('should space redeliveries by the configured curve', async () => {
+    // Given a handler that always throws and a deliberately slow curve
+    serviceName = uniqueServiceName();
+
+    const created = await createTestApp(
+      {
+        name: serviceName,
+        port,
+        events: { consumer: { max_deliver: 3 }, retry: [1_000, 2_000] },
+      },
+      [AlwaysFailingController],
+      [serviceName],
+    );
+
+    app = created.app;
+    const sut = created.module.get(AlwaysFailingController);
+    const client = created.module.get<ClientProxy>(getClientToken(serviceName));
+
+    // When the message is published and burns through its attempts
+    await firstValueFrom(client.emit('order.failing', { id: 1 }));
+    await waitForCondition(() => sut.attemptsAt.length >= 3, 20_000);
+
+    // Then the gaps follow the curve rather than firing back to back
+    const firstGap = sut.attemptsAt[1]! - sut.attemptsAt[0]!;
+    const secondGap = sut.attemptsAt[2]! - sut.attemptsAt[1]!;
+
+    expect(firstGap).toBeGreaterThanOrEqual(800);
+    expect(secondGap).toBeGreaterThanOrEqual(1_800);
+  });
+
+  it('should provision a dead-letter stream without being asked', async () => {
+    // Given a service configured with nothing but a name and servers
+    serviceName = uniqueServiceName();
+
+    const created = await createTestApp(
+      { name: serviceName, port },
+      [QuietController],
+      [serviceName],
+    );
+
+    app = created.app;
+
+    // When the DLQ stream is looked up
+    const jsm = await jetstreamManager(nc);
+    const info = await jsm.streams.info(dlqStreamName(serviceName));
+
+    // Then it exists, sized for dead letters rather than for throughput
+    expect(info.config.name).toBe(dlqStreamName(serviceName));
+    expect(info.config.max_bytes).toBe(256 * 1024 * 1024);
+  });
+
+  it('should provision no dead-letter stream when it is turned off', async () => {
+    // Given the DLQ explicitly disabled
+    serviceName = uniqueServiceName();
+
+    const created = await createTestApp(
+      { name: serviceName, port, dlq: false },
+      [QuietController],
+      [serviceName],
+    );
+
+    app = created.app;
+
+    // When the DLQ stream is looked up / Then it was never created
+    const jsm = await jetstreamManager(nc);
+
+    await expect(jsm.streams.info(dlqStreamName(serviceName))).rejects.toThrow(/not found/i);
+  });
+});

--- a/test/integration/retry-and-dlq-defaults.spec.ts
+++ b/test/integration/retry-and-dlq-defaults.spec.ts
@@ -8,7 +8,14 @@ import { firstValueFrom } from 'rxjs';
 import type { StartedTestContainer } from 'testcontainers';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
-import { dlqStreamName, getClientToken } from '../../src';
+import {
+  consumerName,
+  dlqStreamName,
+  getClientToken,
+  StreamKind,
+  streamName,
+  toNanos,
+} from '../../src';
 import {
   cleanupStreams,
   createNatsConnection,
@@ -91,8 +98,38 @@ describe('Retry pacing and DLQ defaults', () => {
     const firstGap = sut.attemptsAt[1]! - sut.attemptsAt[0]!;
     const secondGap = sut.attemptsAt[2]! - sut.attemptsAt[1]!;
 
+    // Upper bounds matter: without them the default [2s, 10s] curve also passes,
+    // so the test would not prove that `events.retry` was applied at all.
     expect(firstGap).toBeGreaterThanOrEqual(800);
+    expect(firstGap).toBeLessThan(1_800);
     expect(secondGap).toBeGreaterThanOrEqual(1_800);
+    expect(secondGap).toBeLessThan(3_500);
+  });
+
+  it('should keep the full ack deadline on the event consumer', async () => {
+    // Given a service left on the default consumer configuration
+    serviceName = uniqueServiceName();
+
+    const created = await createTestApp(
+      { name: serviceName, port },
+      [QuietController],
+      [serviceName],
+    );
+
+    app = created.app;
+
+    // When the consumer it provisioned is inspected
+    const jsm = await jetstreamManager(nc);
+    const info = await jsm.consumers.info(
+      streamName(serviceName, StreamKind.Event),
+      consumerName(serviceName, StreamKind.Event),
+    );
+
+    // Then ack_wait is the configured 10s, not a value derived from a backoff curve.
+    // JetStream overwrites ack_wait with the first backoff entry, so setting both
+    // would silently cut the deadline to 2s and redeliver while a handler still runs.
+    expect(info.config.ack_wait).toBe(toNanos(10, 'seconds'));
+    expect(info.config.backoff ?? []).toEqual([]);
   });
 
   it('should provision a dead-letter stream without being asked', async () => {

--- a/website/docs/development/contributing.md
+++ b/website/docs/development/contributing.md
@@ -41,7 +41,7 @@ We welcome contributions from the community. The full contribution guidelines li
 
 ## Prerequisites
 
-- Node.js >= 20.0.0
+- Node.js >= 22.0.0
 - pnpm >= 10
 - Docker (integration tests use [Testcontainers](https://testcontainers.com/) to start NATS automatically)
 

--- a/website/docs/development/testing.md
+++ b/website/docs/development/testing.md
@@ -25,7 +25,7 @@ This library handles real-time message delivery, consumer lifecycle, and self-he
 ## Prerequisites
 
 - **Docker**: Testcontainers starts NATS containers automatically. No manual `docker compose up` needed for tests.
-- **Node.js >= 20** and **pnpm**
+- **Node.js >= 22** and **pnpm**
 
 ## Test Commands
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -64,7 +64,7 @@ The caret ranges above skip prereleases, so installing `@nestjs/common@next` nee
 
 ## Runtime requirements
 
-- **Node.js** >= 20.0.0
+- **Node.js** >= 22.0.0
 - **TypeScript** >= 5.7 (required by `@nats-io/*` v3 typed array generics)
 - **NATS Server** >= 2.10 with JetStream enabled (>= 2.12 for [message scheduling](/docs/guides/scheduling))
 

--- a/website/docs/guides/dead-letter-queue.md
+++ b/website/docs/guides/dead-letter-queue.md
@@ -60,7 +60,7 @@ sequenceDiagram
 
 <Since version="2.9.0" />
 
-One option provisions the stream and starts republishing exhausted messages to it:
+The stream is provisioned and exhausted messages are republished to it without any configuration. Override it when the defaults do not fit, or turn it off with `dlq: false`:
 
 ```typescript
 JetstreamModule.forRoot({
@@ -76,7 +76,7 @@ JetstreamModule.forRoot({
 
 ### Defaults
 
-The stream is named `{service}__microservice_dlq-stream` and keeps messages for **30 days** under `Limits` retention, so reading a dead letter does not consume it. Everything else matches the other streams; the [full table](/docs/reference/default-configs#stream-defaults) has the exact values, and `DEFAULT_DLQ_STREAM_CONFIG` is exported if you want to compose overrides on top of it.
+The stream is named `{service}__microservice_dlq-stream`, reserves **256 MB** and keeps messages for **30 days** under `Limits` retention, so reading a dead letter does not consume it. Everything else matches the other streams; the [full table](/docs/reference/default-configs#stream-defaults) has the exact values, and `DEFAULT_DLQ_STREAM_CONFIG` is exported if you want to compose overrides on top of it.
 
 Override through `dlq.stream`. A `name` there is ignored: the stream name is always derived from the service name, which keeps DLQ streams predictable across a fleet. Use the exported `dlqStreamName(serviceName)` helper rather than hardcoding the pattern.
 

--- a/website/docs/guides/migration.md
+++ b/website/docs/guides/migration.md
@@ -21,6 +21,18 @@ You will end up with durable delivery, automatic retries, dead letter handling, 
 See the [Release Notes](/docs/reference/release-notes) instead. This guide covers the one-time switch from `@nestjs/microservices`.
 :::
 
+## Upgrading to 3.0
+
+Four defaults changed, and each one can be restored.
+
+**Streams reserve far less storage.** `max_bytes` drops from 5 GB to 512 MB on events, from 5 GB to 1 GB on ordered, from 2 GB to 256 MB on broadcast and from 100 MB to 64 MB on commands, and `max_msg_size` drops to 1 MB everywhere to match the NATS server's own `max_payload` default. A service used to reserve up to 17 GB before it processed a single message, which exhausted a modest file store after one or two deployments. `max_bytes` is mutable, so existing streams pick the new value up on the next boot; set it back under `events.stream` if you need the old headroom.
+
+**Retries are paced.** A failing handler now naks with a delay from `[2000, 10000]` ms instead of immediately, so three attempts span roughly twelve seconds rather than milliseconds. Pass `events: { retry: false }` for the previous behaviour.
+
+**The dead-letter stream is on by default.** Exhausted messages land in `{service}__microservice_dlq-stream` instead of being dropped. Pass `dlq: false` to opt out. Under `provisioning: { management: Manual }` nothing changes unless you configure `dlq` explicitly.
+
+**Node 20 is no longer supported.** The minimum is Node 22.
+
 ## What changes
 
 The semantic shift is from at-most-once to at-least-once delivery:

--- a/website/docs/reference/default-configs.md
+++ b/website/docs/reference/default-configs.md
@@ -19,19 +19,23 @@ Every stream and consumer the transport creates starts from the values below, ta
 
 Every stream is created with `storage: File`, `num_replicas: 1` (see [replicas in production](#replicas-in-production)), `discard: Old`, `allow_direct: true` and `compression: S2`. What differs per kind:
 
-| Property               | Event        | Command      | Broadcast    | Ordered      | DLQ          |
-| ---------------------- | ------------ | ------------ | ------------ | ------------ | ------------ |
-| `retention`            | `Workqueue`  | `Workqueue`  | `Limits`     | `Limits`     | `Limits`     |
-| `allow_rollup_hdrs`    | `true`       | `false`      | `true`       | `false`      | `false`      |
-| `max_consumers`        | `100`        | `50`         | `200`        | `100`        | `100`        |
-| `max_msg_size`         | `10 MB`      | `5 MB`       | `10 MB`      | `10 MB`      | `10 MB`      |
-| `max_msgs_per_subject` | `5,000,000`  | `100,000`    | `1,000,000`  | `5,000,000`  | `5,000,000`  |
-| `max_msgs`             | `50,000,000` | `1,000,000`  | `10,000,000` | `50,000,000` | `50,000,000` |
-| `max_bytes`            | `5 GB`       | `100 MB`     | `2 GB`       | `5 GB`       | `5 GB`       |
-| `max_age`              | `7 days`     | `3 minutes`  | `1 hour`     | `1 day`      | `30 days`    |
-| `duplicate_window`     | `2 minutes`  | `30 seconds` | `2 minutes`  | `2 minutes`  | `2 minutes`  |
+| Property               | Event       | Command      | Broadcast   | Ordered     | DLQ         |
+| ---------------------- | ----------- | ------------ | ----------- | ----------- | ----------- |
+| `retention`            | `Workqueue` | `Workqueue`  | `Limits`    | `Limits`    | `Limits`    |
+| `allow_rollup_hdrs`    | `true`      | `false`      | `true`      | `false`     | `false`     |
+| `max_consumers`        | `100`       | `50`         | `200`       | `100`       | `100`       |
+| `max_msg_size`         | `1 MB`      | `1 MB`       | `1 MB`      | `1 MB`      | `1 MB`      |
+| `max_msgs_per_subject` | `100,000`   | `10,000`     | `50,000`    | `500,000`   | `50,000`    |
+| `max_msgs`             | `1,000,000` | `100,000`    | `500,000`   | `5,000,000` | `500,000`   |
+| `max_bytes`            | `512 MB`    | `64 MB`      | `256 MB`    | `1 GB`      | `256 MB`    |
+| `max_age`              | `7 days`    | `3 minutes`  | `1 hour`    | `1 day`     | `30 days`   |
+| `duplicate_window`     | `2 minutes` | `30 seconds` | `2 minutes` | `2 minutes` | `2 minutes` |
 
-Sizes are binary: `10 MB` is 10,485,760 bytes, `5 GB` is 5,368,709,120 bytes. Durations are written with [`toNanos`](/docs/reference/module-configuration), so `max_age: toNanos(7, 'days')`.
+`max_bytes` is what the account is charged for, not what the stream currently holds: JetStream counts it against the account's storage budget the moment the stream is created. A service that provisions events plus a DLQ reserves **768 MB**, and one that also uses ordered delivery reserves **1.75 GB**, so a 10 GB file store carries roughly a dozen services rather than one.
+
+`max_msg_size` matches the NATS server's own `max_payload` default of 1 MB. A larger value here has no effect until the server is reconfigured to accept larger payloads.
+
+Sizes are binary: `1 MB` is 1,048,576 bytes, `512 MB` is 536,870,912 bytes. Durations are written with [`toNanos`](/docs/reference/module-configuration), so `max_age: toNanos(7, 'days')`.
 
 What each kind is for:
 
@@ -39,7 +43,7 @@ What each kind is for:
 - **Command** carries RPC requests in [JetStream RPC mode](/docs/patterns/rpc) only. Everything about it is short-lived, because a request nobody answered within three minutes is a request nobody wants answered.
 - **Broadcast** is one stream shared by every service. An hour of `max_age` is enough catch-up for a pod that just started and short enough that config updates do not accumulate.
 - **Ordered** keeps messages for a day under `Limits` retention, because an ordered consumer replays a subject from the beginning rather than consuming it away.
-- **DLQ** is created on demand when `dlq: { stream }` is set in `forRoot()`. Thirty days under `Limits` retention: reading a dead letter must not remove it. See [Dead Letter Queue](/docs/guides/dead-letter-queue#built-in-dlq-stream).
+- **DLQ** is created unless you pass `dlq: false`. Thirty days under `Limits` retention: reading a dead letter must not remove it. See [Dead Letter Queue](/docs/guides/dead-letter-queue#built-in-dlq-stream).
 
 :::note S2 compression
 [S2](https://github.com/klauspost/compress/tree/master/s2) is a Snappy-compatible codec with better ratios. It cuts disk I/O and storage for CPU that varies with payload entropy and size, and needs NATS Server >= 2.10 (see [runtime requirements](/docs/getting-started/installation#runtime-requirements)). Override per kind:
@@ -67,8 +71,11 @@ Every durable consumer uses `ack_policy: Explicit`, `deliver_policy: All` and `r
 | `ack_wait`        | `10 seconds` | `5 minutes` | `10 seconds` |
 | `max_deliver`     | `3`          | `1`         | `3`          |
 | `max_ack_pending` | `100`        | `100`       | `100`        |
+| `backoff`         | `2s, 10s`    | -           | `2s, 10s`    |
 
-An event that fails three times is [dead-lettered](/docs/guides/dead-letter-queue). A command is delivered once and never retried, so an RPC failure reaches the caller instead of being repeated behind their back.
+An event that fails three times is [dead-lettered](/docs/guides/dead-letter-queue). Between attempts the transport naks with a delay taken from the retry curve, so the three attempts span roughly twelve seconds instead of burning out in milliseconds; `backoff` carries the same curve for redeliveries the server schedules itself after `ack_wait` expires. Tune it with `events.retry`, or pass `false` to nak immediately.
+
+A command is delivered once and never retried, so an RPC failure reaches the caller instead of being repeated behind their back.
 
 :::note
 Ordered consumers have no durable configuration. They are ephemeral and managed entirely by the `@nats-io/jetstream` client library.

--- a/website/docs/reference/default-configs.md
+++ b/website/docs/reference/default-configs.md
@@ -8,7 +8,7 @@ schema:
   headline: "Default Stream & Consumer Configs for NATS JetStream"
   description: "Default stream, consumer, and connection settings for every NestJS JetStream StreamKind (event, broadcast, ordered, command, DLQ)."
   datePublished: "2026-03-21"
-  dateModified: "2026-07-27"
+  dateModified: "2026-07-28"
 ---
 
 # Default Configs
@@ -71,9 +71,8 @@ Every durable consumer uses `ack_policy: Explicit`, `deliver_policy: All` and `r
 | `ack_wait`        | `10 seconds` | `5 minutes` | `10 seconds` |
 | `max_deliver`     | `3`          | `1`         | `3`          |
 | `max_ack_pending` | `100`        | `100`       | `100`        |
-| `backoff`         | `2s, 10s`    | -           | `2s, 10s`    |
 
-An event that fails three times is [dead-lettered](/docs/guides/dead-letter-queue). Between attempts the transport naks with a delay taken from the retry curve, so the three attempts span roughly twelve seconds instead of burning out in milliseconds; `backoff` carries the same curve for redeliveries the server schedules itself after `ack_wait` expires. Tune it with `events.retry`, or pass `false` to nak immediately.
+An event that fails three times is [dead-lettered](/docs/guides/dead-letter-queue). Between attempts the transport naks with a delay taken from the retry curve, so the three attempts span roughly twelve seconds instead of burning out in milliseconds. The delay is applied client-side, so `ack_wait` keeps its full value and a slow handler is not redelivered while it still runs. Tune it with `events.retry`, or pass `false` to nak immediately.
 
 A command is delivered once and never retried, so an RPC failure reaches the caller instead of being repeated behind their back.
 

--- a/website/docs/reference/module-configuration.md
+++ b/website/docs/reference/module-configuration.md
@@ -257,9 +257,24 @@ Default: none. Transport lifecycle hook handlers. Unset hooks are silently ignor
 
 Default: none. Async callback for dead letter handling. Called and awaited when a message exhausts all delivery attempts. See [Dead Letter Queue](/docs/guides/dead-letter-queue). <Since version="2.2.0" />
 
-#### `dlq`, `{ stream?: StreamConfigOverrides; management?: EntityManagement }`
+#### `dlq`, `DlqOptions | false`
 
-Default: none. Built-in Dead Letter Queue stream. When set, exhausted messages are automatically republished to a dedicated DLQ stream with tracking headers. The optional `management` field controls whether the DLQ stream is auto-provisioned (`Auto`, default) or externally managed (`Manual`). See [Built-in DLQ stream](/docs/guides/dead-letter-queue#built-in-dlq-stream) and [External DLQ](/docs/guides/external-infrastructure#external-dlq). <Since version="2.9.0" />
+Default: enabled. Exhausted messages are republished to a dedicated DLQ stream with tracking headers. Pass `false` to turn it off and leave them where they land. `management` controls whether the stream is provisioned (`Auto`, default) or bound to an existing one (`Manual`). See [Built-in DLQ stream](/docs/guides/dead-letter-queue#built-in-dlq-stream) and [External DLQ](/docs/guides/external-infrastructure#external-dlq). <Since version="2.9.0" />
+
+:::note Bind-only deployments
+Under `provisioning: { management: Manual }` the implicit default stands down, since a service that provisions nothing should not fail boot over a stream nobody asked for. Set `dlq` explicitly to bind to an externally provisioned one.
+:::
+
+#### `events.retry` / `broadcast.retry`, `readonly number[] | false`
+
+Default: `[2000, 10000]`. Delay in milliseconds before each redelivery after a handler throws or calls `ctx.retry()`; index 0 is the first retry and the last entry repeats once the curve runs out. `false` naks immediately, which burns every attempt as fast as the handler can fail. The same curve is written to the consumer's `backoff`, so redeliveries the server schedules after `ack_wait` expires follow it too. <Since version="3.0.0" />
+
+```typescript
+events: {
+  consumer: { max_deliver: 5 },
+  retry: [1_000, 5_000, 30_000, 60_000],
+}
+```
 
 #### `provisioning`, `ProvisioningOptions`
 

--- a/website/docs/reference/module-configuration.md
+++ b/website/docs/reference/module-configuration.md
@@ -8,7 +8,7 @@ schema:
   headline: "Module Configuration Reference"
   description: "Reference for forRoot(), forRootAsync(), and forFeature() registration methods with stream, consumer, and connection options."
   datePublished: "2026-03-21"
-  dateModified: "2026-07-27"
+  dateModified: "2026-07-28"
 ---
 
 import Since from '@site/src/components/Since';
@@ -267,7 +267,7 @@ Under `provisioning: { management: Manual }` the implicit default stands down, s
 
 #### `events.retry` / `broadcast.retry`, `readonly number[] | false`
 
-Default: `[2000, 10000]`. Delay in milliseconds before each redelivery after a handler throws or calls `ctx.retry()`; index 0 is the first retry and the last entry repeats once the curve runs out. `false` naks immediately, which burns every attempt as fast as the handler can fail. The same curve is written to the consumer's `backoff`, so redeliveries the server schedules after `ack_wait` expires follow it too. <Since version="3.0.0" />
+Default: `[2000, 10000]`. Delay in milliseconds before each redelivery after a handler throws or calls `ctx.retry()`; index 0 is the first retry and the last entry repeats once the curve runs out. `false` naks immediately, which burns every attempt as fast as the handler can fail. Delays are applied client-side when the message is naked, not through the consumer's `backoff`, so `ack_wait` keeps its configured value. <Since version="3.0.0" />
 
 ```typescript
 events: {


### PR DESCRIPTION
## What's new

**Features**

- Streams reserve 512 MB for events, 1 GB for ordered, 256 MB for broadcast and 64 MB for commands, down from up to 17 GB per service.
- Failing handlers retry on a curve, `[2s, 10s]` by default and configurable per kind, applied as delayed naks so the ack deadline keeps its full value.
- The dead-letter stream is provisioned unless you pass `dlq: false`.

**Fixes**

- Ack extension stops after five minutes instead of pinning a hung handler's message forever, and an entry can no longer outlive that deadline when the interval is longer than it.
- The concurrency gate naks its backlog on shutdown instead of leaving it to expire.
- An RPC reply that fails to encode answers with an error instead of hanging the caller.

**Build**

- Node 22 is the minimum supported runtime.

## Why

A service reserved up to 17 GB before handling its first message, which exhausted a modest file store after two deployments. A failing handler naked with no delay, so `max_deliver` burned out in milliseconds and dead-lettered before a transient fault could clear.

## Watch out for

- Four defaults change and each one can be restored. `max_bytes` is mutable, so existing streams pick the new value up on the next boot.
- Retry delays are applied client-side only. Writing the same curve into a consumer's `backoff` looks equivalent but is not: JetStream overwrites `ack_wait` with the first backoff entry, which would cut the ack deadline to 2s and redeliver while a handler is still running. An integration test pins this.
- Under global `Manual` management the dead-letter stream stands down, so a service that provisions nothing does not fail boot over a stream nobody asked for.

<details>
<summary>Testing</summary>

Adds unit coverage for the retry-delay curve and an integration suite pinning the retry and DLQ defaults against a live NATS container, including an assertion that `ack_wait` survives at its configured value.

</details>

<details>
<summary>Changelog</summary>

BEGIN_COMMIT_OVERRIDE
feat(streams)!: right-size default stream reservations
feat(routing)!: pace handler retries with delayed naks
feat(dlq)!: provision the dead-letter stream by default
fix(ack-extension): stop extending a message after five minutes
fix(routing): nak the concurrency backlog on shutdown
fix(rpc): answer with an error when a reply fails to encode
build!: require Node 22
END_COMMIT_OVERRIDE

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retry delay curves for event and broadcast redelivery (including typed routing options).
  * Added typed DLQ configuration with support for disabling DLQ provisioning; DLQ stream naming/handling is now centralized.
  * Added per-message lifetime cap for acknowledgment extensions.
  * Improved JetStream stream default sizing limits and exposed default retry delay constants.
* **Bug Fixes**
  * Queued messages are now negatively acknowledged on shutdown instead of being silently dropped.
  * Improved retry/settlement behavior to use configured pacing delays.
* **Documentation**
  * Updated minimum required Node.js version to 22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->